### PR TITLE
npm: fix missing package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "yarn": "^1.22.17"
   },
   "files": [
-    "build/src",
+    "build",
     "!**/test/**"
   ],
   "lockfile-lint": {


### PR DESCRIPTION
Fixes #990. Regression of #982.

Sorry for the regression. First time I see package.json in the build dir :/