### PR TITLE
runLocal: add missing `await`

### DIFF
--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -41,7 +41,7 @@ export async function getOwnerPerDependency(fromVersion: Index<Version>, toVersi
     const to = toVersion[dep] || null
     const ownerChanged = await packageManager.packageAuthorChanged!(dep, from!, to!, options)
     return {
-      ...accum,
+      ...await accum,
       [dep]: ownerChanged,
     }
   }, {} as Promise<Index<boolean>>)


### PR DESCRIPTION
This is flagged by [lgtm.com](https://lgtm.com/projects/g/raineorshine/npm-check-updates?mode=list), unsure if it's really needed and if it is, maybe some tests need to be adapted so that this is caught?