### PR TITLE
print summary of incompatible/ignored updates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ const jph = require('json-parse-helpfulerror')
 const vm = require('./versionmanager')
 const doctor = require('./doctor')
 const packageManagers = require('./package-managers')
-const { print, printJson, printUpgrades } = require('./logging')
+const { print, printJson, printUpgrades, printIgnoredUpdates } = require('./logging')
 const { deepPatternPrefix, doctorHelpText } = require('./constants')
 const cliOptions = require('./cli-options')
 
@@ -199,6 +199,12 @@ async function analyzeProjectDependencies(options, pkgData, pkgFile) {
       total: Object.keys(upgraded).length,
       ownersChangedDeps
     })
+    if (options.peer) {
+      const ignoredUpdates = await vm.getIgnoredUpgrades(current, upgraded, upgradedPeerDependencies, options)
+      if (!_.isEmpty(ignoredUpdates)) {
+        printIgnoredUpdates(options, ignoredUpdates)
+      }
+    }
   }
 
   if (numUpgraded > 0) {

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -140,4 +140,17 @@ function printUpgrades(options, { current, upgraded, numUpgraded, total, ownersC
   }
 }
 
-module.exports = { print, printJson, printUpgrades, toDependencyTable }
+function printIgnoredUpdates(options, ignoredUpdates) {
+  print(options, `\nIgnored incompatible updates (peer dependencies):\n`)
+  const table = createDependencyTable()
+  const rows = Object.entries(ignoredUpdates).map(([pkgName, { from, to, reason }]) => {
+    const strReason = 'reason: ' + Object.entries(reason)
+      .map(([pkgReason, requirement]) => pkgReason + ' requires ' + requirement)
+      .join(', ')
+    return [pkgName, from, '→', colorizeDiff(from, to), strReason]
+  })
+  rows.forEach(row => table.push(row)) // eslint-disable-line fp/no-mutating-methods
+  print(options, table.toString())
+}
+
+module.exports = { print, printJson, printUpgrades, toDependencyTable, printIgnoredUpdates }

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -328,6 +328,26 @@ function getCurrentDependencies(pkgData = {}, options = {}) {
   return allDependencies
 }
 
+async function getIgnoredUpgrades(current, upgraded, upgradedPeerDependencies, options = {}) {
+  const [upgradedLatestVersions, latestVersions] = await upgradePackageDefinitions(
+    current,
+    { ...options, peer: false, peerDependencies: undefined, loglevel: 'silent' }
+  )
+
+  return Object.entries(upgradedLatestVersions)
+    .filter(([pkgName, newVersion]) => upgraded[pkgName] !== newVersion)
+    .reduce((accum, [pkgName, newVersion]) => ({
+      ...accum,
+      [pkgName]: {
+        from: current[pkgName],
+        to: newVersion,
+        reason: Object.entries(upgradedPeerDependencies)
+          .filter(([, peers]) => peers[pkgName] !== undefined && !semver.satisfies(latestVersions[pkgName], peers[pkgName]))
+          .reduce((accumReason, [peerPkg, peers]) => ({ ...accumReason, [peerPkg]: peers[pkgName] }), {})
+      }
+    }), {})
+}
+
 /**
  * @param [options]
  * @param options.cwd
@@ -576,4 +596,5 @@ module.exports = {
   upgradeDependencies,
   getPackageManager,
   getPeerDependenciesFromRegistry,
+  getIgnoredUpgrades,
 }

--- a/test/versionmanager.test.js
+++ b/test/versionmanager.test.js
@@ -329,6 +329,31 @@ describe('versionmanager', () => {
     })
   })
 
+  describe('getIgnoredUpgrades', function () {
+    it('ncu-test-peer-update', async () => {
+      const data = await vm.getIgnoredUpgrades({
+        'ncu-test-return-version': '1.0.0',
+        'ncu-test-peer': '1.0.0',
+      }, {
+        'ncu-test-return-version': '1.1.0',
+        'ncu-test-peer': '1.1.0',
+      }, {
+        'ncu-test-peer': {
+          'ncu-test-return-version': '1.1.x'
+        }
+      }, {})
+      data.should.deep.equal({
+        'ncu-test-return-version': {
+          from: '1.0.0',
+          to: '2.0.0',
+          reason: {
+            'ncu-test-peer': '1.1.x'
+          }
+        }
+      })
+    })
+  })
+
   describe('getPeerDependenciesFromRegistry', function () {
     it('single package', async () => {
       const data = await vm.getPeerDependenciesFromRegistry({ 'ncu-test-peer': '1.0' }, {})


### PR DESCRIPTION
see https://github.com/raineorshine/npm-check-updates/pull/874#issuecomment-826938074

Example:

```
 vue-fragment    1.5.1  →    1.5.2     
 webpack       ^5.35.1  →  ^5.36.0     

Ignored incompatible updates (peer dependencies):

 css-loader              ^4.3.0  →   ^5.2.4  reason: @nextcloud/webpack-vue-config requires ^4.3.0                                    
 eslint-plugin-promise   ^4.3.1  →   ^5.1.0  reason: @nextcloud/eslint-config requires ^4.2.1, eslint-config-standard requires ^4.2.1 
 sass-loader            ^10.1.1  →  ^11.0.1  reason: @nextcloud/webpack-vue-config requires ^10.0.5                                   

Run ncu -u to upgrade package.json
```