### PR TITLE
Add repository links option to new --format command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ ncu "/^(?!gulp-).*$/" # windows
 Detailed output with links to each repository:
 
 ```sh
-$ ncu --output repositoryLink
+$ ncu --format repo
 ```
 
 ## Options
@@ -136,11 +136,10 @@ $ ncu --output repositoryLink
 -p, --packageManager <name>  npm, yarn (default: "npm")
 -o, --ownerChanged           DEPRECATED. Renamed to "--format ownerChanged".
 --format <value>             Enable additional output data, string or
-                             comma-delimited list: ownerChanged,
-                             repositoryLink. ownerChanged: shows if the
-                             package owner changed between versions.
-                             repositoryLink: infers and displays links to
-                             source code repository. (default: [])
+                             comma-delimited list: ownerChanged, repo.
+                             ownerChanged: shows if the package owner changed
+                             between versions. repo: infers and displays
+                             links to source code repository. (default: [])
 --packageData <value>        Package file data (you can also use stdin).
 --packageFile <path>         Package file location (default: ./package.json).
 --pre <n>                    Include -alpha, -beta, -rc. (default: 0; default

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ $ ncu "/^gulp-.*$/"
 # upgrade packages that do not start with "gulp-".
 $ ncu '/^(?!gulp-).*$/' # mac/linux
 $ ncu "/^(?!gulp-).*$/" # windows
+```
 
-# enable detailed output with links to each repository
+Detailed output with links to each repository:
+
+```sh
 $ ncu --output repositoryLink
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ $ ncu "/^gulp-.*$/"
 # upgrade packages that do not start with "gulp-".
 $ ncu '/^(?!gulp-).*$/' # mac/linux
 $ ncu "/^(?!gulp-).*$/" # windows
+
+# enable detailed output with links to each repository
+$ ncu --output repositoryLink
 ```
 
 ## Options
@@ -128,8 +131,13 @@ $ ncu "/^(?!gulp-).*$/" # windows
                              semver.
 -n, --newest                 DEPRECATED. Renamed to "--target newest".
 -p, --packageManager <name>  npm, yarn (default: "npm")
--o, --ownerChanged           Check if the package owner changed between
-                             current and upgraded version.
+-o, --ownerChanged           DEPRECATED. Renamed to "--output ownerChanged".
+--output <value>             Enable additional output data, string or
+                             comma-delimited list: ownerChanged,
+                             repositoryLink. ownerChanged: shows if the
+                             package owner changed between versions.
+                             repositoryLink: infers and displays links to
+                             source code repository. (default: [])
 --packageData <string>       Package file data (you can also use stdin).
 --packageFile <path>         Package file location (default: ./package.json).
 --pre <n>                    Include -alpha, -beta, -rc. (default: 0; default

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ ncu --output repositoryLink
                              directory of `packageFile`).
 --configFileName <filename>  Config file name (default: .ncurc.{json,yml,js})
 --cwd <path>                 Working directory in which npm will be executed.
---dep <dep>                  Check one or more sections of dependencies only:
+--dep <value>                Check one or more sections of dependencies only:
                              prod, dev, peer, optional, bundle
                              (comma-delimited).
 --deprecated                 Include deprecated packages.
@@ -134,14 +134,14 @@ $ ncu --output repositoryLink
                              semver.
 -n, --newest                 DEPRECATED. Renamed to "--target newest".
 -p, --packageManager <name>  npm, yarn (default: "npm")
--o, --ownerChanged           DEPRECATED. Renamed to "--output ownerChanged".
---output <value>             Enable additional output data, string or
+-o, --ownerChanged           DEPRECATED. Renamed to "--format ownerChanged".
+--format <value>             Enable additional output data, string or
                              comma-delimited list: ownerChanged,
                              repositoryLink. ownerChanged: shows if the
                              package owner changed between versions.
                              repositoryLink: infers and displays links to
                              source code repository. (default: [])
---packageData <string>       Package file data (you can also use stdin).
+--packageData <value>        Package file data (you can also use stdin).
 --packageFile <path>         Package file location (default: ./package.json).
 --pre <n>                    Include -alpha, -beta, -rc. (default: 0; default
                              with --newest and --greatest: 1).

--- a/bin/build.js
+++ b/bin/build.js
@@ -50,16 +50,16 @@ export = ncu
 `
 
   // parse commander values
-  const optionTypes = cliOptions.map(({ optionName, name, description, default: defaultValue, type: typeValue }) => {
-    const tsName = optionName
+  const optionTypes = cliOptions.map(({ long, arg, deprecated, description, default: defaultValue, type: typeValue }) => {
+    const tsName = long
     const tsType = typeValue || (
       defaultValue ? typeof defaultValue
-      : name.includes(' <n>') || name.includes(' <ms>') ? 'number'
-      : !name.includes(' <') ? 'boolean'
+      : ['n', 'ms'].includes(arg) ? 'number'
+      : !arg ? 'boolean'
       : 'string'
     )
     const tsDefault = defaultValue ? ' (default: ' + JSON.stringify(defaultValue) + ')' : ''
-    const deprecatedLine = description.includes('DEPRECATED') ? `
+    const deprecatedLine = deprecated ? `
      * @deprecated` : ''
     return `
     /**

--- a/bin/build.js
+++ b/bin/build.js
@@ -6,7 +6,7 @@ const cliOptions = require('../lib/cli-options')
 /** Extracts CLI options from the bin output. */
 const readOptions = async () => {
   const optionsBinLabel = 'Options:\n'
-  const helpOutput = await spawn('./bin/cli.js', ['--help'])
+  const helpOutput = await spawn('node', ['./bin/cli.js', '--help'])
   return helpOutput.slice(helpOutput.indexOf(optionsBinLabel) + optionsBinLabel.length)
   // outdent
     .split('\n').map(s => s.slice(2)).join('\n')
@@ -50,8 +50,8 @@ export = ncu
 `
 
   // parse commander values
-  const optionTypes = cliOptions.map(({ name, description, default: defaultValue, type: typeValue }) => {
-    const tsName = name.replace(/(?:-\w, )?--([^ ]+)(?: <.*>)?/, (_, m) => m)
+  const optionTypes = cliOptions.map(({ optionName, name, description, default: defaultValue, type: typeValue }) => {
+    const tsName = optionName
     const tsType = typeValue || (
       defaultValue ? typeof defaultValue
       : name.includes(' <n>') || name.includes(' <ms>') ? 'number'

--- a/bin/build.js
+++ b/bin/build.js
@@ -59,8 +59,12 @@ export = ncu
       : 'string'
     )
     const tsDefault = defaultValue ? ' (default: ' + JSON.stringify(defaultValue) + ')' : ''
+    const deprecatedLine = description.includes('DEPRECATED') ? `
+     * @deprecated` : ''
     return `
-    /** ${description}${tsDefault} */
+    /**
+     * ${description}${tsDefault}${deprecatedLine}
+     */
     ${tsName}?: ${tsType};
 `
   })

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,9 +21,9 @@ program
   .usage('[options] [filter]')
 
 // add cli options
-cliOptions.forEach(({ name, description, default: defaultValue, parse }) =>
+cliOptions.forEach(({ long, short, arg, description, default: defaultValue, parse }) =>
   // handle 3rd/4th argument polymorphism
-  program.option(name, description, parse || defaultValue, parse ? defaultValue : undefined))
+  program.option(`${short ? `-${short}, ` : ''}--${long}${arg ? ` <${arg}>` : ''}`, description, parse || defaultValue, parse ? defaultValue : undefined))
 
 // set version option at the end
 program.version(pkg.version)

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,143 +1,184 @@
 // store CLI options separately from bin file so that they can be used to build type definitions
 const cliOptions = [
   {
+    optionName: 'concurrency',
     name: '--concurrency <n>',
     description: 'Max number of concurrent HTTP requests to registry.',
     parse: s => parseInt(s, 10),
     default: 8
   },
   {
+    optionName: 'configFilePath',
     name: '--configFilePath <path>',
     description: 'Directory of .ncurc config file (default: directory of `packageFile`).'
   },
   {
+    optionName: 'configFileName',
     name: '--configFileName <filename>',
     description: 'Config file name (default: .ncurc.{json,yml,js})'
   },
   {
+    optionName: 'cwd',
     name: '--cwd <path>',
     description: 'Working directory in which npm will be executed.'
   },
   {
+    optionName: 'dep',
     name: '--dep <dep>',
     description: 'Check one or more sections of dependencies only: prod, dev, peer, optional, bundle (comma-delimited).'
   },
   {
+    optionName: 'deprecated',
     name: '--deprecated',
     description: 'Include deprecated packages.'
   },
   {
+    optionName: 'doctor',
     name: '--doctor',
     description: 'Iteratively installs upgrades and runs tests to identify breaking upgrades. Run "ncu --doctor" for detailed help. Add "-u" to execute.',
   },
   {
+    optionName: 'enginesNode',
     name: '--enginesNode',
     description: 'Include only packages that satisfy engines.node as specified in the package file.'
   },
   {
+    optionName: 'errorLevel',
     name: '-e, --errorLevel <n>',
     description: 'Set the error level. 1: exits with error code 0 if no errors occur. 2: exits with error code 0 if no packages need updating (useful for continuous integration).',
     parse: s => parseInt(s, 10),
     default: 1
   },
   {
+    optionName: 'filter',
     name: '-f, --filter <matches>',
     description: 'Include only package names matching the given string, comma-or-space-delimited list, or /regex/.',
     type: 'string | string[] | RegExp'
   },
   {
+    optionName: 'global',
     name: '-g, --global',
     description: 'Check global packages instead of in the current project.'
   },
   {
+    optionName: 'greatest',
     name: '--greatest',
     description: 'DEPRECATED. Renamed to "--target greatest".'
   },
   {
+    optionName: 'interactive',
     name: '-i, --interactive',
     description: 'Enable interactive prompts for each dependency; implies -u unless one of the json options are set,'
   },
   {
     // program.json is set to true in programInit if any options that begin with 'json' are true
+    optionName: 'jsonAll',
     name: '-j, --jsonAll',
     description: 'Output new package file instead of human-readable message.'
   },
   {
+    optionName: 'jsonDeps',
     name: '--jsonDeps',
     description: 'Like `jsonAll` but only lists `dependencies`, `devDependencies`, `optionalDependencies`, etc of the new package data.'
   },
   {
+    optionName: 'jsonUpgraded',
     name: '--jsonUpgraded',
     description: 'Output upgraded dependencies in json.'
   },
   {
+    optionName: 'loglevel',
     name: '-l, --loglevel <n>',
     description: 'Amount to log: silent, error, minimal, warn, info, verbose, silly.',
     default: 'warn'
   },
   {
+    optionName: 'minimal',
     name: '-m, --minimal',
     description: 'Do not upgrade newer versions that are already satisfied by the version range according to semver.'
   },
   {
+    optionName: 'newest',
     name: '-n, --newest',
     description: 'DEPRECATED. Renamed to "--target newest".'
   },
   {
+    optionName: 'packageManager',
     name: '-p, --packageManager <name>',
     description: 'npm, yarn',
     default: 'npm'
   },
   {
+    optionName: 'ownerChanged',
     name: '-o, --ownerChanged',
-    description: 'Check if the package owner changed between current and upgraded version.',
+    description: 'DEPRECATED. Renamed to "--output ownerChanged".',
   },
   {
+    optionName: 'output',
+    name: '--output <value>',
+    description: 'Enable additional output data, string or comma-delimited list: ownerChanged, repositoryLink. ownerChanged: shows if the package owner changed between versions. repositoryLink: infers and displays links to source code repository.',
+    parse: value => typeof value === 'string' ? value.split(',') : value,
+    default: [],
+    type: 'string[]'
+  },
+  {
+    optionName: 'packageData',
     name: '--packageData <string>',
     description: 'Package file data (you can also use stdin).'
   },
   {
+    optionName: 'packageFile',
     name: '--packageFile <path>',
     description: 'Package file location (default: ./package.json).'
   },
   {
+    optionName: 'pre',
     name: '--pre <n>',
     description: 'Include -alpha, -beta, -rc. (default: 0; default with --newest and --greatest: 1).',
     type: 'boolean'
   },
   {
+    optionName: 'prefix',
     name: '--prefix <path>',
     description: 'Current working directory of npm.'
   },
   {
+    optionName: 'registry',
     name: '-r, --registry <url>',
     description: 'Third-party npm registry.'
   },
   {
+    optionName: 'removeRange',
     name: '--removeRange',
     description: 'Remove version ranges from the final package version.'
   },
   {
+    optionName: 'semverLevel',
     name: '--semverLevel <value>',
     description: 'DEPRECATED. Renamed to --target.'
   },
   {
+    optionName: 'silent',
     name: '-s, --silent',
     description: 'Don\'t output anything (--loglevel silent).'
   },
   {
+    optionName: 'target',
     name: '-t, --target <value>',
     description: 'Target version to upgrade to: latest, newest, greatest, minor, patch. (default: "latest")'
   },
   {
+    optionName: 'timeout',
     name: '--timeout <ms>',
     description: 'Global timeout in milliseconds. (default: no global timeout and 30 seconds per npm-registery-fetch).'
   },
   {
+    optionName: 'upgrade',
     name: '-u, --upgrade',
     description: 'Overwrite package file with upgraded versions instead of just outputting to console.'
   },
   {
+    optionName: 'reject',
     name: '-x, --reject <matches>',
     description: 'Exclude packages matching the given string, comma-or-space-delimited list, or /regex/.',
     type: 'string | string[] | RegExp'

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -117,7 +117,7 @@ const cliOptions = [
   {
     long: 'format',
     arg: 'value',
-    description: 'Enable additional output data, string or comma-delimited list: ownerChanged, repositoryLink. ownerChanged: shows if the package owner changed between versions. repositoryLink: infers and displays links to source code repository.',
+    description: 'Enable additional output data, string or comma-delimited list: ownerChanged, repo. ownerChanged: shows if the package owner changed between versions. repo: infers and displays links to source code repository.',
     parse: value => typeof value === 'string' ? value.split(',') : value,
     default: [],
     type: 'string[]'

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,185 +1,189 @@
 // store CLI options separately from bin file so that they can be used to build type definitions
 const cliOptions = [
   {
-    optionName: 'concurrency',
-    name: '--concurrency <n>',
+    long: 'concurrency',
+    arg: 'n',
     description: 'Max number of concurrent HTTP requests to registry.',
     parse: s => parseInt(s, 10),
     default: 8
   },
   {
-    optionName: 'configFilePath',
-    name: '--configFilePath <path>',
+    long: 'configFilePath',
+    arg: 'path',
     description: 'Directory of .ncurc config file (default: directory of `packageFile`).'
   },
   {
-    optionName: 'configFileName',
-    name: '--configFileName <filename>',
+    long: 'configFileName',
+    arg: 'filename',
     description: 'Config file name (default: .ncurc.{json,yml,js})'
   },
   {
-    optionName: 'cwd',
-    name: '--cwd <path>',
+    long: 'cwd',
+    arg: 'path',
     description: 'Working directory in which npm will be executed.'
   },
   {
-    optionName: 'dep',
-    name: '--dep <dep>',
+    long: 'dep',
+    arg: 'value',
     description: 'Check one or more sections of dependencies only: prod, dev, peer, optional, bundle (comma-delimited).'
   },
   {
-    optionName: 'deprecated',
-    name: '--deprecated',
+    long: 'deprecated',
     description: 'Include deprecated packages.'
   },
   {
-    optionName: 'doctor',
-    name: '--doctor',
+    long: 'doctor',
     description: 'Iteratively installs upgrades and runs tests to identify breaking upgrades. Run "ncu --doctor" for detailed help. Add "-u" to execute.',
   },
   {
-    optionName: 'enginesNode',
-    name: '--enginesNode',
+    long: 'enginesNode',
     description: 'Include only packages that satisfy engines.node as specified in the package file.'
   },
   {
-    optionName: 'errorLevel',
-    name: '-e, --errorLevel <n>',
+    short: 'e',
+    long: 'errorLevel',
+    arg: 'n',
     description: 'Set the error level. 1: exits with error code 0 if no errors occur. 2: exits with error code 0 if no packages need updating (useful for continuous integration).',
     parse: s => parseInt(s, 10),
     default: 1
   },
   {
-    optionName: 'filter',
-    name: '-f, --filter <matches>',
+    short: 'f',
+    long: 'filter',
+    arg: 'matches',
     description: 'Include only package names matching the given string, comma-or-space-delimited list, or /regex/.',
     type: 'string | string[] | RegExp'
   },
   {
-    optionName: 'global',
-    name: '-g, --global',
+    short: 'g',
+    long: 'global',
     description: 'Check global packages instead of in the current project.'
   },
   {
-    optionName: 'greatest',
-    name: '--greatest',
-    description: 'DEPRECATED. Renamed to "--target greatest".'
+    long: 'greatest',
+    description: 'DEPRECATED. Renamed to "--target greatest".',
+    deprecated: true
   },
   {
-    optionName: 'interactive',
-    name: '-i, --interactive',
+    short: 'i',
+    long: 'interactive',
     description: 'Enable interactive prompts for each dependency; implies -u unless one of the json options are set,'
   },
   {
     // program.json is set to true in programInit if any options that begin with 'json' are true
-    optionName: 'jsonAll',
-    name: '-j, --jsonAll',
+    short: 'j',
+    long: 'jsonAll',
     description: 'Output new package file instead of human-readable message.'
   },
   {
-    optionName: 'jsonDeps',
-    name: '--jsonDeps',
+    long: 'jsonDeps',
     description: 'Like `jsonAll` but only lists `dependencies`, `devDependencies`, `optionalDependencies`, etc of the new package data.'
   },
   {
-    optionName: 'jsonUpgraded',
-    name: '--jsonUpgraded',
+    long: 'jsonUpgraded',
     description: 'Output upgraded dependencies in json.'
   },
   {
-    optionName: 'loglevel',
-    name: '-l, --loglevel <n>',
+    short: 'l',
+    long: 'loglevel',
+    arg: 'n',
     description: 'Amount to log: silent, error, minimal, warn, info, verbose, silly.',
     default: 'warn'
   },
   {
-    optionName: 'minimal',
-    name: '-m, --minimal',
+    short: 'm',
+    long: 'minimal',
     description: 'Do not upgrade newer versions that are already satisfied by the version range according to semver.'
   },
   {
-    optionName: 'newest',
-    name: '-n, --newest',
-    description: 'DEPRECATED. Renamed to "--target newest".'
+    short: 'n',
+    long: 'newest',
+    description: 'DEPRECATED. Renamed to "--target newest".',
+    deprecated: true
   },
   {
-    optionName: 'packageManager',
-    name: '-p, --packageManager <name>',
+    short: 'p',
+    long: 'packageManager',
+    arg: 'name',
     description: 'npm, yarn',
     default: 'npm'
   },
   {
-    optionName: 'ownerChanged',
-    name: '-o, --ownerChanged',
-    description: 'DEPRECATED. Renamed to "--output ownerChanged".',
+    short: 'o',
+    long: 'ownerChanged',
+    description: 'DEPRECATED. Renamed to "--format ownerChanged".',
+    deprecated: true
   },
   {
-    optionName: 'output',
-    name: '--output <value>',
+    long: 'format',
+    arg: 'value',
     description: 'Enable additional output data, string or comma-delimited list: ownerChanged, repositoryLink. ownerChanged: shows if the package owner changed between versions. repositoryLink: infers and displays links to source code repository.',
     parse: value => typeof value === 'string' ? value.split(',') : value,
     default: [],
     type: 'string[]'
   },
   {
-    optionName: 'packageData',
-    name: '--packageData <string>',
+    long: 'packageData',
+    arg: 'value',
     description: 'Package file data (you can also use stdin).'
   },
   {
-    optionName: 'packageFile',
-    name: '--packageFile <path>',
+    long: 'packageFile',
+    arg: 'path',
     description: 'Package file location (default: ./package.json).'
   },
   {
-    optionName: 'pre',
-    name: '--pre <n>',
+    long: 'pre',
+    arg: 'n',
     description: 'Include -alpha, -beta, -rc. (default: 0; default with --newest and --greatest: 1).',
     type: 'boolean'
   },
   {
-    optionName: 'prefix',
-    name: '--prefix <path>',
+    long: 'prefix',
+    arg: 'path',
     description: 'Current working directory of npm.'
   },
   {
-    optionName: 'registry',
-    name: '-r, --registry <url>',
+    short: 'r',
+    long: 'registry',
+    arg: 'url',
     description: 'Third-party npm registry.'
   },
   {
-    optionName: 'removeRange',
-    name: '--removeRange',
+    long: 'removeRange',
     description: 'Remove version ranges from the final package version.'
   },
   {
-    optionName: 'semverLevel',
-    name: '--semverLevel <value>',
-    description: 'DEPRECATED. Renamed to --target.'
+    long: 'semverLevel',
+    arg: 'value',
+    description: 'DEPRECATED. Renamed to --target.',
+    deprecated: true
   },
   {
-    optionName: 'silent',
-    name: '-s, --silent',
+    short: 's',
+    long: 'silent',
     description: 'Don\'t output anything (--loglevel silent).'
   },
   {
-    optionName: 'target',
-    name: '-t, --target <value>',
+    short: 't',
+    long: 'target',
+    arg: 'value',
     description: 'Target version to upgrade to: latest, newest, greatest, minor, patch. (default: "latest")'
   },
   {
-    optionName: 'timeout',
-    name: '--timeout <ms>',
+    long: 'timeout',
+    arg: 'ms',
     description: 'Global timeout in milliseconds. (default: no global timeout and 30 seconds per npm-registery-fetch).'
   },
   {
-    optionName: 'upgrade',
-    name: '-u, --upgrade',
+    short: 'u',
+    long: 'upgrade',
     description: 'Overwrite package file with upgraded versions instead of just outputting to console.'
   },
   {
-    optionName: 'reject',
-    name: '-x, --reject <matches>',
+    short: 'x',
+    long: 'reject',
+    arg: 'matches',
     description: 'Exclude packages matching the given string, comma-or-space-delimited list, or /regex/.',
     type: 'string | string[] | RegExp'
   },

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,106 +2,178 @@ declare namespace ncu {
 
   interface RunOptions {
 
-    /** Max number of concurrent HTTP requests to registry. (default: 8) */
+    /**
+     * Max number of concurrent HTTP requests to registry. (default: 8)
+     */
     concurrency?: number;
 
-    /** Directory of .ncurc config file (default: directory of `packageFile`). */
+    /**
+     * Directory of .ncurc config file (default: directory of `packageFile`).
+     */
     configFilePath?: string;
 
-    /** Config file name (default: .ncurc.{json,yml,js}) */
+    /**
+     * Config file name (default: .ncurc.{json,yml,js})
+     */
     configFileName?: string;
 
-    /** Working directory in which npm will be executed. */
+    /**
+     * Working directory in which npm will be executed.
+     */
     cwd?: string;
 
-    /** Check one or more sections of dependencies only: prod, dev, peer, optional, bundle (comma-delimited). */
+    /**
+     * Check one or more sections of dependencies only: prod, dev, peer, optional, bundle (comma-delimited).
+     */
     dep?: string;
 
-    /** Include deprecated packages. */
+    /**
+     * Include deprecated packages.
+     */
     deprecated?: boolean;
 
-    /** Iteratively installs upgrades and runs tests to identify breaking upgrades. Run "ncu --doctor" for detailed help. Add "-u" to execute. */
+    /**
+     * Iteratively installs upgrades and runs tests to identify breaking upgrades. Run "ncu --doctor" for detailed help. Add "-u" to execute.
+     */
     doctor?: boolean;
 
-    /** Include only packages that satisfy engines.node as specified in the package file. */
+    /**
+     * Include only packages that satisfy engines.node as specified in the package file.
+     */
     enginesNode?: boolean;
 
-    /** Set the error level. 1: exits with error code 0 if no errors occur. 2: exits with error code 0 if no packages need updating (useful for continuous integration). (default: 1) */
+    /**
+     * Set the error level. 1: exits with error code 0 if no errors occur. 2: exits with error code 0 if no packages need updating (useful for continuous integration). (default: 1)
+     */
     errorLevel?: number;
 
-    /** Include only package names matching the given string, comma-or-space-delimited list, or /regex/. */
+    /**
+     * Include only package names matching the given string, comma-or-space-delimited list, or /regex/.
+     */
     filter?: string | string[] | RegExp;
 
-    /** Check global packages instead of in the current project. */
+    /**
+     * Check global packages instead of in the current project.
+     */
     global?: boolean;
 
-    /** DEPRECATED. Renamed to "--target greatest". */
+    /**
+     * DEPRECATED. Renamed to "--target greatest".
+     * @deprecated
+     */
     greatest?: boolean;
 
-    /** Enable interactive prompts for each dependency; implies -u unless one of the json options are set, */
+    /**
+     * Enable interactive prompts for each dependency; implies -u unless one of the json options are set,
+     */
     interactive?: boolean;
 
-    /** Output new package file instead of human-readable message. */
+    /**
+     * Output new package file instead of human-readable message.
+     */
     jsonAll?: boolean;
 
-    /** Like `jsonAll` but only lists `dependencies`, `devDependencies`, `optionalDependencies`, etc of the new package data. */
+    /**
+     * Like `jsonAll` but only lists `dependencies`, `devDependencies`, `optionalDependencies`, etc of the new package data.
+     */
     jsonDeps?: boolean;
 
-    /** Output upgraded dependencies in json. */
+    /**
+     * Output upgraded dependencies in json.
+     */
     jsonUpgraded?: boolean;
 
-    /** Amount to log: silent, error, minimal, warn, info, verbose, silly. (default: "warn") */
+    /**
+     * Amount to log: silent, error, minimal, warn, info, verbose, silly. (default: "warn")
+     */
     loglevel?: string;
 
-    /** Do not upgrade newer versions that are already satisfied by the version range according to semver. */
+    /**
+     * Do not upgrade newer versions that are already satisfied by the version range according to semver.
+     */
     minimal?: boolean;
 
-    /** DEPRECATED. Renamed to "--target newest". */
+    /**
+     * DEPRECATED. Renamed to "--target newest".
+     * @deprecated
+     */
     newest?: boolean;
 
-    /** npm, yarn (default: "npm") */
+    /**
+     * npm, yarn (default: "npm")
+     */
     packageManager?: string;
 
-    /** DEPRECATED. Renamed to "--output ownerChanged". */
+    /**
+     * DEPRECATED. Renamed to "--output ownerChanged".
+     * @deprecated
+     */
     ownerChanged?: boolean;
 
-    /** Enable additional output data, string or comma-delimited list: ownerChanged, repositoryLink. ownerChanged: shows if the package owner changed between versions. repositoryLink: infers and displays links to source code repository. (default: []) */
+    /**
+     * Enable additional output data, string or comma-delimited list: ownerChanged, repositoryLink. ownerChanged: shows if the package owner changed between versions. repositoryLink: infers and displays links to source code repository. (default: [])
+     */
     output?: string[];
 
-    /** Package file data (you can also use stdin). */
+    /**
+     * Package file data (you can also use stdin).
+     */
     packageData?: string;
 
-    /** Package file location (default: ./package.json). */
+    /**
+     * Package file location (default: ./package.json).
+     */
     packageFile?: string;
 
-    /** Include -alpha, -beta, -rc. (default: 0; default with --newest and --greatest: 1). */
+    /**
+     * Include -alpha, -beta, -rc. (default: 0; default with --newest and --greatest: 1).
+     */
     pre?: boolean;
 
-    /** Current working directory of npm. */
+    /**
+     * Current working directory of npm.
+     */
     prefix?: string;
 
-    /** Third-party npm registry. */
+    /**
+     * Third-party npm registry.
+     */
     registry?: string;
 
-    /** Remove version ranges from the final package version. */
+    /**
+     * Remove version ranges from the final package version.
+     */
     removeRange?: boolean;
 
-    /** DEPRECATED. Renamed to --target. */
+    /**
+     * DEPRECATED. Renamed to --target.
+     * @deprecated
+     */
     semverLevel?: string;
 
-    /** Don't output anything (--loglevel silent). */
+    /**
+     * Don't output anything (--loglevel silent).
+     */
     silent?: boolean;
 
-    /** Target version to upgrade to: latest, newest, greatest, minor, patch. (default: "latest") */
+    /**
+     * Target version to upgrade to: latest, newest, greatest, minor, patch. (default: "latest")
+     */
     target?: string;
 
-    /** Global timeout in milliseconds. (default: no global timeout and 30 seconds per npm-registery-fetch). */
+    /**
+     * Global timeout in milliseconds. (default: no global timeout and 30 seconds per npm-registery-fetch).
+     */
     timeout?: number;
 
-    /** Overwrite package file with upgraded versions instead of just outputting to console. */
+    /**
+     * Overwrite package file with upgraded versions instead of just outputting to console.
+     */
     upgrade?: boolean;
 
-    /** Exclude packages matching the given string, comma-or-space-delimited list, or /regex/. */
+    /**
+     * Exclude packages matching the given string, comma-or-space-delimited list, or /regex/.
+     */
     reject?: string | string[] | RegExp;
 
   }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -105,7 +105,7 @@ declare namespace ncu {
     packageManager?: string;
 
     /**
-     * DEPRECATED. Renamed to "--output ownerChanged".
+     * DEPRECATED. Renamed to "--format ownerChanged".
      * @deprecated
      */
     ownerChanged?: boolean;
@@ -113,7 +113,7 @@ declare namespace ncu {
     /**
      * Enable additional output data, string or comma-delimited list: ownerChanged, repositoryLink. ownerChanged: shows if the package owner changed between versions. repositoryLink: infers and displays links to source code repository. (default: [])
      */
-    output?: string[];
+    format?: string[];
 
     /**
      * Package file data (you can also use stdin).

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -62,8 +62,11 @@ declare namespace ncu {
     /** npm, yarn (default: "npm") */
     packageManager?: string;
 
-    /** Check if the package owner changed between current and upgraded version. */
+    /** DEPRECATED. Renamed to "--output ownerChanged". */
     ownerChanged?: boolean;
+
+    /** Enable additional output data, string or comma-delimited list: ownerChanged, repositoryLink. ownerChanged: shows if the package owner changed between versions. repositoryLink: infers and displays links to source code repository. (default: []) */
+    output?: string[];
 
     /** Package file data (you can also use stdin). */
     packageData?: string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -111,7 +111,7 @@ declare namespace ncu {
     ownerChanged?: boolean;
 
     /**
-     * Enable additional output data, string or comma-delimited list: ownerChanged, repositoryLink. ownerChanged: shows if the package owner changed between versions. repositoryLink: infers and displays links to source code repository. (default: [])
+     * Enable additional output data, string or comma-delimited list: ownerChanged, repo. ownerChanged: shows if the package owner changed between versions. repo: infers and displays links to source code repository. (default: [])
      */
     format?: string[];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ const doctor = require('./doctor')
 const packageManagers = require('./package-managers')
 const { print, printJson, printUpgrades } = require('./logging')
 const { doctorHelpText } = require('./constants')
+const cliOptions = require('./cli-options')
 
 // maps package managers to package file names
 const packageFileNames = {
@@ -29,6 +30,15 @@ const packageFileNames = {
 // time to wait for stdin before printing a warning
 const stdinWarningTime = 5000
 const stdinWarningMessage = `Hmmmmm... this is taking a long time. Your console is telling me to wait for input \non stdin, but maybe that is not what you want.\nTry ${chalk.cyan('winpty ncu.cmd')}, or specify a package file explicitly with ${chalk.cyan('--packageFile package.json')}. \nSee https://github.com/raineorshine/npm-check-updates/issues/136#issuecomment-155721102`
+
+// In the format of [argName, deprecationMessage]
+const deprecatedArgs = [
+  ['greatest', '--greatest has been deprecated. Renamed to "--target greatest"'],
+  ['newest', '--newest has been deprecated. Renamed to "--target newest".'],
+  ['o', '-o has been deprecated. Renamed to "--output ownerChanged".'],
+  ['ownerChanged', '--ownerChanged has been deprecated. Renamed to "--output ownerChanged".'],
+  ['semverLevel', '--semverLevel has been deprecated. Renamed to --target']
+]
 
 //
 // Helper functions
@@ -166,7 +176,7 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
   const filteredUpgraded = options.minimal ? cint.filterObject(selectedNewDependencies, dep => !isSatisfied(dep)) : selectedNewDependencies
   const numUpgraded = Object.keys(filteredUpgraded).length
 
-  const ownersChangedDeps = options.ownerChanged
+  const ownersChangedDeps = options.ownerChanged || options.output.includes('ownerChanged')
     ? await vm.getOwnerPerDependency(current, filteredUpgraded, options)
     : null
 
@@ -251,13 +261,11 @@ function initOptions(options) {
 
   return {
     ...options,
-    concurrency: options.concurrency || 8,
-    errorLevel: options.errorLevel != null ? options.errorLevel : 1,
     filter: options.args.join(' ') || options.filter,
     // add shortcut for any keys that start with 'json'
     json,
     // convert silent option to loglevel silent
-    loglevel: options.silent ? 'silent' : options.loglevel || 'warn',
+    loglevel: options.silent ? 'silent' : options.loglevel,
     minimal: options.minimal === undefined ? false : options.minimal,
     // default to false, except when newest or greatest are set
     ...options.pre != null || autoPre
@@ -265,7 +273,7 @@ function initOptions(options) {
       : null,
     target,
     // imply upgrade in interactive mode when json is not specified as the output
-    upgrade: options.interactive && options.upgrade === undefined ? !json : options.upgrade
+    upgrade: options.interactive && options.upgrade === undefined ? !json : options.upgrade,
   }
 }
 
@@ -359,7 +367,14 @@ async function run(options = {}) {
 
   // if not executed on the command-line (i.e. executed as a node module), set some defaults
   if (!options.cli) {
+    const cliDefaults = cliOptions.reduce((acc, curr) => {
+      return {
+        ...acc,
+        [curr.optionName]: curr.default
+      }
+    }, {})
     const defaultOptions = {
+      ...cliDefaults,
       jsonUpgraded: true,
       silent: options.silent || options.loglevel === undefined,
       args: []
@@ -368,6 +383,12 @@ async function run(options = {}) {
   }
 
   options = initOptions(options)
+
+  deprecatedArgs.forEach(([argName, deprecationMessage]) => {
+    if (options[argName] !== undefined) {
+      print(options, deprecationMessage, 'warn')
+    }
+  })
 
   if (options.rcConfigPath) {
     print(options, `Using config file ${options.rcConfigPath}`)

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,8 +31,6 @@ const packageFileNames = {
 const stdinWarningTime = 5000
 const stdinWarningMessage = `Hmmmmm... this is taking a long time. Your console is telling me to wait for input \non stdin, but maybe that is not what you want.\nTry ${chalk.cyan('winpty ncu.cmd')}, or specify a package file explicitly with ${chalk.cyan('--packageFile package.json')}. \nSee https://github.com/raineorshine/npm-check-updates/issues/136#issuecomment-155721102`
 
-const deprecatedArgs = cliOptions.filter(arg => arg.deprecated)
-
 //
 // Helper functions
 //
@@ -272,7 +270,7 @@ function initOptions(options) {
     target,
     // imply upgrade in interactive mode when json is not specified as the output
     upgrade: options.interactive && options.upgrade === undefined ? !json : options.upgrade,
-    format: format
+    format,
   }
 }
 
@@ -368,7 +366,7 @@ async function run(options = {}) {
   if (!options.cli) {
     const cliDefaults = cliOptions.reduce((acc, curr) => ({
       ...acc,
-      ...curr.default !== null ? { [curr.long]: curr.default } : null,
+      ...curr.default != null ? { [curr.long]: curr.default } : null,
     }), {})
     const defaultOptions = {
       ...cliDefaults,
@@ -381,19 +379,12 @@ async function run(options = {}) {
 
   options = initOptions(options)
 
-  let deprecationMessageShown = false
-  deprecatedArgs.forEach(({ short, long, description }) => {
-    const deprecationMessage = options[short] !== undefined
-      ? `-${short}: ${description}`
-      : options[long] !== undefined
-        ? `--${long}: ${description}`
-        : null
-    if (deprecationMessage !== null) {
+  const deprecatedOptions = cliOptions.filter(({ long, deprecated }) => deprecated && options[long])
+  if (deprecatedOptions.length > 0) {
+    deprecatedOptions.forEach(({ short, long, description }) => {
+      const deprecationMessage = `--${long}: ${description}`
       print(options, chalk.yellow(deprecationMessage), 'warn')
-      deprecationMessageShown = true
-    }
-  })
-  if (deprecationMessageShown) {
+    })
     print(options, '', 'warn')
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -273,7 +273,7 @@ function initOptions(options) {
       : null,
     target,
     // imply upgrade in interactive mode when json is not specified as the output
-    upgrade: options.interactive && options.upgrade === undefined ? !json : options.upgrade,
+    upgrade: options.interactive && options.upgrade === undefined ? !json : options.upgrade
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -367,12 +367,10 @@ async function run(options = {}) {
 
   // if not executed on the command-line (i.e. executed as a node module), set some defaults
   if (!options.cli) {
-    const cliDefaults = cliOptions.reduce((acc, curr) => {
-      return {
-        ...acc,
-        [curr.optionName]: curr.default
-      }
-    }, {})
+    const cliDefaults = cliOptions.reduce((acc, curr) => ({
+      ...acc,
+      ...curr.default !== null ? { [curr.optionName]: curr.default } : null,
+    }), {})
     const defaultOptions = {
       ...cliDefaults,
       jsonUpgraded: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,14 +31,7 @@ const packageFileNames = {
 const stdinWarningTime = 5000
 const stdinWarningMessage = `Hmmmmm... this is taking a long time. Your console is telling me to wait for input \non stdin, but maybe that is not what you want.\nTry ${chalk.cyan('winpty ncu.cmd')}, or specify a package file explicitly with ${chalk.cyan('--packageFile package.json')}. \nSee https://github.com/raineorshine/npm-check-updates/issues/136#issuecomment-155721102`
 
-// In the format of [argName, deprecationMessage]
-const deprecatedArgs = [
-  ['greatest', '--greatest has been deprecated. Renamed to "--target greatest"'],
-  ['newest', '--newest has been deprecated. Renamed to "--target newest".'],
-  ['o', '-o has been deprecated. Renamed to "--output ownerChanged".'],
-  ['ownerChanged', '--ownerChanged has been deprecated. Renamed to "--output ownerChanged".'],
-  ['semverLevel', '--semverLevel has been deprecated. Renamed to --target']
-]
+const deprecatedArgs = cliOptions.filter(arg => arg.deprecated)
 
 //
 // Helper functions
@@ -176,7 +169,7 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
   const filteredUpgraded = options.minimal ? cint.filterObject(selectedNewDependencies, dep => !isSatisfied(dep)) : selectedNewDependencies
   const numUpgraded = Object.keys(filteredUpgraded).length
 
-  const ownersChangedDeps = options.ownerChanged || options.output.includes('ownerChanged')
+  const ownersChangedDeps = options.format.includes('ownerChanged')
     ? await vm.getOwnerPerDependency(current, filteredUpgraded, options)
     : null
 
@@ -259,6 +252,11 @@ function initOptions(options) {
 
   const autoPre = target === 'newest' || target === 'greatest'
 
+  const format = [
+    ...options.format,
+    ...options.ownerChanged ? ['ownerChanged'] : []
+  ]
+
   return {
     ...options,
     filter: options.args.join(' ') || options.filter,
@@ -273,7 +271,8 @@ function initOptions(options) {
       : null,
     target,
     // imply upgrade in interactive mode when json is not specified as the output
-    upgrade: options.interactive && options.upgrade === undefined ? !json : options.upgrade
+    upgrade: options.interactive && options.upgrade === undefined ? !json : options.upgrade,
+    format: format
   }
 }
 
@@ -369,7 +368,7 @@ async function run(options = {}) {
   if (!options.cli) {
     const cliDefaults = cliOptions.reduce((acc, curr) => ({
       ...acc,
-      ...curr.default !== null ? { [curr.optionName]: curr.default } : null,
+      ...curr.default !== null ? { [curr.long]: curr.default } : null,
     }), {})
     const defaultOptions = {
       ...cliDefaults,
@@ -383,8 +382,13 @@ async function run(options = {}) {
   options = initOptions(options)
 
   let deprecationMessageShown = false
-  deprecatedArgs.forEach(([argName, deprecationMessage]) => {
-    if (options[argName] !== undefined) {
+  deprecatedArgs.forEach(({ short, long, description }) => {
+    const deprecationMessage = options[short] !== undefined
+      ? `-${short}: ${description}`
+      : options[long] !== undefined
+        ? `--${long}: ${description}`
+        : null
+    if (deprecationMessage !== null) {
       print(options, chalk.yellow(deprecationMessage), 'warn')
       deprecationMessageShown = true
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -384,11 +384,16 @@ async function run(options = {}) {
 
   options = initOptions(options)
 
+  let deprecationMessageShown = false
   deprecatedArgs.forEach(([argName, deprecationMessage]) => {
     if (options[argName] !== undefined) {
-      print(options, deprecationMessage, 'warn')
+      print(options, chalk.yellow(deprecationMessage), 'warn')
+      deprecationMessageShown = true
     }
   })
+  if (deprecationMessageShown) {
+    print(options, '', 'warn')
+  }
 
   if (options.rcConfigPath) {
     print(options, `Using config file ${options.rcConfigPath}`)

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -71,7 +71,7 @@ function createDependencyTable() {
  * @param args.ownersChangedDeps
  * @param args.output Array of strings from the --output CLI arg
  */
-function toDependencyTable({ from: fromDeps, to: toDeps, ownersChangedDeps, output }) {
+function toDependencyTable({ from: fromDeps, to: toDeps, ownersChangedDeps, format }) {
   const table = createDependencyTable()
   const rows = Object.keys(toDeps).map(dep => {
     const from = fromDeps[dep] || ''
@@ -85,7 +85,7 @@ function toDependencyTable({ from: fromDeps, to: toDeps, ownersChangedDeps, outp
         : '*unknown*'
       : ''
     const toColorized = colorizeDiff(from, to)
-    const repoUrl = output.includes('repositoryLink')
+    const repoUrl = format.includes('repositoryLink')
       ? getRepoUrl(dep) || ''
       : ''
     return [dep, from, '→', toColorized, ownerChanged, repoUrl]
@@ -129,7 +129,7 @@ function printUpgrades(options, { current, upgraded, numUpgraded, total, ownersC
       from: current,
       to: upgraded,
       ownersChangedDeps,
-      output: options.output,
+      format: options.format,
     })
     print(options, table.toString())
   }

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -69,7 +69,7 @@ function createDependencyTable() {
  * @param args.from
  * @param args.to
  * @param args.ownersChangedDeps
- * @param args.output Array of strings from the --format CLI arg
+ * @param args.format Array of strings from the --format CLI arg
  */
 function toDependencyTable({ from: fromDeps, to: toDeps, ownersChangedDeps, format }) {
   const table = createDependencyTable()

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -5,6 +5,7 @@
 const Table = require('cli-table')
 const chalk = require('chalk')
 const { colorizeDiff, isGithubUrl, getGithubUrlTag, isNpmAlias, parseNpmAlias } = require('./version-util')
+const { getRepoUrl } = require('./repo-url')
 
 // maps string levels to numeric levels
 const logLevels = {
@@ -42,7 +43,7 @@ function printJson(options, object) {
 
 function createDependencyTable() {
   return new Table({
-    colAligns: ['left', 'right', 'right', 'right'],
+    colAligns: ['left', 'right', 'right', 'right', 'left', 'left'],
     chars: {
       top: '',
       'top-mid': '',
@@ -64,13 +65,14 @@ function createDependencyTable() {
 }
 
 /**
+ * @param output Array of strings from the --output CLI arg
  * @param args
  * @param args.from
  * @param args.to
  * @param args.ownersChangedDeps
  * @returns
  */
-function toDependencyTable(args) {
+function toDependencyTable(output, args) {
   const table = createDependencyTable()
   const rows = Object.keys(args.to).map(dep => {
     const from = args.from[dep] || ''
@@ -84,7 +86,10 @@ function toDependencyTable(args) {
         : '*unknown*'
       : ''
     const toColorized = colorizeDiff(from, to)
-    return [dep, from, '→', toColorized, ownerChanged]
+    const repoUrl = output.includes('repositoryLink')
+      ? getRepoUrl(dep) || ''
+      : ''
+    return [dep, from, '→', toColorized, ownerChanged, repoUrl]
   })
   rows.forEach(row => table.push(row)) // eslint-disable-line fp/no-mutating-methods
   return table
@@ -121,7 +126,7 @@ function printUpgrades(options, { current, upgraded, numUpgraded, total, ownersC
 
   // print table
   if (numUpgraded > 0) {
-    const table = toDependencyTable({
+    const table = toDependencyTable(options.output, {
       from: current,
       to: upgraded,
       ownersChangedDeps

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -65,24 +65,23 @@ function createDependencyTable() {
 }
 
 /**
- * @param output Array of strings from the --output CLI arg
  * @param args
  * @param args.from
  * @param args.to
  * @param args.ownersChangedDeps
- * @returns
+ * @param args.output Array of strings from the --output CLI arg
  */
-function toDependencyTable(output, args) {
+function toDependencyTable({ from: fromDeps, to: toDeps, ownersChangedDeps, output }) {
   const table = createDependencyTable()
-  const rows = Object.keys(args.to).map(dep => {
-    const from = args.from[dep] || ''
-    const toRaw = args.to[dep] || ''
+  const rows = Object.keys(toDeps).map(dep => {
+    const from = fromDeps[dep] || ''
+    const toRaw = toDeps[dep] || ''
     const to = isGithubUrl(toRaw) ? getGithubUrlTag(toRaw)
       : isNpmAlias(toRaw) ? parseNpmAlias(toRaw)[1]
       : toRaw
-    const ownerChanged = args.ownersChangedDeps
-      ? dep in args.ownersChangedDeps
-        ? args.ownersChangedDeps[dep] ? '*owner changed*' : ''
+    const ownerChanged = ownersChangedDeps
+      ? dep in ownersChangedDeps
+        ? ownersChangedDeps[dep] ? '*owner changed*' : ''
         : '*unknown*'
       : ''
     const toColorized = colorizeDiff(from, to)
@@ -126,10 +125,11 @@ function printUpgrades(options, { current, upgraded, numUpgraded, total, ownersC
 
   // print table
   if (numUpgraded > 0) {
-    const table = toDependencyTable(options.output, {
+    const table = toDependencyTable({
       from: current,
       to: upgraded,
-      ownersChangedDeps
+      ownersChangedDeps,
+      output: options.output,
     })
     print(options, table.toString())
   }

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -69,7 +69,7 @@ function createDependencyTable() {
  * @param args.from
  * @param args.to
  * @param args.ownersChangedDeps
- * @param args.output Array of strings from the --output CLI arg
+ * @param args.output Array of strings from the --format CLI arg
  */
 function toDependencyTable({ from: fromDeps, to: toDeps, ownersChangedDeps, format }) {
   const table = createDependencyTable()
@@ -85,7 +85,7 @@ function toDependencyTable({ from: fromDeps, to: toDeps, ownersChangedDeps, form
         : '*unknown*'
       : ''
     const toColorized = colorizeDiff(from, to)
-    const repoUrl = format.includes('repositoryLink')
+    const repoUrl = format.includes('repo')
       ? getRepoUrl(dep) || ''
       : ''
     return [dep, from, '→', toColorized, ownerChanged, repoUrl]

--- a/lib/repo-url.js
+++ b/lib/repo-url.js
@@ -5,40 +5,29 @@ const path = require('path')
 const { URL } = require('url')
 const hostedGitInfo = require('hosted-git-info')
 
+const commonBranchPath = hostedGitInfo.fromUrl('user/repo').browse('').match(/(\/tree\/[a-z]+)/)[0]
+
 /**
  * @param packageName A package name as listed in package.json's dependencies list
  * @param packageJson Optional param to specify a object representation of a package.json file instead of loading from node_modules
  * @returns A valid url to the root of the package's source or null if a url could not be determined
  */
 function getRepoUrl(packageName, packageJson = undefined) {
-  if (packageJson === undefined) {
-    try {
-      const nodeModulePaths = require.resolve.paths(packageName)
-      for (const basePath of nodeModulePaths) { // eslint-disable-line fp/no-loops
-        const packageJsonPath = path.join(basePath, packageName, 'package.json')
-        if (fs.existsSync(packageJsonPath)) {
-          packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
-          break
-        }
-      }
-      // The package.json file cannot be found
-      if (packageJson === undefined) {
-        return null
-      }
-    }
-    catch (e) {
-      return null
-    }
+  let repositoryMetadata
+  if (!packageJson) {
+    repositoryMetadata = getPackageRepo(packageName)
   }
-  // The repository field may not exist
-  if (packageJson.repository === undefined) {
+  else if (packageJson.repository) {
+    repositoryMetadata = packageJson.repository
+  }
+  if (!repositoryMetadata) {
     return null
   }
   let gitURL
   let directory = ''
   // It may be a string instead of an object
-  if (typeof packageJson.repository === 'string') {
-    gitURL = packageJson.repository
+  if (typeof repositoryMetadata === 'string') {
+    gitURL = repositoryMetadata
     try {
       // It may already be a valid Repo URL
       const url = new URL(gitURL)
@@ -49,18 +38,48 @@ function getRepoUrl(packageName, packageJson = undefined) {
     }
     catch (e) {}
   }
-  else if (typeof packageJson.repository.url === 'string') {
-    gitURL = packageJson.repository.url
-    if (typeof packageJson.repository.directory === 'string') {
-      directory = packageJson.repository.directory
+  else if (typeof repositoryMetadata.url === 'string') {
+    gitURL = repositoryMetadata.url
+    if (typeof repositoryMetadata.directory === 'string') {
+      directory = repositoryMetadata.directory
     }
   }
   if (typeof gitURL === 'string' && typeof directory === 'string') {
-    return hostedGitInfo.fromUrl(gitURL).browse(directory).replace(/\/$/, '')
+    return cleanRepoUrl(hostedGitInfo.fromUrl(gitURL).browse(directory))
   }
   return null
 }
 
+function getPackageRepo (packageName) {
+  let packageJson
+  try {
+    const nodeModulePaths = require.resolve.paths(packageName)
+    for (const basePath of nodeModulePaths) { // eslint-disable-line fp/no-loops
+      const packageJsonPath = path.join(basePath, packageName, 'package.json')
+      if (fs.existsSync(packageJsonPath)) {
+        packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+        break
+      }
+    }
+    // The package.json file cannot be found
+    if (!packageJson) {
+      return null
+    }
+  }
+  catch (e) {
+    return null
+  }
+  // The repository field may not exist
+  if (!packageJson.repository) {
+    return null
+  }
+  return packageJson.repository
+}
+
+function cleanRepoUrl (url) {
+  return url.replace(/\/$/, '').replace(new RegExp(`${commonBranchPath}$`), '')
+}
+
 module.exports = {
-  getRepoUrl,
+  getRepoUrl
 }

--- a/lib/repo-url.js
+++ b/lib/repo-url.js
@@ -5,7 +5,30 @@ const path = require('path')
 const { URL } = require('url')
 const hostedGitInfo = require('hosted-git-info')
 
-const commonBranchPath = hostedGitInfo.fromUrl('user/repo').browse('').match(/(\/tree\/[a-z]+)/)[0]
+// extract the defaultBranchPath so it can be stripped in the final output
+const defaultBranchPath = hostedGitInfo.fromUrl('user/repo').browse('').match(/(\/tree\/[a-z]+)/)[0]
+const regexDefaultBranchPath = new RegExp(`${defaultBranchPath}$`)
+
+/** Gets the repo url of an installed package. */
+function getPackageRepo(packageName) {
+  const nodeModulePaths = require.resolve.paths(packageName)
+  for (const basePath of nodeModulePaths) { // eslint-disable-line fp/no-loops
+    const packageJsonPath = path.join(basePath, packageName, 'package.json')
+    if (fs.existsSync(packageJsonPath)) {
+      try {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+        return packageJson.repository
+      }
+      catch (e) {}
+    }
+  }
+
+  return null
+}
+
+/** Remove the default branch path from a git url. */
+const cleanRepoUrl = url =>
+  url.replace(/\/$/, '').replace(regexDefaultBranchPath, '')
 
 /**
  * @param packageName A package name as listed in package.json's dependencies list
@@ -13,18 +36,17 @@ const commonBranchPath = hostedGitInfo.fromUrl('user/repo').browse('').match(/(\
  * @returns A valid url to the root of the package's source or null if a url could not be determined
  */
 function getRepoUrl(packageName, packageJson = undefined) {
-  let repositoryMetadata
-  if (!packageJson) {
-    repositoryMetadata = getPackageRepo(packageName)
-  }
-  else if (packageJson.repository) {
-    repositoryMetadata = packageJson.repository
-  }
-  if (!repositoryMetadata) {
-    return null
-  }
+
+  const repositoryMetadata =
+    !packageJson ? getPackageRepo(packageName)
+    : packageJson.repository ? packageJson.repository
+    : null
+
+  if (!repositoryMetadata) return null
+
   let gitURL
   let directory = ''
+
   // It may be a string instead of an object
   if (typeof repositoryMetadata === 'string') {
     gitURL = repositoryMetadata
@@ -44,40 +66,10 @@ function getRepoUrl(packageName, packageJson = undefined) {
       directory = repositoryMetadata.directory
     }
   }
-  if (typeof gitURL === 'string' && typeof directory === 'string') {
-    return cleanRepoUrl(hostedGitInfo.fromUrl(gitURL).browse(directory))
-  }
-  return null
-}
 
-function getPackageRepo (packageName) {
-  let packageJson
-  try {
-    const nodeModulePaths = require.resolve.paths(packageName)
-    for (const basePath of nodeModulePaths) { // eslint-disable-line fp/no-loops
-      const packageJsonPath = path.join(basePath, packageName, 'package.json')
-      if (fs.existsSync(packageJsonPath)) {
-        packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
-        break
-      }
-    }
-    // The package.json file cannot be found
-    if (!packageJson) {
-      return null
-    }
-  }
-  catch (e) {
-    return null
-  }
-  // The repository field may not exist
-  if (!packageJson.repository) {
-    return null
-  }
-  return packageJson.repository
-}
-
-function cleanRepoUrl (url) {
-  return url.replace(/\/$/, '').replace(new RegExp(`${commonBranchPath}$`), '')
+  return typeof gitURL === 'string' && typeof directory === 'string'
+    ? cleanRepoUrl(hostedGitInfo.fromUrl(gitURL).browse(directory))
+    : null
 }
 
 module.exports = {

--- a/lib/repo-url.js
+++ b/lib/repo-url.js
@@ -21,6 +21,10 @@ function getRepoUrl(packageName, packageJson = undefined) {
           break
         }
       }
+      // The package.json file cannot be found
+      if (packageJson === undefined) {
+        return null
+      }
     }
     catch (e) {
       return null

--- a/lib/repo-url.js
+++ b/lib/repo-url.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const { URL } = require('url')
+const hostedGitInfo = require('hosted-git-info')
+
+/**
+ * @param packageName A package name as listed in package.json's dependencies list
+ * @param packageJson Optional param to specify a object representation of a package.json file instead of loading from node_modules
+ * @returns A valid url to the root of the package's source or null if a url could not be determined
+ */
+function getRepoUrl(packageName, packageJson = undefined) {
+  if (packageJson === undefined) {
+    try {
+      const nodeModulePaths = require.resolve.paths(packageName)
+      for (const basePath of nodeModulePaths) { // eslint-disable-line fp/no-loops
+        const packageJsonPath = path.join(basePath, packageName, 'package.json')
+        if (fs.existsSync(packageJsonPath)) {
+          packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+          break
+        }
+      }
+    }
+    catch (e) {
+      return null
+    }
+  }
+  // The repository field may not exist
+  if (packageJson.repository === undefined) {
+    return null
+  }
+  let gitURL
+  let directory = ''
+  // It may be a string instead of an object
+  if (typeof packageJson.repository === 'string') {
+    gitURL = packageJson.repository
+    try {
+      // It may already be a valid Repo URL
+      const url = new URL(gitURL)
+      // Some packages put a full URL in this field although it's not spec compliant. Let's detect that and use it if present
+      if (['github.com', 'gitlab.com', 'bitbucket.org'].includes(url.hostname) && url.protocol === 'https:') {
+        return gitURL
+      }
+    }
+    catch (e) {}
+  }
+  else if (typeof packageJson.repository.url === 'string') {
+    gitURL = packageJson.repository.url
+    if (typeof packageJson.repository.directory === 'string') {
+      directory = packageJson.repository.directory
+    }
+  }
+  if (typeof gitURL === 'string' && typeof directory === 'string') {
+    return hostedGitInfo.fromUrl(gitURL).browse(directory).replace(/\/$/, '')
+  }
+  return null
+}
+
+module.exports = {
+  getRepoUrl,
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "nyc": "nyc",
     "mocha": "mocha test test/package-managers/npm test/package-managers/yarn && mocha --exit test/timeout",
     "test": "npm run lintall && npm run mocha",
-    "watch": "chokidar \"lib/**/*.js\" -c \"npm run test\""
+    "watch": "chokidar \"lib/**/*.js\" -c \"npm run test\"",
+    "ncu": "node ./bin/cli.js"
   },
   "bin": {
     "npm-check-updates": "./bin/cli.js",
@@ -56,6 +57,7 @@
     "commander": "^6.2.0",
     "find-up": "5.0.0",
     "get-stdin": "^8.0.0",
+    "hosted-git-info": "^3.0.7",
     "json-parse-helpfulerror": "^1.0.3",
     "jsonlines": "^0.1.1",
     "libnpmconfig": "^1.2.1",

--- a/test/repo-url.test.js
+++ b/test/repo-url.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const chai = require('chai')
+const repoUrl = require('../lib/repo-url')
+
+const should = chai.should()
+
+describe('repo-url', () => {
+
+  describe('getRepoUrl', () => {
+    it('return null if package is not installed', () => {
+      should.equal(repoUrl.getRepoUrl('not-installed/package'), null)
+    })
+    it('return null repository field is undefined', () => {
+      should.equal(repoUrl.getRepoUrl('package-name', {}), null)
+    })
+    it('return null repository field is unknown type', () => {
+      should.equal(repoUrl.getRepoUrl('package-name', { repository: true }), null)
+    })
+    it('return url directly from repository field if valid github url', () => {
+      repoUrl.getRepoUrl('package-name', { repository: 'https://github.com/user/repo' }).should.equal('https://github.com/user/repo')
+    })
+    it('return url directly from repository field if valid gitlab url', () => {
+      repoUrl.getRepoUrl('package-name', { repository: 'https://gitlab.com/user/repo' }).should.equal('https://gitlab.com/user/repo')
+    })
+    it('return url directly from repository field if valid bitbucket url', () => {
+      repoUrl.getRepoUrl('package-name', { repository: 'https://bitbucket.org/user/repo' }).should.equal('https://bitbucket.org/user/repo')
+    })
+    it('return url constructed from github shortcut syntax string', () => {
+      repoUrl.getRepoUrl('package-name', { repository: 'user/repo' }).should.equal('https://github.com/user/repo/tree/master')
+    })
+    it('return url constructed from repository specific shortcut syntax string', () => {
+      repoUrl.getRepoUrl('package-name', { repository: 'github:user/repo' }).should.equal('https://github.com/user/repo/tree/master')
+    })
+    it('return url constructed from git-https protocol', () => {
+      repoUrl.getRepoUrl('package-name', { repository: { url: 'git+https://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo/tree/master')
+    })
+    it('return url constructed from git protocol', () => {
+      repoUrl.getRepoUrl('package-name', { repository: { url: 'git://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo/tree/master')
+    })
+    it('return url constructed from http protocol', () => {
+      repoUrl.getRepoUrl('package-name', { repository: { url: 'http://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo/tree/master')
+    })
+    it('return url with directory path', () => {
+      repoUrl.getRepoUrl('package-name', { repository: { url: 'http://github.com/user/repo.git', directory: 'packages/specific-package' } }).should.equal('https://github.com/user/repo/tree/master/packages/specific-package')
+    })
+  })
+
+})

--- a/test/repo-url.test.js
+++ b/test/repo-url.test.js
@@ -27,19 +27,19 @@ describe('repo-url', () => {
       repoUrl.getRepoUrl('package-name', { repository: 'https://bitbucket.org/user/repo' }).should.equal('https://bitbucket.org/user/repo')
     })
     it('return url constructed from github shortcut syntax string', () => {
-      repoUrl.getRepoUrl('package-name', { repository: 'user/repo' }).should.equal('https://github.com/user/repo/tree/master')
+      repoUrl.getRepoUrl('package-name', { repository: 'user/repo' }).should.equal('https://github.com/user/repo')
     })
     it('return url constructed from repository specific shortcut syntax string', () => {
-      repoUrl.getRepoUrl('package-name', { repository: 'github:user/repo' }).should.equal('https://github.com/user/repo/tree/master')
+      repoUrl.getRepoUrl('package-name', { repository: 'github:user/repo' }).should.equal('https://github.com/user/repo')
     })
     it('return url constructed from git-https protocol', () => {
-      repoUrl.getRepoUrl('package-name', { repository: { url: 'git+https://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo/tree/master')
+      repoUrl.getRepoUrl('package-name', { repository: { url: 'git+https://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo')
     })
     it('return url constructed from git protocol', () => {
-      repoUrl.getRepoUrl('package-name', { repository: { url: 'git://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo/tree/master')
+      repoUrl.getRepoUrl('package-name', { repository: { url: 'git://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo')
     })
     it('return url constructed from http protocol', () => {
-      repoUrl.getRepoUrl('package-name', { repository: { url: 'http://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo/tree/master')
+      repoUrl.getRepoUrl('package-name', { repository: { url: 'http://github.com/user/repo.git' } }).should.equal('https://github.com/user/repo')
     })
     it('return url with directory path', () => {
       repoUrl.getRepoUrl('package-name', { repository: { url: 'http://github.com/user/repo.git', directory: 'packages/specific-package' } }).should.equal('https://github.com/user/repo/tree/master/packages/specific-package')


### PR DESCRIPTION
## This PR adds/changes the following items:

### Main changes
* Added option to show repository links in the output with the new `--format repositoryLink` arg
  * This will infer the link from the data in the `package.json` for that package which is already installed on disk. If the link cannot be determined, the column will be left blank

### Minor changes
* Deprecates the `-o` and `--ownerChanged` CLI arguments in favor of the new `--format` arg
* Adds the new `--format` arg which can take a single string or a comma-delimited list of strings indicating which additional fields should be shown in the output. This enables future expansions for more custom/advanced data to be shown and enabled one at a time.
* Added `@deprecated` annotation to TypeScript types for deprecated fields
* Added new mechanism to warn users when using deprecated args with a custom message

### Developer experience changes
* Update build command to work on Windows
* Refactor `cli-args` data structure to make it easier to use this data elsewhere
* Refactored default args handling to use the `default` field from `cli-args`
* Adds `ncu` command to run this package against itself

Closes #570 