### PR TITLE
Exclude test files from the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "yarn": "^1.22.17"
   },
   "files": [
-    "build"
+    "build/src",
+    "!**/test/**"
   ],
   "lockfile-lint": {
     "allowed-schemes": [


### PR DESCRIPTION
Before:

```
npm notice === Tarball Details ===
npm notice package size:  100.8 kB
npm notice unpacked size: 539.3 kB
npm notice total files:   178
```

After:

```
npm notice === Tarball Details ===
npm notice package size:  70.0 kB
npm notice unpacked size: 295.5 kB
npm notice total files:   108
```

@raineorshine please confirm by doing `npm pack --dry` :)