### PR TITLE
feat: support "github:" dependencies

### DIFF
--- a/lib/package-managers/gitTags.js
+++ b/lib/package-managers/gitTags.js
@@ -8,6 +8,8 @@ const { print } = require('../logging')
 
 /** Gets remote versions sorted. */
 const getSortedVersions = async (name, declaration, options) => {
+  // if present, github: is parsed as the protocol. This is not valid when passed into remote-git-tags.
+  declaration = declaration.replace(/^github:/, '')
   const { auth, protocol, host, path } = parseGithubUrl(declaration)
   const url = `${protocol ? protocol.replace('git+', '') : 'https:'}//${auth ? auth + '@' : ''}${host}/${path}`
   let tagMap = new Map()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -653,6 +653,32 @@ describe('run', function () {
       })
     })
 
+    it('upgrade short github urls', async () => {
+      const upgrades = await ncu.run({
+        packageData: JSON.stringify({
+          dependencies: {
+            'ncu-test-v2': 'github:raineorshine/ncu-test-v2#1.0.0'
+          }
+        })
+      })
+      upgrades.should.deep.equal({
+        'ncu-test-v2': 'github:raineorshine/ncu-test-v2#2.0.0'
+      })
+    })
+
+    it('upgrade shortest github urls', async () => {
+      const upgrades = await ncu.run({
+        packageData: JSON.stringify({
+          dependencies: {
+            'ncu-test-v2': 'raineorshine/ncu-test-v2#1.0.0'
+          }
+        })
+      })
+      upgrades.should.deep.equal({
+        'ncu-test-v2': 'raineorshine/ncu-test-v2#2.0.0'
+      })
+    })
+
     it('upgrade github http urls with semver', async () => {
       const upgrades = await ncu.run({
         packageData: JSON.stringify({


### PR DESCRIPTION
When you install from a GitHub dependency (e.g. `npm install raineorshine/npm-check-updates#v11.2.1`), the default entry that appears is:
```
"npm-check-updates": "github:raineorshine/npm-check-updates#v11.2.1"
```
This isn't picked up by ncu. I've fixed this and added a test.