### PR TITLE
fix getRepoUrl undefined crash

### DIFF
--- a/src/lib/getRepoUrl.ts
+++ b/src/lib/getRepoUrl.ts
@@ -67,10 +67,14 @@ function getRepoUrl(packageName: string, packageJson?: PackageFile) {
       directory = repositoryMetadata.directory
     }
   }
-
-  return typeof gitURL === 'string' && typeof directory === 'string'
-    ? cleanRepoUrl(hostedGitInfo.fromUrl(gitURL)!.browse(directory))
-    : null
+  
+  if (typeof gitURL === 'string' && typeof directory === 'string') {
+    const hostedGitURL = hostedGitInfo.fromUrl(gitURL)?.browse(directory)
+    if (hostedGitURL === undefined) {
+      return cleanRepoUrl(hostedGitURL)
+    }
+  }
+  return null
 }
 
 export default getRepoUrl

--- a/src/lib/getRepoUrl.ts
+++ b/src/lib/getRepoUrl.ts
@@ -70,7 +70,7 @@ function getRepoUrl(packageName: string, packageJson?: PackageFile) {
   
   if (typeof gitURL === 'string' && typeof directory === 'string') {
     const hostedGitURL = hostedGitInfo.fromUrl(gitURL)?.browse(directory)
-    if (hostedGitURL === undefined) {
+    if (hostedGitURL !== undefined) {
       return cleanRepoUrl(hostedGitURL)
     }
   }

--- a/src/lib/getRepoUrl.ts
+++ b/src/lib/getRepoUrl.ts
@@ -67,7 +67,7 @@ function getRepoUrl(packageName: string, packageJson?: PackageFile) {
       directory = repositoryMetadata.directory
     }
   }
-  
+
   if (typeof gitURL === 'string' && typeof directory === 'string') {
     const hostedGitURL = hostedGitInfo.fromUrl(gitURL)?.browse(directory)
     if (hostedGitURL !== undefined) {


### PR DESCRIPTION
`fromUrl` can return `undefined` and would crash the script if the git directory was malformed or unrecognized (eg: for an internal/private git repo). This change handles the undefined case.