### PR TITLE
Lint all source files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     'plugin:import/typescript',
     'raine'
   ],
+  ignorePatterns: ['build'],
   overrides: [
     {
       files: ['**/*.ts'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
     'plugin:import/typescript',
     'raine'
   ],
-  ignorePatterns: ['build'],
   overrides: [
     {
       files: ['**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "cross-env FORCE_COLOR=1 npm-run-all --parallel --aggregate-output lint:*",
     "lint:lockfile": "lockfile-lint",
     "lint:markdown": "markdownlint \"**/*.md\" --ignore node_modules --ignore build --config .markdownlint.js",
-    "lint:src": "eslint --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives src scripts",
+    "lint:src": "eslint --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives .",
     "c8": "c8",
     "prepublishOnly": "npm run build",
     "test": "npm run test:src && npm run test:timeout",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "cross-env FORCE_COLOR=1 npm-run-all --parallel --aggregate-output lint:*",
     "lint:lockfile": "lockfile-lint",
     "lint:markdown": "markdownlint \"**/*.md\" --ignore node_modules --ignore build --config .markdownlint.js",
-    "lint:src": "eslint --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives .",
+    "lint:src": "eslint --cache --cache-location node_modules/.cache/.eslintcache --ignore-path .gitignore --report-unused-disable-directives .",
     "c8": "c8",
     "prepublishOnly": "npm run build",
     "test": "npm run test:src && npm run test:timeout",

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -19,6 +19,8 @@ const bin = path.join(__dirname, '../build/src/bin/cli.js')
 describe('bin', function () {
 
   let last = 0
+
+  /** Gets the temp package file path. */
   function getTempFile() {
     return `test/temp_package${++last}.json`
   }

--- a/test/deep.test.js
+++ b/test/deep.test.js
@@ -23,6 +23,7 @@ describe('--deep', function () {
 
   let last = 0
 
+  /** Gets information about the temporary package file. */
   function getTempPackage() {
     ++last
     const pkgDir = path.join(cwd, `tmp/tmp-pkg-${last}`)
@@ -207,6 +208,8 @@ describe('--deep with nested ncurc files', function () {
   })
 
   it('merge options', () => {
+
+    /** Asserts that merging two options object deep equals the given result object. */
     const eq = (o1, o2, result, opts) => chai.expect(mergeOptions(o1, o2)).to.deep.equal(result)
 
     // trivial cases

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -19,8 +19,7 @@ const doctorTests = path.join(__dirname, 'doctor')
 /** Run the ncu CLI. */
 const ncu = (args, options) => spawn('node', [bin, ...args], options)
 
-// tests that need to be run for npm and yarn
-
+/** Assertions for npm or yarn when tests pass. */
 const testPass = ({ packageManager }) => {
 
   it('upgrade dependencies when tests pass', async function () {
@@ -79,6 +78,7 @@ const testPass = ({ packageManager }) => {
 
 }
 
+/** Assertions for npm or yarn when tests fail. */
 const testFail = ({ packageManager }) => {
 
   it('identify broken upgrade', async function() {

--- a/test/enginesNode.js
+++ b/test/enginesNode.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const chai = require('chai')
 const ncu = require('../src/index')
 

--- a/test/getIgnoredUpgrades.test.js
+++ b/test/getIgnoredUpgrades.test.js
@@ -30,4 +30,3 @@ describe('getIgnoredUpgrades', function () {
     })
   })
 })
-

--- a/test/getPeerDependenciesFromRegistry.test.js
+++ b/test/getPeerDependenciesFromRegistry.test.js
@@ -36,4 +36,3 @@ describe('getPeerDependenciesFromRegistry', function () {
   })
 
 })
-

--- a/test/getPreferredWildcard.test.js
+++ b/test/getPreferredWildcard.test.js
@@ -1,9 +1,6 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const chai = require('chai')
-const ncu = require('../src/index')
 const getPreferredWildcard = require('../src/lib/getPreferredWildcard').default
 
 const should = chai.should()

--- a/test/gitTag.test.js
+++ b/test/gitTag.test.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const chai = require('chai')
 const ncu = require('../src/index')
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,12 +2,10 @@
 
 const fs = require('fs')
 const path = require('path')
-const rimraf = require('rimraf')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const chaiString = require('chai-string')
 const ncu = require('../src/')
-const spawnNpm = require('../src/package-managers/npm').default
 
 chai.use(chaiAsPromised)
 chai.use(chaiString)
@@ -17,9 +15,12 @@ process.env.NCU_TESTS = true
 describe('run', function () {
 
   let last = 0
+
+  /** Gets the temporary package file path. */
   function getTempFile() {
     return `test/temp_package${++last}.json`
   }
+
   it('return promised jsonUpgraded', () => {
     return ncu.run({
       packageData: fs.readFileSync(path.join(__dirname, 'ncu/package.json'), 'utf-8')

--- a/test/isUpgradeable.test.js
+++ b/test/isUpgradeable.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const chai = require('chai')
-const ncu = require('../src/index')
 const isUpgradeable = require('../src/lib/isUpgradeable').default
 
 chai.should()

--- a/test/peer.test.js
+++ b/test/peer.test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const fs = require('fs')
 const path = require('path')
 const rimraf = require('rimraf')
 const chai = require('chai')

--- a/test/queryVersions.test.js
+++ b/test/queryVersions.test.js
@@ -2,7 +2,6 @@
 
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
-const ncu = require('../src/index')
 const queryVersions = require('../src/lib/queryVersions').default
 
 chai.should()


### PR DESCRIPTION
Lint the entire project. Ignore the `build` directory.

Fixes lint errors in previously unlinted tests.