### PR TITLE
chore: update commander to latest major

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -3,9 +3,6 @@ module.exports = {
 
     'cint',
 
-    // breaking changes (just need to spend some time to fix them)
-    'commander',
-
     // "Must use import to load ES Module"
     // These can be removed once the tests are converted to Typescript
     'find-up',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "^4.1.2",
         "cint": "^8.2.1",
         "cli-table": "^0.3.6",
-        "commander": "^6.2.1",
+        "commander": "^8.3.0",
         "fast-memoize": "^2.5.2",
         "find-up": "5.0.0",
         "fp-and-or": "^0.1.3",
@@ -1490,11 +1490,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 12"
       }
     },
     "node_modules/comment-parser": {
@@ -7789,9 +7789,9 @@
       }
     },
     "commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
     },
     "comment-parser": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "chalk": "^4.1.2",
     "cint": "^8.2.1",
     "cli-table": "^0.3.6",
-    "commander": "^6.2.1",
+    "commander": "^8.3.0",
     "fast-memoize": "^2.5.2",
     "find-up": "5.0.0",
     "fp-and-or": "^0.1.3",

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import program from 'commander'
+import { program } from 'commander'
 import _ from 'lodash'
 import updateNotifier from 'update-notifier'
 import ncu from '../index'
@@ -61,12 +61,14 @@ program.version(pkg.version)
 
 program.parse(process.argv)
 
-const { configFileName, configFilePath, packageFile, mergeConfig } = program
+let programOpts = program.opts()
+
+const { configFileName, configFilePath, packageFile, mergeConfig } = programOpts
 
 // load .ncurc
 // Do not load when global option is set
 // Do not load when tests are running (an be overridden if configFilePath is set explicitly, or --mergeConfig option specified)
-const rcResult = !program.global && (!process.env.NCU_TESTS || configFilePath || mergeConfig)
+const rcResult = !programOpts.global && (!process.env.NCU_TESTS || configFilePath || mergeConfig)
   ? getNcuRc({ configFileName, configFilePath, packageFile })
   : null
 
@@ -80,6 +82,7 @@ const combinedArguments = rcResult
   : process.argv
 
 program.parse(combinedArguments)
+programOpts = program.opts()
 
 // filter out undefined program options and combine cli options with config file options
 const options = {
@@ -88,7 +91,7 @@ const options = {
     : null,
   ..._.pickBy(program.opts(), value => value !== undefined),
   args: program.args,
-  ...program.filter ? { filter: program.filter } : null,
+  ...programOpts.filter ? { filter: programOpts.filter } : null,
   cli: true,
 }
 


### PR DESCRIPTION
Now that version 12 requires node 12, can bump commander to 8, which also requires node 12.