### PR TITLE
Fix to support private modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ logs
 results
 
 npm-debug.log
+
+node_modules

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -118,9 +118,15 @@ function printDependencyUpgrades(currentDependencies, upgradedDependencies, inst
         print("All dependencies match the latest package versions :)");
     } else {
         for (var dependency in upgradedDependencies) {
-            print('"' + dependency + '" can be updated from ' +
-                currentDependencies[dependency] + ' to ' + upgradedDependencies[dependency] +
-                " (Installed: " + (installedVersions[dependency] ? installedVersions[dependency] : "none") + ", Latest: " + latestVersions[dependency] + ")");
+            if (latestVersions[dependency]) {
+                print('"' + dependency + '" can be updated from ' +
+                    currentDependencies[dependency] + ' to ' + upgradedDependencies[dependency] +
+                    " (Installed: " + (installedVersions[dependency] ? installedVersions[dependency] : "none") + ", Latest: " + latestVersions[dependency] + ")");
+            }
+            else {
+                print('Unable to update "' + dependency + '". Might be a private dependency?');
+            }
+
         }
     }
 }

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -17,6 +17,9 @@ function upgradeDependencyDeclaration(declaration, latestVersion) {
 
     // Maintain constraints
     newDeclaration += getVersionConstraints(declaration);
+    if (!latestVersion) {
+        return newDeclaration;
+    }
     declaration = declaration.substr(newDeclaration.length, declaration.length);
 
     var currentComponents = declaration.split('.');
@@ -194,7 +197,13 @@ function getLatestPackageVersion(packageName, callback) {
 function getLatestVersions(packageList, callback) {
     async.map(packageList, getLatestPackageVersion, function (error, latestVersions) {
         if (error) {
-            return callback(error);
+            if (error.code === "E404") {
+                error = undefined;
+            }
+            else {
+                return callback(error);
+            }
+
         }
 
         // Merge the array of versions into one object, for easier lookups
@@ -247,7 +256,7 @@ function mergeObjects(o1, o2) {
         if (o1.hasOwnProperty(property))
             newObject[property] = o1[property];
     }
-    for (var property in o2) {
+    for (property in o2) {
         if (o2.hasOwnProperty(property))
             newObject[property] = o2[property];
     }


### PR DESCRIPTION
- No longer exists early when it checks a package it can’t find in npm.
- Prints nice message if it can't upgrade a package.

I realize there's another pull request for a similar fix, but I already finished this so I figured maybe the author can see them both so he/she has not only two ways to fix it but could choose to use the PR's to write their own way!

I just want to see this feature get added into NPM.
