### PR TITLE
feat: detect yarn according to yarn.lock

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,7 +5,6 @@
 const program = require('commander')
 const _ = require('lodash')
 const updateNotifier = require('update-notifier')
-const fs = require('fs')
 const ncu = require('../lib/')
 const pkg = require('../package.json')
 const cliOptions = require('../lib/cli-options')
@@ -83,7 +82,7 @@ const combinedArguments = rcResult
 
 program.parse(combinedArguments)
 
-// filter out undefined program options and combine with config file options
+// filter out undefined program options and combine cli options with config file options
 const options = {
   ...rcResult && Object.keys(rcResult.config).length > 0
     ? { rcConfigPath: rcResult.filePath }
@@ -94,15 +93,6 @@ const options = {
   cli: true,
 }
 
-/**
- * Detect package manager according to lock file
- */
-const files = fs.readdirSync('.')
-
-// By default, npm is set as package manager.
-// If yarn is detected, set yarn instead
-if (files.includes('yarn.lock') && !files.includes('package-lock.json')) {
-  options.packageManager = 'yarn'
-}
+// NOTE: Options handling and defaults go in initOptions in index.js
 
 ncu.run(options)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,6 +5,7 @@
 const program = require('commander')
 const _ = require('lodash')
 const updateNotifier = require('update-notifier')
+const fs = require('fs')
 const ncu = require('../lib/')
 const pkg = require('../package.json')
 const cliOptions = require('../lib/cli-options')
@@ -91,6 +92,17 @@ const options = {
   args: program.args,
   ...program.filter ? { filter: program.filter } : null,
   cli: true,
+}
+
+/**
+ * Detect package manager according to lock file
+ */
+const files = fs.readdirSync('.')
+
+// By default, npm is set as package manager.
+// If yarn is detected, set yarn instead
+if (files.includes('yarn.lock') && !files.includes('package-lock.json')) {
+  options.packageManager = 'yarn'
 }
 
 ncu.run(options)

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -182,8 +182,8 @@ const cliOptions = [
     long: 'packageManager',
     short: 'p',
     arg: 'name',
-    description: 'npm, yarn',
-    default: 'npm'
+    // manual default to allow overriding auto yarn detection
+    description: 'npm, yarn (default: "npm")'
   },
   {
     long: 'pre',

--- a/lib/index.js
+++ b/lib/index.js
@@ -297,9 +297,12 @@ function initOptions(options) {
     ...options.ownerChanged ? ['ownerChanged'] : []
   ]
 
-  // autodetect yarn if no package-lock.json is present
+  // autodetect yarn
   const files = fs.readdirSync(options.cwd || '.')
   const autoYarn = !options.packageManager && files.includes('yarn.lock') && !files.includes('package-lock.json')
+  if (autoYarn) {
+    print(options, 'Using yarn')
+  }
 
   return {
     ...options,
@@ -318,7 +321,7 @@ function initOptions(options) {
     target,
     // imply upgrade in interactive mode when json is not specified as the output
     ...options.interactive && options.upgrade === undefined ? { upgrade: !json } : null,
-    ...autoYarn ? { packageManager: 'yarn' } : null,
+    ...!options.packageManager && { packageManager: autoYarn ? 'yarn' : 'npm' },
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -297,6 +297,10 @@ function initOptions(options) {
     ...options.ownerChanged ? ['ownerChanged'] : []
   ]
 
+  // autodetect yarn if no package-lock.json is present
+  const files = fs.readdirSync(options.cwd || '.')
+  const autoYarn = !options.packageManager && files.includes('yarn.lock') && !files.includes('package-lock.json')
+
   return {
     ...options,
     ...options.deep ? { packageFile: `${deepPatternPrefix}${getPackageFileName(options)}` } : null,
@@ -314,6 +318,7 @@ function initOptions(options) {
     target,
     // imply upgrade in interactive mode when json is not specified as the output
     ...options.interactive && options.upgrade === undefined ? { upgrade: !json } : null,
+    ...autoYarn ? { packageManager: 'yarn' } : null,
   }
 }
 


### PR DESCRIPTION
Hello,

I saw that PR were merged to detect yarn but It does not work for me. I read the code and I do not understand how yarn could be detected.

I add the following code set yarn as package manager if `yarn.lock` is detected without the presence of `package-lock.json`.
I use the simplest code I can :)

Thank you for your project, it is very useful!
Have a nice day.
