### PR TITLE
Don't include deprecated versions when using yarn package manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "npm-check-updates",
       "version": "12.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/package-managers/filters.ts
+++ b/src/package-managers/filters.ts
@@ -1,0 +1,53 @@
+import _ from 'lodash'
+import semver from 'semver'
+import * as versionUtil from '../version-util'
+import { Index, Maybe, Options, Packument, Version } from '../types'
+
+/**
+ * @param versionResult  Available version
+ * @param options     Options
+ * @returns         True if deprecated versions are allowed or the version is not deprecated
+ */
+export function allowDeprecatedOrIsNotDeprecated(versionResult: Packument, options: Options): boolean {
+  if (!!options.deprecated) return true
+  return !versionResult.deprecated;
+}
+
+/**
+ * @param versionResult  Available version
+ * @param options     Options
+ * @returns         True if pre-releases are allowed or the version is not a pre-release
+ */
+export function allowPreOrIsNotPre(versionResult: Packument, options: Options): boolean {
+  if (!!options.pre) return true
+  return !versionUtil.isPre(versionResult.version)
+}
+
+/**
+ * Returns true if the node engine requirement is satisfied or not specified for a given package version.
+ *
+ * @param versionResult     Version object returned by pacote.packument.
+ * @param nodeEngineVersion The value of engines.node in the package file.
+ * @returns                 True if the node engine requirement is satisfied or not specified.
+ */
+export function satisfiesNodeEngine(versionResult: Packument, nodeEngineVersion: Maybe<string>): boolean {
+  if (!nodeEngineVersion) return true
+  const minVersion = _.get(semver.minVersion(nodeEngineVersion), 'version')
+  if (!minVersion) return true
+  const versionNodeEngine = _.get(versionResult, 'engines.node')
+  return versionNodeEngine && semver.satisfies(minVersion, versionNodeEngine)
+}
+
+/**
+ * Returns true if the peer dependencies requirement is satisfied or not specified for a given package version.
+ *
+ * @param versionResult     Version object returned by pacote.packument.
+ * @param peerDependencies  The list of peer dependencies.
+ * @returns                 True if the peer dependencies are satisfied or not specified.
+ */
+export function satisfiesPeerDependencies(versionResult: Packument, peerDependencies: Index<Index<Version>>) {
+  if (!peerDependencies) return true
+  return Object.values(peerDependencies).every(
+    peers => peers[versionResult.name] === undefined || semver.satisfies(versionResult.version, peers[versionResult.name])
+  )
+}

--- a/src/package-managers/filters.ts
+++ b/src/package-managers/filters.ts
@@ -9,8 +9,8 @@ import { Index, Maybe, Options, Packument, Version } from '../types'
  * @returns         True if deprecated versions are allowed or the version is not deprecated
  */
 export function allowDeprecatedOrIsNotDeprecated(versionResult: Packument, options: Options): boolean {
-  if (!!options.deprecated) return true
-  return !versionResult.deprecated;
+  if (options.deprecated) return true
+  return !versionResult.deprecated
 }
 
 /**
@@ -19,7 +19,7 @@ export function allowDeprecatedOrIsNotDeprecated(versionResult: Packument, optio
  * @returns         True if pre-releases are allowed or the version is not a pre-release
  */
 export function allowPreOrIsNotPre(versionResult: Packument, options: Options): boolean {
-  if (!!options.pre) return true
+  if (options.pre) return true
   return !versionUtil.isPre(versionResult.version)
 }
 

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -153,7 +153,7 @@ export async function viewOne(packageName: string, field: string, currentVersion
 }
 
 /** Returns a composite predicate that filters out deprecated, prerelease, and node engine incompatibilies from version objects returns by pacote.packument. */
-export function filterPredicate(options: Options): (o: Packument) => boolean {
+function filterPredicate(options: Options): (o: Packument) => boolean {
   return _.overEvery([
     o => allowDeprecatedOrIsNotDeprecated(o, options),
     o => allowPreOrIsNotPre(o, options),

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -79,7 +79,7 @@ async function parseJsonLines(result: string): Promise<{ dependencies: Index<Par
 }
 
 /** Returns a composite predicate that filters out deprecated, prerelease, and node engine incompatibilies from version objects returns by pacote.packument. */
-export function filterPredicate(options: Options): (o: Packument) => boolean {
+function filterPredicate(options: Options): (o: Packument) => boolean {
   return _.overEvery([
     o => allowDeprecatedOrIsNotDeprecated(o, options),
     o => allowPreOrIsNotPre(o, options),

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -4,13 +4,13 @@
 import { once, EventEmitter } from 'events'
 import _ from 'lodash'
 import cint from 'cint'
-import semver from 'semver'
 import spawn from 'spawn-please'
 import libnpmconfig from 'libnpmconfig'
 import jsonlines from 'jsonlines'
 import * as versionUtil from '../version-util'
 import { viewOne, viewManyMemoized } from './npm'
 import { GetVersion, Index, Options, Packument, SpawnOptions, Version, YarnOptions } from '../types'
+import { allowDeprecatedOrIsNotDeprecated, allowPreOrIsNotPre, satisfiesNodeEngine } from './filters'
 
 interface ParsedDep {
   version: string,
@@ -78,33 +78,13 @@ async function parseJsonLines(result: string): Promise<{ dependencies: Index<Par
 
 }
 
-/**
- * @param versions  Array of all available versions
- * @param pre     Enabled prerelease?
- * @returns         An array of versions with the release versions filtered out
- */
-function filterOutPrereleaseVersions(versions: Version[], pre: boolean) {
-  return pre ? versions : versions.filter(
-    version => !versionUtil.isPre(version))
-}
-
-/**
- * @param versions            Object with all versions
- * @param nodeEngineVersion   Package engines.node range
- * @returns An array of versions which satisfies engines.node range
- */
-function doesSatisfyEnginesNode(versions: Packument[], nodeEngineVersion?: Version) {
-  if (!versions) return []
-  if (!nodeEngineVersion) return Object.keys(versions)
-
-  const minVersion = _.get(semver.minVersion(nodeEngineVersion), 'version')
-  if (!minVersion) return Object.keys(versions)
-
-  return versions.filter(version => {
-    const versionEnginesNode = _.get(version, 'engines.node')
-    return versionEnginesNode &&
-      semver.satisfies(minVersion, versionEnginesNode)
-  })
+/** Returns a composite predicate that filters out deprecated, prerelease, and node engine incompatibilies from version objects returns by pacote.packument. */
+export function filterPredicate(options: Options): (o: Packument) => boolean {
+  return _.overEvery([
+    o => allowDeprecatedOrIsNotDeprecated(o, options),
+    o => allowPreOrIsNotPre(o, options),
+    options.enginesNode ? o => satisfiesNodeEngine(o, options.nodeEngineVersion) : null!,
+  ])
 }
 
 /**
@@ -191,22 +171,25 @@ export const list = async (options: Options = {}, spawnOptions?: SpawnOptions) =
  * @returns
  */
 export const latest: GetVersion = async (packageName: string, currentVersion: Version, options: Options = {}) => {
-  const latest = await viewOne(packageName, 'dist-tags.latest', currentVersion, options) as unknown as Packument
+  const latest = await viewOne(packageName, 'dist-tags.latest', currentVersion, {
+    registry: options.registry,
+    timeout: options.timeout,
+  }) as unknown as Packument // known type based on dist-tags.latest
 
+  // latest should not be deprecated
   // if latest exists and latest is not a prerelease version, return it
   // if latest exists and latest is a prerelease version and --pre is specified, return it
   // if latest exists and latest not satisfies min version of engines.node
-  if (latest && (!versionUtil.isPre(latest.version) || options.pre) &&
-    doesSatisfyEnginesNode([latest], options.nodeEngineVersion).length) {
-    return latest.version
-    // if latest is a prerelease version and --pre is not specified, find the next
-    // version that is not a prerelease
-  }
-  else {
-    const versions = await viewOne(packageName, 'versions', currentVersion) as Packument[]
-    const versionsSatisfyingNodeEngine = doesSatisfyEnginesNode(versions, options.nodeEngineVersion) as string[]
-    return _.last(filterOutPrereleaseVersions(versionsSatisfyingNodeEngine, !!options.pre)) || null
-  }
+  if (latest && filterPredicate(options)(latest)) return latest.version
+
+  // if latest is a prerelease version and --pre is not specified
+  // or latest is deprecated
+  // find the next valid version
+  // known type based on dist-tags.latest
+  const versions = await viewOne(packageName, 'versions', currentVersion) as Packument[]
+  const validVersions = _.filter(versions, filterPredicate(options))
+
+  return _.last(validVersions.map(o => o.version)) || null
 }
 
 /**
@@ -215,18 +198,22 @@ export const latest: GetVersion = async (packageName: string, currentVersion: Ve
  * @param options
  * @returns
  */
-export const newest: GetVersion = (packageName: string, currentVersion, options = {}) => {
-  return viewManyMemoized(packageName, ['time', 'versions'], currentVersion, options).then(result => {
-    // todo
-    const versions = doesSatisfyEnginesNode(result.versions, options.nodeEngineVersion) as Version[]
-    return Object.keys(result.time || {}).reduce((accum: string[], key) =>
-      accum.concat(
-        TIME_FIELDS.includes(key) || versions.includes(key) ? key : []), []
-    )
-  }).then(_.partialRight(_.pullAll, TIME_FIELDS)).then(versions =>
-    _.last(filterOutPrereleaseVersions(versions as Version[],
-      options.pre == null || options.pre)) || null
+export const newest: GetVersion = async (packageName: string, currentVersion, options = {}) => {
+  const result = await viewManyMemoized(packageName, ['time', 'versions'], currentVersion, options)
+
+  const versionsSatisfyingNodeEngine = _.filter(result.versions, version => satisfiesNodeEngine(version, options.nodeEngineVersion))
+    .map((o: Packument) => o.version)
+
+  const versions = Object.keys(result.time || {}).reduce((accum: string[], key: string) =>
+    accum.concat(TIME_FIELDS.includes(key) || versionsSatisfyingNodeEngine.includes(key) ? key : []), []
   )
+
+  const versionsWithTime = _.pullAll(versions, TIME_FIELDS)
+
+  return _.last(options.pre !== false
+    ? versions :
+    versionsWithTime.filter(version => !versionUtil.isPre(version))
+  ) || null
 }
 
 /**
@@ -237,10 +224,12 @@ export const newest: GetVersion = (packageName: string, currentVersion, options 
  */
 export const greatest: GetVersion = async (packageName, currentVersion, options = {}) => {
   const versions = await viewOne(packageName, 'versions', currentVersion, options) as Packument[]
-  // eslint-disable-next-line fp/no-mutating-methods
-  return _.last(filterOutPrereleaseVersions(
-    doesSatisfyEnginesNode(versions, options.nodeEngineVersion) as Version[],
-    options.pre == null || options.pre).sort(versionUtil.compareVersions)
+
+  return _.last(
+    // eslint-disable-next-line fp/no-mutating-methods
+    _.filter(versions, filterPredicate(options))
+      .map(o => o.version)
+      .sort(versionUtil.compareVersions)
   ) || null
 }
 
@@ -253,10 +242,7 @@ export const greatest: GetVersion = async (packageName, currentVersion, options 
 export const minor: GetVersion = async (packageName, currentVersion, options = {}) => {
   const versions = await viewOne(packageName, 'versions', currentVersion, options) as Packument[]
   return versionUtil.findGreatestByLevel(
-    filterOutPrereleaseVersions(
-      doesSatisfyEnginesNode(versions, options.nodeEngineVersion) as Version[],
-      !!options.pre
-    ),
+    _.filter(versions, filterPredicate(options)).map(o => o.version),
     currentVersion,
     'minor'
   )
@@ -271,10 +257,7 @@ export const minor: GetVersion = async (packageName, currentVersion, options = {
 export const patch: GetVersion = async (packageName, currentVersion, options = {}) => {
   const versions = await viewOne(packageName, 'versions', currentVersion, options) as Packument[]
   return versionUtil.findGreatestByLevel(
-    filterOutPrereleaseVersions(
-      doesSatisfyEnginesNode(versions, options.nodeEngineVersion) as Version[],
-      !!options.pre
-    ),
+    _.filter(versions, filterPredicate(options)).map(o => o.version),
     currentVersion,
     'patch'
   )

--- a/test/package-managers/npm/index.ts
+++ b/test/package-managers/npm/index.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import * as npm from '../../../src/package-managers/npm'

--- a/test/package-managers/yarn/index.ts
+++ b/test/package-managers/yarn/index.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import spawn from 'spawn-please'
 import * as yarn from '../../../src/package-managers/yarn'
 
 chai.should()
@@ -29,6 +28,17 @@ describe('yarn', function () {
     const testDir = path.join(__dirname, 'default')
     const version = await yarn.latest('chalk', '', { cwd: testDir })
     parseInt(version!, 10).should.be.above(3)
+  })
+
+  it('greatest', async () => {
+    const version = await yarn.greatest('ncu-test-greatest-not-newest', '', { pre: true, cwd: __dirname })
+    version!.should.equal('2.0.0-beta')
+  })
+
+  it('avoids deprecated', async () => {
+    const testDir = path.join(__dirname, 'default')
+    const version = await yarn.minor('popper.js', '1.15.0', { cwd: testDir, pre: true })
+    version!.should.equal('1.16.1-lts')
   })
 
   it('"No lockfile" error should be thrown on list command when there is no lockfile', async () => {


### PR DESCRIPTION
Fixes #906.

Re-use the npm filters in the yarn file. Don't include the peer dependencies, because I wasn't sure about that bit.

Now, `newest`, `greatest`, `minor`, `patch` differ only in the `filterPredicates` function, so this could be extracted. I left it as it was for now, though.