### PR TITLE
package.json: remove the deprecated `preferGlobal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "management",
     "ncu"
   ],
-  "preferGlobal": true,
   "engines": {
     "node": ">=12"
   },


### PR DESCRIPTION
This option is removed from npm >= 7.x