### PR TITLE
Fix getPeerDependencies to use cwd

### DIFF
--- a/src/lib/getPeerDependencies.ts
+++ b/src/lib/getPeerDependencies.ts
@@ -6,7 +6,7 @@ import { Index, Options, VersionSpec } from '../types'
 
 /** Get peer dependencies from installed packages */
 function getPeerDependencies(current: Index<VersionSpec>, options: Options) {
-  const basePath = options.cwd || '../'
+  const basePath = options.cwd || './'
   return Object.keys(current).reduce((accum, pkgName) => {
     const path = basePath + 'node_modules/' + pkgName + '/package.json'
     let peers = {}


### PR DESCRIPTION
Hi there!

I noticed after upgrading to v12 that the `--peer` option seemed to be broken from https://github.com/raineorshine/npm-check-updates/commit/d2584170738690b99e1d32e27d98702fc7a3c906

This is a simple change that fixes that by not using the path above.

Example:
![image](https://user-images.githubusercontent.com/50554676/140408732-9495119c-8bd0-414c-bee3-1566540ea862.png)
