### PR TITLE
Print correct install message when using yarn

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,7 +192,7 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
         // do not await until end
         writePromise = writePackageFile(pkgFile, newPkgData)
           .then(() => {
-            print(options, `\nRun ${chalk.cyan('npm install')} to install new versions.\n`)
+            print(options, `\nRun ${chalk.cyan(options.packageManager === 'yarn' ? 'yarn install' : 'npm install')} to install new versions.\n`)
           })
       }
       else {


### PR DESCRIPTION
When using yarn, the message after running "ncu -u" should be "Run 'yarn install' ..." instead of "Run 'npm install' ...", this PR adds the correct message.