### PR TITLE
Convert npm config to pacote config

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash')
 const cint = require('cint')
+const fs = require('fs')
 const semver = require('semver')
 const spawn = require('spawn-please')
 const pacote = require('pacote')
@@ -10,16 +11,49 @@ const versionUtil = require('../version-util')
 
 const TIME_FIELDS = ['modified', 'created']
 
+const npmConfigToPacoteMap = {
+  cafile: path => {
+    // load-cafile, based on github.com/npm/cli/blob/40c1b0f/lib/config/load-cafile.js
+    if (!path) return
+    const cadata = fs.readFileSync(path, 'utf8')
+    const delim = '-----END CERTIFICATE-----'
+    const output = cadata
+      .split(delim)
+      .filter(xs => !!xs.trim())
+      .map(xs => `${xs.trimLeft()}${delim}`)
+    return { ca: output }
+  },
+  'fetch-retries': 'fetchRetries',
+  'fetch-retry-factor': 'fetchRetryFactor',
+  'fetch-retry-mintimeout': 'fetchRetryMintimeout',
+  'local-address': 'localAddress',
+  'prefer-offline': 'preferOffline',
+  'prefer-online': 'preferOnline',
+  'strict-ssl': 'strictSSL',
+  'user-agent': 'userAgent',
+}
+
 // needed until pacote supports full npm config compatibility
 // See: https://github.com/zkat/pacote/issues/156
 const npmConfig = {}
 libnpmconfig.read().forEach((value, key) => {
   // replace env ${VARS} in strings with the process.env value
-  npmConfig[key] = typeof value !== 'string' ?
+  const normalizedValue = typeof value !== 'string' ?
     value :
     value.replace(/\${([^}]+)}/, (_, envVar) =>
       process.env[envVar]
     )
+
+  const { [key]: pacoteKey } = npmConfigToPacoteMap
+  if (_.isString(pacoteKey)) {
+    npmConfig[pacoteKey] = normalizedValue
+  }
+  else if (_.isFunction(pacoteKey)) {
+    _.assign(npmConfig, pacoteKey(normalizedValue))
+  }
+  else {
+    npmConfig[key] = normalizedValue
+  }
 })
 npmConfig.cache = false
 

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -23,14 +23,8 @@ const npmConfigToPacoteMap = {
       .map(xs => `${xs.trimLeft()}${delim}`)
     return { ca: output }
   },
-  'fetch-retries': 'fetchRetries',
-  'fetch-retry-factor': 'fetchRetryFactor',
-  'fetch-retry-mintimeout': 'fetchRetryMintimeout',
-  'local-address': 'localAddress',
-  'prefer-offline': 'preferOffline',
-  'prefer-online': 'preferOnline',
+  maxsockets: 'maxSockets',
   'strict-ssl': 'strictSSL',
-  'user-agent': 'userAgent',
 }
 
 // needed until pacote supports full npm config compatibility
@@ -52,7 +46,7 @@ libnpmconfig.read().forEach((value, key) => {
     _.assign(npmConfig, pacoteKey(normalizedValue))
   }
   else {
-    npmConfig[key] = normalizedValue
+    npmConfig[_.camelCase(key)] = normalizedValue
   }
 })
 npmConfig.cache = false

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -46,7 +46,7 @@ libnpmconfig.read().forEach((value, key) => {
     _.assign(npmConfig, pacoteKey(normalizedValue))
   }
   else {
-    npmConfig[_.camelCase(key)] = normalizedValue
+    npmConfig[key.match(/^[a-z]/i) ? _.camelCase(key) : key] = normalizedValue
   }
 })
 npmConfig.cache = false


### PR DESCRIPTION
Here is my first pass at resolving #707. 

Handles the following cases:
- Keys that are converted to camelCase
- `strict-ssl` -> `strictSSL`
- Parses `cafile` and sets result as `npmConfig.ca`
  - npm does this internally when it references the same config
  - `cafile` is not handled in pacote/npm-registry-fetch
  - caveat: if `ca` is specified AFTER `cafile`, `ca` will overwrite the parsed result (npm parses `cafile` last)

I did what I could to cross reference [npm config](https://docs.npmjs.com/misc/config), [pacote docs](https://www.npmjs.com/package/pacote), and [npm-registry-fetch](https://www.npmjs.com/package/npm-registry-fetch).  

> Note: Pacote does reference [cacache](https://github.com/npm/cacache) in its opts docs. I am not sure if it is relevant here.