### PR TITLE
Enable `isGlobal` setting

### DIFF
--- a/bin/ncu.js
+++ b/bin/ncu.js
@@ -12,7 +12,7 @@ const pkg = require('../package.json')
 // check if a new version of ncu is available and print an update notification
 const notifier = updateNotifier({ pkg })
 if (notifier.update && notifier.update.latest !== pkg.version) {
-  notifier.notify({ defer: false })
+  notifier.notify({ defer: false, isGlobal: true })
 }
 
 program


### PR DESCRIPTION
The update message by `update-notifier` was telling me to run `npm install npm-check-updates`, and without looking carefully I did just that, and installed the package into my local `node_modules`. As this package says in the README, it should be installed as a global package. I propose changing the `isGlobal` option passed to `update-notifier` to `true`, that way the command displayed in the update message will look like `npm install -g npm-check-updates`.