### PR TITLE
Add upgrade instruction for global execution

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -149,14 +149,15 @@ function analyzeGlobalPackages(options) {
 
                     if (options.global) {
                     	var instruction = '[package]';
-                    	if (upgraded)
+                    	if (upgraded) {
                         	instruction = Object.keys(upgraded).map(function (package) {
-                        		return package + '@' + upgraded[package]
+                        		return package + '@' + upgraded[package];
                         	}).join(' ');
+                        }
                         print(options, chalk.cyan('ncu') + ' cannot upgrade global packages. Run the following to upgrade them: ' + chalk.cyan('npm -g install ' + instruction));
                     }
 
-                    return upgradePromise
+                    return upgradePromise;
                 });
         });
 }


### PR DESCRIPTION
Similar to #399 this adds an upgrade command below the upgrade-able packages.

Whenever someone executes `ncu -n -g` that someone is definitely interested in upgrading packages. Why else would you run this command, so it should always give you an easy way to upgrade.
However, I did not add a prompt, as I think you don't always want to upgrade every package. This way someone can copy & paste the command, remove the package that should stay like it is and move on.