### PR TITLE
tests: fix the mocha config key for extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "mocha": {
     "check-leaks": true,
-    "extensions": [
+    "extension": [
       "js",
       "ts"
     ],

--- a/src/version-util.ts
+++ b/src/version-util.ts
@@ -303,7 +303,7 @@ export const upgradeNpmAlias = (declaration: string, upgraded: string) => {
 /**
  * Returns true if a version declaration is a Github URL with a valid semver version.
  */
-export const isGithubUrl = (declaration: string) => {
+export const isGithubUrl = (declaration: string | null) => {
   if (!declaration) return false
   const parsed = parseGithubUrl(declaration)
   if (!parsed || !parsed.branch) return false
@@ -316,7 +316,7 @@ export const isGithubUrl = (declaration: string) => {
 /**
  * Returns the embedded tag in a Github URL.
  */
-export const getGithubUrlTag = (declaration: string) => {
+export const getGithubUrlTag = (declaration: string | null) => {
   if (!declaration) return null
   const parsed = parseGithubUrl(declaration)
   if (!parsed || !parsed.branch) return null
@@ -333,8 +333,12 @@ export const getGithubUrlTag = (declaration: string) => {
  * @param [options={}]
  * @returns The upgraded dependency declaration (e.g. "1.3.x")
  */
-export function upgradeDependencyDeclaration(declaration: string, latestVersion: string, options: UpgradeOptions = {}) {
+export function upgradeDependencyDeclaration(declaration: string, latestVersion: string | null, options: UpgradeOptions = {}) {
   options.wildcard = options.wildcard || DEFAULT_WILDCARD
+
+  if (!latestVersion) {
+    return declaration
+  }
 
   // parse the latestVersion
   // return original declaration if latestSemver is invalid

--- a/test/version-util.test.ts
+++ b/test/version-util.test.ts
@@ -1,9 +1,7 @@
-'use strict'
-
-const chai = require('chai')
-const chalk = require('chalk')
-const chaiAsPromised = require('chai-as-promised')
-const versionUtil = require('../src/version-util')
+import chai from 'chai'
+import chalk from 'chalk'
+import chaiAsPromised from 'chai-as-promised'
+import * as versionUtil from '../src/version-util'
 
 const should = chai.should()
 
@@ -125,28 +123,28 @@ describe('version-util', () => {
   describe('getPrecision', () => {
 
     it('detect versions as precise as "major"', () => {
-      versionUtil.getPrecision('1').should.equal('major')
+      versionUtil.getPrecision('1')!.should.equal('major')
     })
 
     it('detect versions as precise as "minor"', () => {
-      versionUtil.getPrecision('1.2').should.equal('minor')
+      versionUtil.getPrecision('1.2')!.should.equal('minor')
     })
 
     it('detect versions as precise as "patch"', () => {
-      versionUtil.getPrecision('1.2.3').should.equal('patch')
+      versionUtil.getPrecision('1.2.3')!.should.equal('patch')
     })
 
     it('detect versions as precise as "release"', () => {
-      versionUtil.getPrecision('1.2.3-alpha.1').should.equal('release')
-      versionUtil.getPrecision('1.2.3-beta.1').should.equal('release')
-      versionUtil.getPrecision('1.2.3-rc.1').should.equal('release')
-      versionUtil.getPrecision('1.2.3-alpha').should.equal('release')
-      versionUtil.getPrecision('1.2.3-beta').should.equal('release')
-      versionUtil.getPrecision('1.2.3-rc').should.equal('release')
+      versionUtil.getPrecision('1.2.3-alpha.1')!.should.equal('release')
+      versionUtil.getPrecision('1.2.3-beta.1')!.should.equal('release')
+      versionUtil.getPrecision('1.2.3-rc.1')!.should.equal('release')
+      versionUtil.getPrecision('1.2.3-alpha')!.should.equal('release')
+      versionUtil.getPrecision('1.2.3-beta')!.should.equal('release')
+      versionUtil.getPrecision('1.2.3-rc')!.should.equal('release')
     })
 
     it('detect versions as precise as "build"', () => {
-      versionUtil.getPrecision('1.2.3+build12345').should.equal('build')
+      versionUtil.getPrecision('1.2.3+build12345')!.should.equal('build')
     })
 
   })
@@ -375,12 +373,12 @@ describe('version-util', () => {
     it('find the greatest version at the given semantic versioning level', () => {
       const versions = ['0.1.0', '1.0.0', '1.0.1', '1.1.0', '2.0.1']
 
-      versionUtil.findGreatestByLevel(versions, '1.0.0', 'major').should.equal('2.0.1')
-      versionUtil.findGreatestByLevel(versions, '2.0.0', 'major').should.equal('2.0.1')
-      versionUtil.findGreatestByLevel(versions, '1.0.0', 'minor').should.equal('1.1.0')
-      versionUtil.findGreatestByLevel(versions, '1.1.0', 'minor').should.equal('1.1.0')
-      versionUtil.findGreatestByLevel(versions, '1.0.0', 'patch').should.equal('1.0.1')
-      versionUtil.findGreatestByLevel(versions, '1.0.1', 'patch').should.equal('1.0.1')
+      versionUtil.findGreatestByLevel(versions, '1.0.0', 'major')!.should.equal('2.0.1')
+      versionUtil.findGreatestByLevel(versions, '2.0.0', 'major')!.should.equal('2.0.1')
+      versionUtil.findGreatestByLevel(versions, '1.0.0', 'minor')!.should.equal('1.1.0')
+      versionUtil.findGreatestByLevel(versions, '1.1.0', 'minor')!.should.equal('1.1.0')
+      versionUtil.findGreatestByLevel(versions, '1.0.0', 'patch')!.should.equal('1.0.1')
+      versionUtil.findGreatestByLevel(versions, '1.0.1', 'patch')!.should.equal('1.0.1')
     })
 
     it('handle wildcards', () => {
@@ -395,7 +393,7 @@ describe('version-util', () => {
 
     it('sort version list', () => {
       const versions = ['0.1.0', '0.3.0', '0.2.0']
-      versionUtil.findGreatestByLevel(versions, '0.1.0', 'minor').should.equal('0.3.0')
+      versionUtil.findGreatestByLevel(versions, '0.1.0', 'minor')!.should.equal('0.3.0')
     })
 
   })
@@ -427,7 +425,7 @@ describe('version-util', () => {
     describe('parseNpmAlias', () => {
 
       it('parse an npm alias into [name, version]', () => {
-        versionUtil.parseNpmAlias('npm:chalk@1.0.0').should.eql(['chalk', '1.0.0'])
+        versionUtil.parseNpmAlias('npm:chalk@1.0.0')!.should.eql(['chalk', '1.0.0'])
       })
 
       it('return null if given a non-alias', () => {
@@ -452,7 +450,7 @@ describe('version-util', () => {
     describe('upgradeNpmAlias', () => {
 
       it('replace embedded version', () => {
-        versionUtil.upgradeNpmAlias('npm:chalk@^1.0.0', '2.0.0')
+        versionUtil.upgradeNpmAlias('npm:chalk@^1.0.0', '2.0.0')!
           .should.equal('npm:chalk@2.0.0')
       })
 


### PR DESCRIPTION
Additionally, move one test to typescript as proof.

It might be better to target ".test.js" and ".test.ts" and enable "recursive", which should prevent you from needing to specify the package manager tests by themselves (when appropriately renamed).