### PR TITLE
update peer dependencies on upgrade and retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ ncu "/^(?!react-).*$/" # windows
                              ./package.json).
 -p, --packageManager <name>  npm, yarn (default: "npm")
 --peer                       Check peer dependencies of installed packages
-                             and filter updates to compatible versions.
+                             and filter updates to compatible versions. Run
+                             "ncu --help --peer" for details.
 --pre <n>                    Include -alpha, -beta, -rc. (default: 0; default
                              with --newest and --greatest: 1).
 --prefix <path>              Current working directory of npm.

--- a/lib/cli-options.js
+++ b/lib/cli-options.js
@@ -1,5 +1,6 @@
 const _ = require('lodash')
 const Table = require('cli-table')
+const chalk = require('chalk')
 const { deepPatternPrefix } = require('./constants')
 
 /*
@@ -35,8 +36,44 @@ other version numbers that are higher. Includes prereleases.`])
 const cliOptions = [
   {
     long: 'peer',
-    description: 'Check peer dependencies of installed packages and filter updates to compatible versions.',
-    type: 'boolean'
+    description: 'Check peer dependencies of installed packages and filter updates to compatible versions. Run "ncu --help --peer" for details.',
+    type: 'boolean',
+    help: `Check peer dependencies of installed packages and filter updates to compatible versions.
+
+${chalk.bold('Example')}
+
+The following example demonstrates how --peer works, and how it uses peer dependencies from upgraded modules.
+
+The package ${chalk.bold('ncu-test-peer-update')} has two versions published:
+
+- 1.0.0 has peer dependency "ncu-test-return-version": "1.0.x"
+- 1.1.0 has peer dependency "ncu-test-return-version": "1.1.x"
+
+Our test app has the following dependencies:
+
+    "ncu-test-peer-update": "1.0.0",
+    "ncu-test-return-version": "1.0.0"
+
+The latest versions of these packages are:
+
+    "ncu-test-peer-update": "1.1.0",
+    "ncu-test-return-version": "2.0.0"
+
+${chalk.bold('With --peer')}
+
+ncu upgrades packages to the highest version that still adheres to the peer dependency constraints:
+
+
+ ncu-test-peer-update     1.0.0  →  1.${chalk.cyan('1.0')}
+ ncu-test-return-version  1.0.0  →  1.${chalk.cyan('1.0')}
+
+${chalk.bold('Without --peer')}
+
+As a comparison: without using the --peer option, ncu will suggest the latest versions, ignoring peer dependencies:
+
+ ncu-test-peer-update     1.0.0  →  1.${chalk.cyan('1.0')}
+ ncu-test-return-version  1.0.0  →  ${chalk.red('2.0.0')}
+  `
   },
   {
     long: 'color',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -141,7 +141,7 @@ declare namespace ncu {
     packageManager?: string;
 
     /**
-     * Check peer dependencies of installed packages and filter updates to compatible versions.
+     * Check peer dependencies of installed packages and filter updates to compatible versions. Run "ncu --help --peer" for details.
      */
     peer?: boolean;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,10 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
   print(options, '\nOptions:', 'verbose')
   print(options, sortOptions(options), 'verbose')
 
-  const [upgraded, latest] = await vm.upgradePackageDefinitions(current, options)
+  const [upgraded, latest, upgradedPeerDependencies] = await vm.upgradePackageDefinitions(current, options)
+
+  print(options, '\nupgradedPeerDependencies:', 'verbose')
+  print(options, upgradedPeerDependencies, 'verbose')
 
   print(options, '\nFetched:', 'verbose')
   print(options, latest, 'verbose')
@@ -233,22 +236,18 @@ function getPeerDependencies(current, options) {
   const basePath = options.cwd || './'
   return Object.keys(current).map(pkgName => {
     const path = basePath + 'node_modules/' + pkgName + '/package.json'
+    let peers = {}
     try {
       const pkgData = fs.readFileSync(path)
       const pkg = jph.parse(pkgData)
-      return vm.getCurrentDependencies(pkg, { ...options, dep: 'peer' })
+      peers = vm.getCurrentDependencies(pkg, { ...options, dep: 'peer' })
     }
     catch (e) {
       print(options, 'Could not read peer dependencies for package ' + pkgName + '. Is this package installed?', 'warn')
-      return {}
     }
-  }).reduce((acc, peers) => {
-    Object.entries(peers).forEach(([pkgName, version]) => {
-      if (acc[pkgName] === undefined) {
-        acc[pkgName] = []
-      }
-      acc[pkgName][acc[pkgName].length] = version
-    })
+    return [pkgName, peers]
+  }).reduce((acc, [pkgName, peers]) => {
+    acc[pkgName] = peers
     return acc
   }, {})
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -234,7 +234,7 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
 /** Get peer dependencies from installed packages */
 function getPeerDependencies(current, options) {
   const basePath = options.cwd || './'
-  return Object.keys(current).map(pkgName => {
+  return Object.keys(current).reduce((accum, pkgName) => {
     const path = basePath + 'node_modules/' + pkgName + '/package.json'
     let peers = {}
     try {
@@ -245,10 +245,7 @@ function getPeerDependencies(current, options) {
     catch (e) {
       print(options, 'Could not read peer dependencies for package ' + pkgName + '. Is this package installed?', 'warn')
     }
-    return [pkgName, peers]
-  }).reduce((acc, [pkgName, peers]) => {
-    acc[pkgName] = peers
-    return acc
+    return { ...accum, [pkgName]: peers }
   }, {})
 }
 

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -177,9 +177,9 @@ function satisfiesNodeEngine(versionResult, nodeEngine) {
  */
 function satisfiesPeerDependencies(versionResult, peerDependencies) {
   if (!peerDependencies) return true
-  const pkgPeerDependencies = peerDependencies[versionResult.name]
-  if (!pkgPeerDependencies) return true
-  return pkgPeerDependencies.every(v => semver.satisfies(versionResult.version, v))
+  return Object.values(peerDependencies).every(
+    peers => peers[versionResult.name] === undefined || semver.satisfies(versionResult.version, peers[versionResult.name])
+  )
 }
 
 /** Returns a composite predicate that filters out deprecated, prerelease, and node engine incompatibilies from version objects returns by pacote.packument. */
@@ -202,9 +202,9 @@ function filterPredicate(options) {
  */
 function spawnNpm(args, npmOptions = {}, spawnOptions = {}) {
   const cmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  args = Array.isArray(args) ? args : [args]
 
-  const fullArgs = [].concat(
-    args,
+  const fullArgs = args.concat(
     npmOptions.global ? '--global' : [],
     npmOptions.prefix ? `--prefix=${npmOptions.prefix}` : [],
     '--depth=0',
@@ -255,6 +255,21 @@ async function defaultPrefix(options) {
 module.exports = {
 
   npm: spawnNpm,
+
+  /**
+   * Requests the list of peer dependencies for a specific package version
+   *
+   * @param packageName
+   * @param version
+   * @returns Promised {packageName: version} collection
+   */
+  async getPeerDependencies(packageName, version) {
+    const result = await spawnNpm(
+      ['view', packageName + '@' + version, 'peerDependencies'],
+      {},
+      { rejectOnError: false })
+    return result ? parseJson(result, { command: 'npm view' }) : {}
+  },
 
   /**
    * @param [options]

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -214,7 +214,7 @@ async function getOwnerPerDependency(fromVersion, toVersion, options) {
 }
 
 /**
- * Returns an 2-tuple of upgradedDependencies and their latest versions.
+ * Returns an 3-tuple of upgradedDependencies, their latest versions and the resulting peer dependencies.
  *
  * @param currentDependencies
  * @param options
@@ -231,7 +231,24 @@ async function upgradePackageDefinitions(currentDependencies, options) {
     return !options.jsonUpgraded || !options.minimal || !isSatisfied(latestVersions[dep], currentDependencies[dep])
   })
 
-  return [filteredUpgradedDependencies, latestVersions]
+  let result = [filteredUpgradedDependencies, latestVersions, options.peerDependencies]
+  if (options.peer && !_.isEmpty(filteredUpgradedDependencies)) {
+    const upgradedPeerDependencies = await getPeerDependenciesFromRegistry(filteredUpgradedDependencies, options)
+    const peerDependencies = { ...options.peerDependencies, ...upgradedPeerDependencies }
+    result[2] = peerDependencies
+    if (!_.isEqual(options.peerDependencies, peerDependencies)) {
+      const [newUpgradedDependencies, newLatestVersions, newPeerDependencies] = await upgradePackageDefinitions(
+        { ...currentDependencies, ...filteredUpgradedDependencies },
+        { ...options, peerDependencies, loglevel: 'silent' }
+      )
+      result = [
+        { ...filteredUpgradedDependencies, ...newUpgradedDependencies },
+        { ...latestVersions, ...newLatestVersions },
+        newPeerDependencies
+      ]
+    }
+  }
+  return result
 }
 
 /**
@@ -442,6 +459,37 @@ async function queryVersions(packageMap, options = {}) {
 }
 
 /**
+ * Get the latest or greatest versions from the NPM repository based on the version target.
+ *
+ * @param packageMap   An object whose keys are package name and values are version
+ * @param [options={}] Options.
+ * @returns Promised {packageName: peer dependencies} collection
+ */
+async function getPeerDependenciesFromRegistry(packageMap, options) {
+  const numItems = Object.keys(packageMap).length
+  let bar
+  if (!options.json && options.loglevel !== 'silent' && options.loglevel !== 'verbose' && numItems > 0) {
+    bar = new ProgressBar('[:bar] :current/:total :percent', { total: numItems, width: 20 })
+    bar.render()
+  }
+
+  const packageManager = getPackageManager(options.packageManager)
+  let result = {}
+  if (packageManager.getPeerDependencies) {
+    result = await Object.entries(packageMap).reduce(async (prom, [pkg, version]) => {
+      const dep = await packageManager.getPeerDependencies(pkg, version)
+      if (bar) {
+        bar.tick()
+      }
+      const acc = await prom
+      acc[pkg] = dep
+      return acc
+    }, {})
+  }
+  return result
+}
+
+/**
  *
  * @param dependencies A dependencies collection
  * @returns Returns whether the user prefers ^, ~, .*, or .x
@@ -532,4 +580,5 @@ module.exports = {
   queryVersions,
   upgradeDependencies,
   getPackageManager,
+  getPeerDependenciesFromRegistry,
 }

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -231,24 +231,22 @@ async function upgradePackageDefinitions(currentDependencies, options) {
     return !options.jsonUpgraded || !options.minimal || !isSatisfied(latestVersions[dep], currentDependencies[dep])
   })
 
-  let result = [filteredUpgradedDependencies, latestVersions, options.peerDependencies]
   if (options.peer && !_.isEmpty(filteredUpgradedDependencies)) {
     const upgradedPeerDependencies = await getPeerDependenciesFromRegistry(filteredUpgradedDependencies, options)
     const peerDependencies = { ...options.peerDependencies, ...upgradedPeerDependencies }
-    result[2] = peerDependencies
     if (!_.isEqual(options.peerDependencies, peerDependencies)) {
       const [newUpgradedDependencies, newLatestVersions, newPeerDependencies] = await upgradePackageDefinitions(
         { ...currentDependencies, ...filteredUpgradedDependencies },
         { ...options, peerDependencies, loglevel: 'silent' }
       )
-      result = [
+      return [
         { ...filteredUpgradedDependencies, ...newUpgradedDependencies },
         { ...latestVersions, ...newLatestVersions },
         newPeerDependencies
       ]
     }
   }
-  return result
+  return [filteredUpgradedDependencies, latestVersions, options.peerDependencies]
 }
 
 /**

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -466,6 +466,9 @@ async function queryVersions(packageMap, options = {}) {
  * @returns Promised {packageName: peer dependencies} collection
  */
 async function getPeerDependenciesFromRegistry(packageMap, options) {
+  const packageManager = getPackageManager(options.packageManager)
+  if (!packageManager.getPeerDependencies) return {}
+
   const numItems = Object.keys(packageMap).length
   let bar
   if (!options.json && options.loglevel !== 'silent' && options.loglevel !== 'verbose' && numItems > 0) {
@@ -473,20 +476,14 @@ async function getPeerDependenciesFromRegistry(packageMap, options) {
     bar.render()
   }
 
-  const packageManager = getPackageManager(options.packageManager)
-  let result = {}
-  if (packageManager.getPeerDependencies) {
-    result = await Object.entries(packageMap).reduce(async (prom, [pkg, version]) => {
-      const dep = await packageManager.getPeerDependencies(pkg, version)
-      if (bar) {
-        bar.tick()
-      }
-      const acc = await prom
-      acc[pkg] = dep
-      return acc
-    }, {})
-  }
-  return result
+  return Object.entries(packageMap).reduce(async (accumPromise, [pkg, version]) => {
+    const dep = await packageManager.getPeerDependencies(pkg, version)
+    if (bar) {
+      bar.tick()
+    }
+    const accum = await accumPromise
+    return { ...accum, [pkg]: dep }
+  }, {})
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -741,6 +741,22 @@ describe('run', function () {
       }
     })
 
+    const peerUpdatePath = path.join(__dirname, '/peer-update/')
+    it('peer dependencies of installed packages are checked iteratively when using option peer', async () => {
+      try {
+        await spawnNpm('install', {}, { cwd: peerUpdatePath })
+        const upgrades = await ncu.run({ cwd: peerUpdatePath, peer: true })
+        upgrades.should.deep.equal({
+          'ncu-test-return-version': '1.1.0',
+          'ncu-test-peer-update': '1.1.0'
+        })
+      }
+      finally {
+        rimraf.sync(path.join(peerUpdatePath, 'node_modules'))
+        rimraf.sync(path.join(peerUpdatePath, 'package-lock.json'))
+      }
+    })
+
   })
 
 })

--- a/test/package-managers/npm/index.js
+++ b/test/package-managers/npm/index.js
@@ -31,4 +31,11 @@ describe('npm', function () {
     await packageManagers.npm.packageAuthorChanged('htmlparser2', '^3.10.1', '^4.0.0').should.eventually.equal(false)
     await packageManagers.npm.packageAuthorChanged('ncu-test-v2', '^1.0.0', '2.2.0').should.eventually.be.null
   })
+
+  it('getPeerDependencies', async () => {
+    await packageManagers.npm.getPeerDependencies('ncu-test-return-version', '1.0').should.eventually.deep.equal({})
+    await packageManagers.npm.getPeerDependencies('ncu-test-peer', '1.0').should.eventually.deep.equal({
+      'ncu-test-return-version': '1.x'
+    })
+  })
 })

--- a/test/peer-update/package.json
+++ b/test/peer-update/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "ncu-test-peer-update": "1.0.0",
+    "ncu-test-return-version": "1.0.1"
+  }
+}

--- a/test/peer-update/package.json
+++ b/test/peer-update/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "ncu-test-peer-update": "1.0.0",
-    "ncu-test-return-version": "1.0.1"
+    "ncu-test-return-version": "1.0.0"
   }
 }

--- a/test/versionmanager.test.js
+++ b/test/versionmanager.test.js
@@ -329,6 +329,33 @@ describe('versionmanager', () => {
     })
   })
 
+  describe('getPeerDependenciesFromRegistry', function () {
+    it('single package', async () => {
+      const data = await vm.getPeerDependenciesFromRegistry({ 'ncu-test-peer': '1.0' }, {})
+      data.should.deep.equal({
+        'ncu-test-peer': {
+          'ncu-test-return-version': '1.x'
+        }
+      })
+    })
+    it('single package empty', async () => {
+      const data = await vm.getPeerDependenciesFromRegistry({ 'ncu-test-return-version': '1.0' }, {})
+      data.should.deep.equal({ 'ncu-test-return-version': {} })
+    })
+    it('multiple packages', async () => {
+      const data = await vm.getPeerDependenciesFromRegistry({
+        'ncu-test-return-version': '1.0.0',
+        'ncu-test-peer': '1.0.0',
+      }, {})
+      data.should.deep.equal({
+        'ncu-test-return-version': {},
+        'ncu-test-peer': {
+          'ncu-test-return-version': '1.x'
+        }
+      })
+    })
+  })
+
   describe('queryVersions', function () {
     // We increase the timeout to allow for more time to retrieve the version information
     this.timeout(30000)


### PR DESCRIPTION
This is a follow-up of #869 and improves the situation, where updated packages have different peer dependencies. Here is an example:

The package `ncu-test-peer-update` is published with two versions:
- `1.0.0` has peer dependency `"ncu-test-return-version": "1.0.x"`
- `1.1.0` has peer dependency `"ncu-test-return-version": "1.1.x"`

Our test app has the following dependencies:
```
    "ncu-test-peer-update": "1.0.0",
    "ncu-test-return-version": "1.0.0"
```

### Before (i.e. with `ncu` version 11.5.1)
A call of `ncu --peer` will propose the following updates:
```
 ncu-test-peer-update     1.0.0  →  1.1.0     
 ncu-test-return-version  1.0.0  →  1.0.1     
```
There is not update suggestion for `ncu-test-return-version` to `1.1.0`, since the installed version of `ncu-test-peer-update` requires version `1.0.x`. This means, I would have to run `npm install` afterwards and then again `ncu --peer` to get all updates.

### After (i.e. with this PR)
Now, `ncu` will get the new peer dependencies from the registry and check again for updates. I.e., the resulting update suggestion will contain all compatible updates.
```
 ncu-test-peer-update     1.0.0  →  1.1.0     
 ncu-test-return-version  1.0.0  →  1.1.0     
```

### Without `--peer` option
Just as comparison: without using the `--peer` option, `ncu` will suggest incompatible updates in both cases (with and without this PR):
```
 ncu-test-peer-update     1.0.0  →  1.1.0     
 ncu-test-return-version  1.0.0  →  2.0.0     
```