### PR TITLE
Replace some lodash methods with native

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -313,10 +313,8 @@ function printUpgrades(options, {current, upgraded, numUpgraded, total}) {
 
 /** Initializes and consolidates options from the cli. */
 function initOptions(options) {
-
-    const json = _(options)
-        .keys()
-        .filter(_.partial(_.startsWith, _, 'json', 0))
+    const json = Object.keys(options)
+        .filter(option => option.startsWith('json'))
         .some(_.propertyOf(options));
 
     return {

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -420,12 +420,13 @@ process.on('unhandledRejection', err => {
 async function run(options = {}) {
     // if not executed on the command-line (i.e. executed as a node module), set some defaults
     if (!options.cli) {
-        options = _.defaults({}, options, {
+        const defaultOptions = {
             jsonUpgraded: true,
             loglevel: 'silent',
             packageManager: 'npm',
             args: []
-        });
+        };
+        options = {...defaultOptions, ...options};
     }
 
     options = initOptions(options);

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -70,7 +70,7 @@ function viewMany(packageName, fields, currentVersion, {timeout} = {}) {
         return Promise.resolve({});
     }
 
-    npmConfig.fullMetadata = _.includes(fields, 'time');
+    npmConfig.fullMetadata = fields.includes('time');
 
     return pacote.packument(packageName, {...npmConfig, timeout}).then(result =>
         fields.reduce((accum, field) => Object.assign(
@@ -219,7 +219,7 @@ module.exports = {
             .then(result => {
                 const versions = doesSatisfyEnginesNode(result.versions, options.enginesNode);
                 return _.keys(result.time).reduce((accum, key) =>
-                    accum.concat(_.includes(TIME_FIELDS, key) || _.includes(versions, key) ? key : []), []
+                    accum.concat(TIME_FIELDS.includes(key) || versions.includes(key) ? key : []), []
                 );
             })
             .then(_.partialRight(_.pullAll, TIME_FIELDS))

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -99,14 +99,17 @@ function filterOutPrereleaseVersions(versions, pre) {
  * @returns {Array} An array of versions which satisfies engines.node range
  */
 function doesSatisfyEnginesNode(versions, enginesNode) {
+    if (!versions) {
+        return [];
+    }
     if (!enginesNode) {
-        return _.keys(versions);
+        return Object.keys(versions);
     }
     const minVersion = _.get(semver.minVersion(enginesNode), 'version');
     if (!minVersion) {
-        return _.keys(versions);
+        return Object.keys(versions);
     }
-    return _.keys(versions).filter(version => {
+    return Object.keys(versions).filter(version => {
         const versionEnginesNode = _.get(versions[version], 'engines.node');
         return versionEnginesNode && semver.satisfies(minVersion, versionEnginesNode);
     });
@@ -218,7 +221,7 @@ module.exports = {
         return viewMany(packageName, ['time', 'versions'], currentVersion, {timeout: options.timeout})
             .then(result => {
                 const versions = doesSatisfyEnginesNode(result.versions, options.enginesNode);
-                return _.keys(result.time).reduce((accum, key) =>
+                return Object.keys(result.time || {}).reduce((accum, key) =>
                     accum.concat(TIME_FIELDS.includes(key) || versions.includes(key) ? key : []), []
                 );
             })

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -73,14 +73,12 @@ function viewMany(packageName, fields, currentVersion, {timeout} = {}) {
     npmConfig.fullMetadata = fields.includes('time');
 
     return pacote.packument(packageName, {...npmConfig, timeout}).then(result =>
-        fields.reduce((accum, field) => Object.assign(
-            accum,
-            {
-                [field]: field.startsWith('dist-tags.') && result.versions ?
-                    result.versions[_.get(result, field)] :
-                    result[field]
-            }
-        ), {})
+        fields.reduce((accum, field) => ({
+            ...accum,
+            [field]: field.startsWith('dist-tags.') && result.versions ?
+                result.versions[_.get(result, field)] :
+                result[field]
+        }), {})
     );
 }
 

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -90,7 +90,7 @@ function viewMany(packageName, fields, currentVersion, {timeout} = {}) {
  * @returns {Array}         An array of versions with the release versions filtered out
  */
 function filterOutPrereleaseVersions(versions, pre) {
-    return pre ? versions : _.filter(versions, version => !versionUtil.isPre(version));
+    return pre ? versions : versions.filter(version => !versionUtil.isPre(version));
 }
 
 /**

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -97,7 +97,7 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options = {}) 
         .value();
     const operator = uniqueOperators[0] || '';
 
-    const hasWildCard = versionUtil.WILDCARDS.some(_.partial(_.includes, newSemverString, _, 0));
+    const hasWildCard = versionUtil.WILDCARDS.some(wildcard => newSemverString.includes(wildcard));
     const isLessThan = uniqueOperators[0] === '<' || uniqueOperators[0] === '<=';
     const isMixed = uniqueOperators.length > 1;
 

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -338,13 +338,16 @@ function getCurrentDependencies(pkgData = {}, options = {}) {
         options.prod = options.dev = options.peer = options.optional = options.bundle = true;
     }
 
-    const allDependencies = cint.filterObject(_.merge({},
-        options.prod && pkgData.dependencies,
-        options.dev && pkgData.devDependencies,
-        options.peer && pkgData.peerDependencies,
-        options.optional && pkgData.optionalDependencies,
-        options.bundle && pkgData.bundleDependencies
-    ), filterAndReject(options.filter, options.reject));
+    const allDependencies = cint.filterObject(
+        {
+            ...(options.prod && pkgData.dependencies),
+            ...(options.dev && pkgData.devDependencies),
+            ...(options.peer && pkgData.peerDependencies),
+            ...(options.optional && pkgData.optionalDependencies),
+            ...(options.bundle && pkgData.bundleDependencies)
+        },
+        filterAndReject(options.filter, options.reject)
+    );
 
     return allDependencies;
 }


### PR DESCRIPTION
Some notes:

* Since some lodash methods work with undefined/null while the native methods don't, I had to adapt `doesSatisfyEnginesNode()` because apparently `versions` could be undefined, at least in some of the tests
* ~~I'm not 100% sure that `cint.partialAt` is 100% the same as `_.partialRight` so please confirm since you are the author of cint 🙂~~ I dropped that patch for this PR
* The plan isn't to get rid of lodash or cint for that matter; the plan is to use native methods when possible without sacrificing FP
* Could you maybe have a look and see if we can replace cint with lodash in the codebase? I know you are the author of cint but I assume it's not actively maintained even though it works, and less dependencies is always better as long as one does not reinvent the wheel.

BTW have you thought about adding coverage?