### PR TITLE
feat: try SSH keys before HTTPS for github packages without protocol

### DIFF
--- a/lib/package-managers/gitTags.js
+++ b/lib/package-managers/gitTags.js
@@ -15,10 +15,11 @@ const getSortedVersions = async (name, declaration, options) => {
   const protocolKnown = protocol != null
   if (protocolKnown) {
     tagsPromise = tagsPromise.then(() => remoteGitTags(`${protocol ? protocol.replace('git+', '') : 'https:'}//${auth ? auth + '@' : ''}${host}/${path}`))
-  } else {
+  }
+  else {
     // try ssh first, then https on failure
     tagsPromise = tagsPromise.then(() => remoteGitTags(`ssh://git@${host}/${path}`))
-    .catch(() => remoteGitTags(`https://${auth ? auth + '@' : ''}${host}/${path}`))
+      .catch(() => remoteGitTags(`https://${auth ? auth + '@' : ''}${host}/${path}`))
   }
 
   let tagMap = new Map()

--- a/lib/package-managers/gitTags.js
+++ b/lib/package-managers/gitTags.js
@@ -11,12 +11,21 @@ const getSortedVersions = async (name, declaration, options) => {
   // if present, github: is parsed as the protocol. This is not valid when passed into remote-git-tags.
   declaration = declaration.replace(/^github:/, '')
   const { auth, protocol, host, path } = parseGithubUrl(declaration)
-  const url = `${protocol ? protocol.replace('git+', '') : 'https:'}//${auth ? auth + '@' : ''}${host}/${path}`
+  let tagsPromise = Promise.resolve()
+  const protocolKnown = protocol != null
+  if (protocolKnown) {
+    tagsPromise = tagsPromise.then(() => remoteGitTags(`${protocol ? protocol.replace('git+', '') : 'https:'}//${auth ? auth + '@' : ''}${host}/${path}`))
+  } else {
+    // try ssh first, then https on failure
+    tagsPromise = tagsPromise.then(() => remoteGitTags(`ssh://git@${host}/${path}`))
+    .catch(() => remoteGitTags(`https://${auth ? auth + '@' : ''}${host}/${path}`))
+  }
+
   let tagMap = new Map()
 
   // fetch remote tags
   try {
-    tagMap = await remoteGitTags(url)
+    tagMap = await tagsPromise
   }
   // catch a variety of errors that occur on invalid or private repos
   catch (e) {


### PR DESCRIPTION
Fixes #850.

If no protocol is specified for a github URL, try the SSH url followed by the HTTPS url. If a protocol is specified, only try that one: assume that people have put in the url correctly.

We try SSH first because HTTPS might prompt for credentials for private repos, while SSH fails silently.

The graphical glitch where the password prompt pops up and disappears if the progress bar updates persists: I'm okay with that because I can't see how you could manage to install a package without either an SSH key or having signed in to GitHub, in which case you're hopefully expecting it.