### PR TITLE
Fix github dependency upgrades with partial semver

### DIFF
--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -53,11 +53,11 @@ function upgradeDependencies(currentDependencies, latestVersions, options = {}) 
 
         const currentTag = versionUtil.getGithubUrlTag(current)
         const [currentSemver] = semverutils.parseRange(currentTag)
-        currentParsed = versionUtil.stringify(currentSemver)
+        currentParsed = versionUtil.stringify(currentSemver, 'patch')
 
         const latestTag = versionUtil.getGithubUrlTag(latest)
         const [latestSemver] = semverutils.parseRange(latestTag)
-        latestParsed = versionUtil.stringify(latestSemver)
+        latestParsed = versionUtil.stringify(latestSemver, 'patch')
       }
 
       return { current, currentParsed, latest, latestParsed }

--- a/test/versionmanager.test.js
+++ b/test/versionmanager.test.js
@@ -288,6 +288,10 @@ describe('versionmanager', () => {
       vm.upgradeDependencies({ 'ncu-test-simple-tag': 'v1' }, { 'ncu-test-simple-tag': 'v3' }).should.eql({ 'ncu-test-simple-tag': 'v3' })
     })
 
+    it('upgrade github dependencies', () => {
+      vm.upgradeDependencies({ foo: 'github:foo/bar#v1.0.0' }, { foo: 'github:foo/bar#v2.0.0' }).should.eql({ foo: 'github:foo/bar#v2.0.0' })
+    })
+
     it('upgrade latest versions that already satisfy the specified version', () => {
       vm.upgradeDependencies({ mongodb: '^1.0.0' }, { mongodb: '1.4.30' }).should.eql({
         mongodb: '^1.4.30'

--- a/test/versionmanager.test.js
+++ b/test/versionmanager.test.js
@@ -289,6 +289,8 @@ describe('versionmanager', () => {
     })
 
     it('upgrade github dependencies', () => {
+      vm.upgradeDependencies({ foo: 'github:foo/bar#v1' }, { foo: 'github:foo/bar#v2' }).should.eql({ foo: 'github:foo/bar#v2' })
+      vm.upgradeDependencies({ foo: 'github:foo/bar#v1.0' }, { foo: 'github:foo/bar#v2.0' }).should.eql({ foo: 'github:foo/bar#v2.0' })
       vm.upgradeDependencies({ foo: 'github:foo/bar#v1.0.0' }, { foo: 'github:foo/bar#v2.0.0' }).should.eql({ foo: 'github:foo/bar#v2.0.0' })
     })
 


### PR DESCRIPTION
I have added a test that shows a problem.

Error occurs because `revertMissingPatch` and `revertMissingMinorAndPatch` relies that `latest` is in format `major.minor.patch`, while github refs could be in other format.

Maybe it worth to make this functions more generic, but because of their specialisation i opted to add minimal changes rather than overengineer it.