### PR TITLE
Lint tweaks.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,14 @@
 {
+    "env": {
+        "node": true,
+        "mocha": true,
+        "es6": true
+    },
+    "extends": [
+        "eslint:recommended"
+    ],
     "parserOptions": {
-        "ecmaVersion": 8
+        "ecmaVersion": 2018
     },
     "rules": {
         "indent": [
@@ -101,6 +109,8 @@
             2,
             "always"
         ],
+        "prefer-const": 2,
+        "prefer-spread": 2,
         "no-throw-literal": 2,
         "no-eval": 2,
         "no-unneeded-ternary": 2,
@@ -117,11 +127,5 @@
         "no-trailing-spaces": 2,
         "camelcase": 2,
         "no-undef": 2
-    },
-    "env": {
-        "node": true,
-        "mocha": true,
-        "es6": true
-    },
-    "extends": ["eslint:recommended"]
+    }
 }

--- a/bin/ncu
+++ b/bin/ncu
@@ -64,7 +64,7 @@ const {configFileName, configFilePath, packageFile} = program;
 // load .ncurc
 // NOTE: Do not load .ncurc from project directory when tests are running
 // Can be overridden if configFilePath is set explicitly
-let rcArguments = []
+let rcArguments = [];
 if (process.env.NODE_ENV !== 'test' || configFilePath) {
     const rcConfig = ncu.getNcurc({
         configFileName,

--- a/lib/npm-check-updates.d.ts
+++ b/lib/npm-check-updates.d.ts
@@ -1,155 +1,155 @@
 declare namespace ncu {
-  interface RunOptions {
+    interface RunOptions {
     /**
      * rc config file path (default: directory of `packageFile` or ./ otherwise)
      */
-    configFilePath?: string;
+        configFilePath?: string;
 
-    /**
+        /**
      * rc config file name (default: .ncurc.{json,yml,js})
      */
-    configFileName?: string;
+        configFileName?: string;
 
-    /**
+        /**
      * Used as current working directory for `spawn` in npm listing
      */
-    cwd?: string;
+        cwd?: string;
 
-    /**
+        /**
      * check only a specific section(s) of dependencies:
      * prod|dev|peer|optional|bundle (comma-delimited)
      */
-    dep?: string;
+        dep?: string;
 
-    /**
+        /**
      * upgrade to version which satisfies engines.node range
      */
-    enginesNode?: boolean;
+        enginesNode?: boolean;
 
-    /**
+        /**
      * set the error-level. 1: exits with error code 0 if no errors occur. 2:
      * exits with error code 0 if no packages need updating (useful for
      * continuous integration). Default is 1.
      */
-    errorLevel?: number;
+        errorLevel?: number;
 
-    /**
+        /**
      * include only package names matching the given string,
      * comma-or-space-delimited list, or /regex/
      */
-    filter?: string | string[] | RegExp;
+        filter?: string | string[] | RegExp;
 
-    /**
+        /**
      * check global packages instead of in the current project
      */
-    global?: boolean;
+        global?: boolean;
 
-    /**
+        /**
      * find the highest versions available instead of the latest stable versions
      */
-    greatest?: boolean;
+        greatest?: boolean;
 
-    /**
+        /**
      * Enable interactive prompts for each dependency; implies -u unless one of
      * the json options are set
      */
-    interactive?: boolean;
+        interactive?: boolean;
 
-    /**
+        /**
      * output new package file instead of human-readable message
      */
-    jsonAll?: boolean;
+        jsonAll?: boolean;
 
-    /**
+        /**
      * Will return output like `jsonAll` but only lists `dependencies`,
      * `devDependencies`, and `optionalDependencies` of the new package data.
      */
-    jsonDeps?: boolean;
+        jsonDeps?: boolean;
 
-    /**
+        /**
      * output upgraded dependencies in json
      */
-    jsonUpgraded?: boolean;
+        jsonUpgraded?: boolean;
 
-    /**
+        /**
      * what level of logs to report: silent, error, minimal, warn, info,
      * verbose, silly (default: warn)
      */
-    loglevel?: string;
+        loglevel?: string;
 
-    /**
+        /**
      * do not upgrade newer versions that are already satisfied by the version
      * range according to semver
      */
-    minimal?: boolean;
+        minimal?: boolean;
 
-    /**
+        /**
      * find the newest versions available instead of the latest stable versions
      */
-    newest?: boolean;
+        newest?: boolean;
 
-    /**
+        /**
      * npm (default) or bower
      */
-    packageManager?: string;
+        packageManager?: string;
 
-    /**
+        /**
      * include stringified package file (use stdin instead)
      */
-    packageData?: string;
+        packageData?: string;
 
-    /**
+        /**
      * package file location (default: ./package.json)
      */
-    packageFile?: string;
+        packageFile?: string;
 
-    /**
+        /**
      * Include -alpha, -beta, -rc. Default: 0. Default with --newest and
      * --greatest: 1
      */
-    pre?: boolean;
+        pre?: boolean;
 
-    /**
+        /**
      * Used as current working directory in bower and npm
      */
-    prefix?: string;
+        prefix?: string;
 
-    /**
+        /**
      * specify third-party npm registry
      */
-    registry?: string;
+        registry?: string;
 
-    /**
+        /**
      * exclude packages matching the given string, comma-or-space-delimited
      * list, or /regex/
      */
-    reject?: string | string[] | RegExp;
+        reject?: string | string[] | RegExp;
 
-    /**
+        /**
      * remove version ranges from the final package version
      */
-    removeRange?: boolean;
+        removeRange?: boolean;
 
-    /**
+        /**
      * don't output anything (--loglevel silent)
      */
-    silent?: boolean;
+        silent?: boolean;
 
-    /**
+        /**
      * find the highest version within "major" or "minor"
      */
-    semverLevel?: string;
+        semverLevel?: string;
 
-    /**
+        /**
      * a global timeout in ms
      */
-    timeout?: number;
+        timeout?: number;
 
-    /**
+        /**
      * overwrite package file
      */
-    upgrade?: boolean;
-  }
+        upgrade?: boolean;
+    }
 
   type RunResults = Record<string, string>;
 

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -319,7 +319,8 @@ function initOptions(options) {
         .filter(_.partial(_.startsWith, _, 'json', 0))
         .some(_.propertyOf(options));
 
-    return Object.assign({}, options, {
+    return {
+        ...options,
         filter: options.args.join(' ') || options.filter,
         // convert silent option to loglevel silent
         loglevel: options.silent ? 'silent' : options.loglevel,
@@ -330,7 +331,7 @@ function initOptions(options) {
         json,
         // imply upgrade in interactive mode when json is not specified as the output
         upgrade: options.interactive && options.upgrade === undefined ? !json : options.upgrade
-    });
+    };
 }
 
 /**
@@ -436,9 +437,9 @@ async function run(options = {}) {
     }
 
     let timeout;
-    let timeoutPromise = new Promise(r => r);
+    let timeoutPromise = new Promise(resolve => resolve);
     if (options.timeout) {
-        const timeoutMs = _.isString(options.timeout) ? parseInt(options.timeout, 10) : options.timeout;
+        const timeoutMs = _.isString(options.timeout) ? Number.parseInt(options.timeout, 10) : options.timeout;
         timeoutPromise = new Promise((resolve, reject) => {
             timeout = setTimeout(() => {
                 // must catch the error and reject explicitly since we are in a setTimeout
@@ -484,7 +485,4 @@ function getNcurc({configFileName, configFilePath, packageFile} = {}) {
     return file && file.config;
 }
 
-module.exports = Object.assign({
-    run,
-    getNcurc
-}, vm);
+module.exports = {run, getNcurc, ...vm};

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -70,7 +70,7 @@ function viewMany(packageName, fields, currentVersion, {timeout} = {}) {
 
     npmConfig.fullMetadata = _.includes(fields, 'time');
 
-    return pacote.packument(packageName, Object.assign({}, npmConfig, {timeout})).then(result =>
+    return pacote.packument(packageName, {...npmConfig, timeout}).then(result =>
         fields.reduce((accum, field) => Object.assign(
             accum,
             {
@@ -105,7 +105,7 @@ function doesSatisfyEnginesNode(versions, enginesNode) {
         return _.keys(versions);
     }
     return _.keys(versions).filter(version => {
-        let versionEnginesNode = _.get(versions[version], 'engines.node');
+        const versionEnginesNode = _.get(versions[version], 'engines.node');
         return versionEnginesNode && semver.satisfies(minVersion, versionEnginesNode);
     });
 }

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -205,7 +205,7 @@ function packageNameFilter(filter) {
     } else if (typeof filter === 'string') {
         // RegExp filter
         if (filter[0] === '/' && cint.index(filter,-1) === '/') {
-            const regexp = new RegExp(filter.slice(1, filter.length-1));
+            const regexp = new RegExp(filter.slice(1, -1));
             filterPackages = regexp.test.bind(regexp);
         } else {
             // string filter
@@ -219,7 +219,7 @@ function packageNameFilter(filter) {
         // raw RegExp
         filterPackages = filter.test.bind(filter);
     } else {
-        throw new Error('Invalid packages filter. Must be a RegExp, array, or comma-or-space-delimited list.');
+        throw new TypeError('Invalid packages filter. Must be a RegExp, array, or comma-or-space-delimited list.');
     }
 
     // (limit the arity to 1 to avoid passing the value)
@@ -285,7 +285,7 @@ function upgradePackageDefinitions(currentDependencies, options) {
 async function upgradePackageData(pkgData, oldDependencies, newDependencies, newVersions, options = {}) {
 
     // copy newDependencies for mutation via interactive mode
-    const selectedNewDependencies = Object.assign({}, newDependencies);
+    const selectedNewDependencies = {...newDependencies};
     let newPkgData = pkgData;
 
     for (const dependency in newDependencies) {
@@ -426,14 +426,11 @@ function queryVersions(packageMap, options = {}) {
      * @returns {Promise}
      */
     function getPackageVersionProtected(dep) {
-        return getPackageVersion(dep, packageMap[dep], Object.assign(
-            {},
-            options,
+        return getPackageVersion(dep, packageMap[dep], {
+            ...options,
             // upgrade prereleases to newer prereleases by default
-            {
-                pre: options.pre != null ? options.pre : versionUtil.isPre(packageMap[dep])
-            }
-        )).catch(err => {
+            pre: options.pre != null ? options.pre : versionUtil.isPre(packageMap[dep])
+        }).catch(err => {
             const errorMessage = err ? (err.message || err).toString() : '';
             if (errorMessage.match(/E404|ENOTFOUND|404 Not Found/i)) {
                 return null;

--- a/test/individual/test-package-managers.js
+++ b/test/individual/test-package-managers.js
@@ -8,7 +8,7 @@ chai.should();
 chai.use(chaiAsPromised);
 
 // the directory with the test bower.json/package.json
-const testDir = path.resolve(__dirname + '/../ncu');
+const testDir = path.resolve(path.join(__dirname, '/../ncu'));
 
 describe('package-managers', () => {
 

--- a/test/test-version-util.js
+++ b/test/test-version-util.js
@@ -287,13 +287,13 @@ describe('version-util', () => {
     describe('isPre', () => {
 
         it('should return false for non-prerelease versions', () => {
-            versionUtil.isPre('1.0.0').should.be.false;
+            versionUtil.isPre('1.0.0').should.equal(false);
         });
 
         it('should return true for prerelease versions', () => {
-            versionUtil.isPre('1.0.0-alpha').should.be.true;
-            versionUtil.isPre('1.0.0-beta').should.be.true;
-            versionUtil.isPre('1.0.0-rc').should.be.true;
+            versionUtil.isPre('1.0.0-alpha').should.equal(true);
+            versionUtil.isPre('1.0.0-beta').should.equal(true);
+            versionUtil.isPre('1.0.0-rc').should.equal(true);
         });
 
     });


### PR DESCRIPTION
* fix indentation in lib/npm-check-updates.d.ts
* use Object.spread when possible
* use `Number.parseInt`
* add `prefer-const`
* simplify string.slice by replacing `length - 1` with `-1` for its second param
* throw a `TypeError` when the type isn't the expected one
* use `path.join` to join paths
* use `should.equal` for booleans too
* remove unneeded ESLint suppression