### PR TITLE
Respect peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ ncu "/^(?!react-).*$/" # windows
 ## Options
 
 ```text
+--checkPeer                  Check peer dependencies of installed packages
+                             and filter updates to compatible versions.
 --color                      Force color in terminal
 --concurrency <n>            Max number of concurrent HTTP requests to
                              registry. (default: 8)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ ncu "/^(?!react-).*$/" # windows
 --deep                       Run recursively in current working directory.
                              Alias of (--packageFile '**/package.json').
 --dep <value>                Check one or more sections of dependencies only:
-                             prod, dev, peer, optional, bundle
+                             dev, optional, peer, prod, bundle
                              (comma-delimited).
 --deprecated                 Include deprecated packages.
 --doctor                     Iteratively installs upgrades and runs tests to

--- a/README.md
+++ b/README.md
@@ -117,8 +117,6 @@ ncu "/^(?!react-).*$/" # windows
 ## Options
 
 ```text
---checkPeer                  Check peer dependencies of installed packages
-                             and filter updates to compatible versions.
 --color                      Force color in terminal
 --concurrency <n>            Max number of concurrent HTTP requests to
                              registry. (default: 8)
@@ -174,6 +172,8 @@ ncu "/^(?!react-).*$/" # windows
 --packageFile <path|glob>    Package file(s) location (default:
                              ./package.json).
 -p, --packageManager <name>  npm, yarn (default: "npm")
+--peer                       Check peer dependencies of installed packages
+                             and filter updates to compatible versions.
 --pre <n>                    Include -alpha, -beta, -rc. (default: 0; default
                              with --newest and --greatest: 1).
 --prefix <path>              Current working directory of npm.

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -34,7 +34,7 @@ other version numbers that are higher. Includes prereleases.`])
 // store CLI options separately from bin file so that they can be used to build type definitions
 const cliOptions = [
   {
-    long: 'checkPeer',
+    long: 'peer',
     description: 'Check peer dependencies of installed packages and filter updates to compatible versions.',
     type: 'boolean'
   },

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -34,6 +34,11 @@ other version numbers that are higher. Includes prereleases.`])
 // store CLI options separately from bin file so that they can be used to build type definitions
 const cliOptions = [
   {
+    long: 'checkPeer',
+    description: 'Check peer dependencies of installed packages and filter updates to compatible versions.',
+    type: 'boolean'
+  },
+  {
     long: 'color',
     description: 'Force color in terminal',
   },

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -72,7 +72,7 @@ const cliOptions = [
   {
     long: 'dep',
     arg: 'value',
-    description: 'Check one or more sections of dependencies only: prod, dev, peer, optional, bundle (comma-delimited).'
+    description: 'Check one or more sections of dependencies only: dev, optional, peer, prod, bundle (comma-delimited).'
   },
   {
     long: 'deprecated',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,6 +3,11 @@ declare namespace ncu {
   interface RunOptions {
 
     /**
+     * Check peer dependencies of installed packages and filter updates to compatible versions.
+     */
+    checkPeer?: boolean;
+
+    /**
      * Force color in terminal
      */
     color?: boolean;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -38,7 +38,7 @@ declare namespace ncu {
     deep?: boolean;
 
     /**
-     * Check one or more sections of dependencies only: prod, dev, peer, optional, bundle (comma-delimited).
+     * Check one or more sections of dependencies only: dev, optional, peer, prod, bundle (comma-delimited).
      */
     dep?: string;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,11 +3,6 @@ declare namespace ncu {
   interface RunOptions {
 
     /**
-     * Check peer dependencies of installed packages and filter updates to compatible versions.
-     */
-    checkPeer?: boolean;
-
-    /**
      * Force color in terminal
      */
     color?: boolean;
@@ -144,6 +139,11 @@ declare namespace ncu {
      * npm, yarn (default: "npm")
      */
     packageManager?: string;
+
+    /**
+     * Check peer dependencies of installed packages and filter updates to compatible versions.
+     */
+    peer?: boolean;
 
     /**
      * Include -alpha, -beta, -rc. (default: 0; default with --newest and --greatest: 1).

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,14 +142,14 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
     options.enginesNode = _.get(pkg, 'engines.node')
   }
 
+  if (options.checkPeer) {
+    options.peerDependencies = getPeerDependencies(current, options)
+  }
+
   print(options, '\nOptions:', 'verbose')
   print(options, sortOptions(options), 'verbose')
 
-  const peerDependencies = getPeerDependencies(current, options)
-  print(options, '\nPeerDependencies:', 'verbose')
-  print(options, peerDependencies, 'verbose')
-
-  const [upgraded, latest] = await vm.upgradePackageDefinitions(current, { ...options, peerDependencies })
+  const [upgraded, latest] = await vm.upgradePackageDefinitions(current, options)
 
   print(options, '\nFetched:', 'verbose')
   print(options, latest, 'verbose')
@@ -247,8 +247,7 @@ function getPeerDependencies(current, options) {
       if (acc[pkgName] === undefined) {
         acc[pkgName] = []
       }
-      // eslint-disable-next-line fp/no-mutating-methods
-      acc[pkgName].push(version)
+      acc[pkgName][acc[pkgName].length] = version
     })
     return acc
   }, {})

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,7 +145,11 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
   print(options, '\nOptions:', 'verbose')
   print(options, sortOptions(options), 'verbose')
 
-  const [upgraded, latest] = await vm.upgradePackageDefinitions(current, options)
+  const peerDependencies = getPeerDependencies(current, options)
+  print(options, '\nPeerDependencies:', 'verbose')
+  print(options, peerDependencies, 'verbose')
+
+  const [upgraded, latest] = await vm.upgradePackageDefinitions(current, { ...options, peerDependencies })
 
   print(options, '\nFetched:', 'verbose')
   print(options, latest, 'verbose')
@@ -222,6 +226,32 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
   await writePromise
 
   return output
+}
+
+/** Get peer dependencies from installed packages */
+function getPeerDependencies(current, options) {
+  const basePath = options.cwd || './'
+  return Object.keys(current).map(pkgName => {
+    const path = basePath + 'node_modules/' + pkgName + '/package.json'
+    try {
+      const pkgData = fs.readFileSync(path)
+      const pkg = jph.parse(pkgData)
+      return vm.getCurrentDependencies(pkg, { dep: 'peer', filter: options.filter, reject: options.reject })
+    }
+    catch (e) {
+      print(options, 'Could not read peer dependencies for package ' + pkgName + '. Is this package installed?', 'warn')
+      return {}
+    }
+  }).reduce((acc, peers) => {
+    Object.entries(peers).forEach(([pkgName, version]) => {
+      if (acc[pkgName] === undefined) {
+        acc[pkgName] = []
+      }
+      // eslint-disable-next-line fp/no-mutating-methods
+      acc[pkgName].push(version)
+    })
+    return acc
+  }, {})
 }
 
 //
@@ -535,4 +565,4 @@ function getNcurc({ configFileName, configFilePath, packageFile } = {}) {
   return result ? { ...result, args } : null
 }
 
-module.exports = { run, getNcurc, ...vm }
+module.exports = { run, getNcurc, getPeerDependencies, ...vm }

--- a/lib/index.js
+++ b/lib/index.js
@@ -236,7 +236,7 @@ function getPeerDependencies(current, options) {
     try {
       const pkgData = fs.readFileSync(path)
       const pkg = jph.parse(pkgData)
-      return vm.getCurrentDependencies(pkg, { dep: 'peer', filter: options.filter, reject: options.reject })
+      return vm.getCurrentDependencies(pkg, { ...options, dep: 'peer' })
     }
     catch (e) {
       print(options, 'Could not read peer dependencies for package ' + pkgName + '. Is this package installed?', 'warn')

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,7 +142,7 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
     options.enginesNode = _.get(pkg, 'engines.node')
   }
 
-  if (options.checkPeer) {
+  if (options.peer) {
     options.peerDependencies = getPeerDependencies(current, options)
   }
 

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -168,12 +168,27 @@ function satisfiesNodeEngine(versionResult, nodeEngine) {
   return versionNodeEngine && semver.satisfies(minVersion, versionNodeEngine)
 }
 
+/**
+ * Returns true if the peer dependencies requirement is satisfied or not specified for a given package version.
+ *
+ * @param versionResult     Version object returned by pacote.packument.
+ * @param peerDependencies  The list of peer dependencies.
+ * @returns                 True if the peer dependencies are satisfied or not specified.
+ */
+function satisfiesPeerDependencies(versionResult, peerDependencies) {
+  if (!peerDependencies) return true
+  const pkgPeerDependencies = peerDependencies[versionResult.name]
+  if (!pkgPeerDependencies) return true
+  return pkgPeerDependencies.every(v => semver.satisfies(versionResult.version, v))
+}
+
 /** Returns a composite predicate that filters out deprecated, prerelease, and node engine incompatibilies from version objects returns by pacote.packument. */
 function filterPredicate(options) {
   return _.overEvery([
     options.deprecated ? null : o => !o.deprecated,
     options.pre ? null : o => !versionUtil.isPre(o.version),
     options.enginesNode ? o => satisfiesNodeEngine(o, options.enginesNode) : null,
+    options.peerDependencies ? o => satisfiesPeerDependencies(o, options.peerDependencies) : null,
   ])
 }
 

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -295,25 +295,17 @@ async function upgradePackageData(pkgData, oldDependencies, newDependencies, new
  */
 function getCurrentDependencies(pkgData = {}, options = {}) {
 
-  if (options.dep) {
-    const deps = (options.dep || '').split(',')
-    options.prod = deps.includes('prod')
-    options.dev = deps.includes('dev')
-    options.peer = deps.includes('peer')
-    options.optional = deps.includes('optional')
-    options.bundle = deps.includes('bundle')
-  }
-  else {
-    options.prod = options.dev = options.peer = options.optional = options.bundle = true
-  }
+  const deps = options.dep
+    ? (options.dep || '').split(',')
+    : ['dev', 'optional', 'peer', 'prod', 'bundle']
 
   const allDependencies = cint.filterObject(
     {
-      ...options.prod && pkgData.dependencies,
-      ...options.dev && pkgData.devDependencies,
-      ...options.peer && pkgData.peerDependencies,
-      ...options.optional && pkgData.optionalDependencies,
-      ...options.bundle && pkgData.bundleDependencies
+      ...deps.includes('prod') && pkgData.dependencies,
+      ...deps.includes('dev') && pkgData.devDependencies,
+      ...deps.includes('peer') && pkgData.peerDependencies,
+      ...deps.includes('optional') && pkgData.optionalDependencies,
+      ...deps.includes('bundle') && pkgData.bundleDependencies
     },
     filterAndReject(options.filter, options.reject, options.filterVersion, options.rejectVersion)
   )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const rimraf = require('rimraf')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const chaiString = require('chai-string')
@@ -713,19 +714,31 @@ describe('run', function () {
     const peerPath = path.join(__dirname, '/peer/')
 
     it('peer dependencies of installed packages are ignored by default', async () => {
-      await spawnNpm('install', {}, { cwd: peerPath })
-      const upgrades = await ncu.run({ cwd: peerPath })
-      upgrades.should.deep.equal({
-        'ncu-test-return-version': '2.0.0'
-      })
+      try {
+        await spawnNpm('install', {}, { cwd: peerPath })
+        const upgrades = await ncu.run({ cwd: peerPath })
+        upgrades.should.deep.equal({
+          'ncu-test-return-version': '2.0.0'
+        })
+      }
+      finally {
+        rimraf.sync(path.join(peerPath, 'node_modules'))
+        rimraf.sync(path.join(peerPath, 'package-lock.json'))
+      }
     })
 
     it('peer dependencies of installed packages are checked when using option peer', async () => {
-      await spawnNpm('install', {}, { cwd: peerPath })
-      const upgrades = await ncu.run({ cwd: peerPath, peer: true })
-      upgrades.should.deep.equal({
-        'ncu-test-return-version': '1.1.0'
-      })
+      try {
+        await spawnNpm('install', {}, { cwd: peerPath })
+        const upgrades = await ncu.run({ cwd: peerPath, peer: true })
+        upgrades.should.deep.equal({
+          'ncu-test-return-version': '1.1.0'
+        })
+      }
+      finally {
+        rimraf.sync(path.join(peerPath, 'node_modules'))
+        rimraf.sync(path.join(peerPath, 'package-lock.json'))
+      }
     })
 
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,6 +6,7 @@ const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const chaiString = require('chai-string')
 const ncu = require('../lib/')
+const { npm: spawnNpm } = require('../lib/package-managers/npm')
 
 chai.use(chaiAsPromised)
 chai.use(chaiString)
@@ -703,6 +704,27 @@ describe('run', function () {
       })
       upgrades.should.deep.equal({
         'ncu-test-v2': 'git+ssh://git@github.com/raineorshine/ncu-test-v2.git#semver:^2.0.0'
+      })
+    })
+
+  })
+
+  describe('peer dependencies', () => {
+    const peerPath = path.join(__dirname, '/peer/')
+
+    it('peer dependencies of installed packages are ignored by default', async () => {
+      await spawnNpm('install', {}, { cwd: peerPath })
+      const upgrades = await ncu.run({ cwd: peerPath })
+      upgrades.should.deep.equal({
+        'ncu-test-return-version': '2.0.0'
+      })
+    })
+
+    it('peer dependencies of installed packages are checked when using option checkPeer', async () => {
+      await spawnNpm('install', {}, { cwd: peerPath })
+      const upgrades = await ncu.run({ cwd: peerPath, checkPeer: true })
+      upgrades.should.deep.equal({
+        'ncu-test-return-version': '1.1.0'
       })
     })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -720,9 +720,9 @@ describe('run', function () {
       })
     })
 
-    it('peer dependencies of installed packages are checked when using option checkPeer', async () => {
+    it('peer dependencies of installed packages are checked when using option peer', async () => {
       await spawnNpm('install', {}, { cwd: peerPath })
-      const upgrades = await ncu.run({ cwd: peerPath, checkPeer: true })
+      const upgrades = await ncu.run({ cwd: peerPath, peer: true })
       upgrades.should.deep.equal({
         'ncu-test-return-version': '1.1.0'
       })

--- a/test/peer/package.json
+++ b/test/peer/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "ncu-test-peer": "1.0.0",
+    "ncu-test-return-version": "1.0.0"
+  }
+}


### PR DESCRIPTION
The purpose of this PR is to fix #376. 

@raineorshine Please have a look if this goes in the correct direction. Open questions are, e.g.:
- should the check be optional, what is default?
- which warning should be raised if detection does not work? (the tests are currently failing due to this warning)

I've exported the new `getPeerDependencies` for the purpose that other tools can use it too, e.g. https://github.com/th0r/npm-upgrade