### PR TITLE
git tags auth

### DIFF
--- a/lib/package-managers/gitTags.js
+++ b/lib/package-managers/gitTags.js
@@ -9,7 +9,7 @@ const { print } = require('../logging')
 /** Return the highest numbered tag on a remote Git URL. */
 const greatest = async (name, version, options) => {
   const { auth, protocol, host, path } = parseGithubUrl(version)
-  const url = `${protocol ? protocol.replace('git+', '') : 'https:'}//${auth || ''}${host}/${path}`
+  const url = `${protocol ? protocol.replace('git+', '') : 'https:'}//${auth ? auth + '@' : ''}${host}/${path}`
   let tagMap = new Map()
 
   // fetch remote tags

--- a/lib/package-managers/gitTags.js
+++ b/lib/package-managers/gitTags.js
@@ -8,8 +8,8 @@ const { print } = require('../logging')
 
 /** Return the highest numbered tag on a remote Git URL. */
 const greatest = async (name, version, options) => {
-  const { protocol, host, path } = parseGithubUrl(version)
-  const url = `${protocol ? protocol.replace('git+', '') : 'https:'}//${host}/${path}`
+  const { auth, protocol, host, path } = parseGithubUrl(version)
+  const url = `${protocol ? protocol.replace('git+', '') : 'https:'}//${auth || ''}${host}/${path}`
   let tagMap = new Map()
 
   // fetch remote tags


### PR DESCRIPTION
Add missing auth component to url used in `git ls-remote`. Fixes #749.