### PR TITLE
fix `**/package.json` cause comment loose effect

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,7 +28,7 @@ declare namespace ncu {
     cwd?: string;
 
     /**
-     * Run recursively in current working directory. Alias of (--packageFile '**/package.json').
+     * Run recursively in current working directory. Alias of (--packageFile '**\/package.json').
      */
     deep?: boolean;
 


### PR DESCRIPTION
fix `**/package.json` cause comment loose effect


![image](https://user-images.githubusercontent.com/1646883/105811665-ee001900-5fe7-11eb-9a81-6c536c37b423.png)



```
 /**
 * Run recursively in current working directory. Alias of (--packageFile '**/package.json').
 */
    deep?: boolean;
```
should add \ to avoid or use inline comment