### PR TITLE
Add current versions to output, fix #3

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -64,7 +64,8 @@ function analyzeGlobalDependecies() {
                 print("All global packages are up to date :)");
             } else {
                 for (var package in upgradedPackages) {
-                    print('Package "' + package + '" could be updated to version ' + upgradedPackages[package]);
+                    print('Package "' + package + '" could be updated from version ' + 
+                        globalPackages[package] + ' to ' + upgradedPackages[package]);
                 }
             }
         });
@@ -87,7 +88,8 @@ function analyzeProjectDependencies(packageFile) {
                 print("All dependencies match the latest package versions :)");
             } else {
                 for (var dependency in upgradedDependencies) {
-                    print('Dependency "' + dependency + '" could be updated to ' + upgradedDependencies[dependency]);
+                    print('Dependency "' + dependency + '" could be updated from ' + 
+                        currentDependencies[dependency] + ' to ' + upgradedDependencies[dependency]);
                 }
 
                 if (program.upgrade) {


### PR DESCRIPTION
After the change, it will look like this:

```
Dependency "underscore" could be updated from ~1.4.0 to ~1.5.2
```

Not tested though (edited quickly through web interface).
