### PR TITLE
buildReadme.js: remove unused variables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
     'plugin:import/typescript',
     'raine'
   ],
-  ignorePatterns: 'scripts',
   overrides: [
     {
       files: ['**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "cross-env FORCE_COLOR=1 npm-run-all --parallel --aggregate-output lint:*",
     "lint:lockfile": "lockfile-lint",
     "lint:markdown": "markdownlint \"**/*.md\" --ignore node_modules --ignore build --config .markdownlint.js",
-    "lint:src": "eslint --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives src",
+    "lint:src": "eslint --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives src scripts",
     "nyc": "nyc",
     "prepublishOnly": "npm run build",
     "test": "npm run test:src && npm run test:timeout",

--- a/scripts/buildReadme.js
+++ b/scripts/buildReadme.js
@@ -3,12 +3,7 @@
 'use strict'
 
 const fs = require('fs')
-const path = require('path')
 const spawn = require('spawn-please')
-const cliOptions = require('../build/src/cli-options.js').default
-
-/** Escape closing block comments that would interfere with JSDOC. */
-const escapeComments = s => s.replace(/\*\*\//g, '**\\/')
 
 /** Extracts CLI options from the bin output. */
 const readOptions = async () => {


### PR DESCRIPTION
Unsure why these weren't caught by ESLint? Maybe we should adapt ESLint?