### PR TITLE
make rimraf a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "prompts": "^2.3.2",
     "rc-config-loader": "^3.0.0",
     "remote-git-tags": "^3.0.0",
+    "rimraf": "^3.0.2",
     "semver": "^7.3.2",
     "semver-utils": "^1.1.4",
     "spawn-please": "^0.4.1",
@@ -85,7 +86,6 @@
     "eslint-plugin-standard": "^4.0.1",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
-    "rimraf": "^3.0.2",
     "should": "^13.2.3",
     "tmp": "0.2.1"
   },


### PR DESCRIPTION
Installation with yarn berry fails because rimraf is referenced in build files but it isn't included as a dependency in production builds.

```
Error: npm-check-updates tried to access rimraf, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: rimraf (via "rimraf")
Required by: npm-check-updates@npm:9.0.1 (via /Users/brian/.yarn/berry/cache/npm-check-updates-npm-9.0.1-4c479406dd-2.zip/node_modules/npm-check-updates/lib/)
```