### PR TITLE
feat: Add retry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ ncu "/^(?!react-).*$/" # windows
                              comma-or-space-delimited list, or /regex/.
 --removeRange                Remove version ranges from the final package
                              version.
+--retry <n>                  Number of times to retry failed requests for
+                             package info. (default: 3)
 --semverLevel <value>        DEPRECATED. Renamed to --target.
 -s, --silent                 Don't output anything (--loglevel silent).
 -t, --target <value>         Target version to upgrade to: latest, newest,

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -284,6 +284,13 @@ As a comparison: without using the --peer option, ncu will suggest the latest ve
     description: 'Remove version ranges from the final package version.'
   },
   {
+    long: 'retry',
+    arg: 'n',
+    description: 'Number of times to retry failed requests for package info.',
+    parse: s => parseInt(s, 10),
+    default: 3,
+  },
+  {
     long: 'semverLevel',
     arg: 'value',
     description: 'DEPRECATED. Renamed to --target.',
@@ -305,13 +312,6 @@ As a comparison: without using the --peer option, ncu will suggest the latest ve
     long: 'timeout',
     arg: 'ms',
     description: 'Global timeout in milliseconds. (default: no global timeout and 30 seconds per npm-registry-fetch).',
-  },
-  {
-    long: 'retry',
-    arg: 'rt',
-    description: 'Global request retries.',
-    parse: s => parseInt(s, 10),
-    default: 2,
   },
   {
     long: 'upgrade',

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -307,6 +307,13 @@ As a comparison: without using the --peer option, ncu will suggest the latest ve
     description: 'Global timeout in milliseconds. (default: no global timeout and 30 seconds per npm-registry-fetch).',
   },
   {
+    long: 'retry',
+    arg: 'rt',
+    description: 'Global request retries.',
+    parse: s => parseInt(s, 10),
+    default: 2,
+  },
+  {
     long: 'upgrade',
     short: 'u',
     description: 'Overwrite package file with upgraded versions instead of just outputting to console.',

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -73,6 +73,7 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
           ...options,
           // upgrade prereleases to newer prereleases by default
           pre: options.pre != null ? options.pre : isPre(version),
+          retry: options.retry ?? 2,
         })
         versionNew = npmAlias && versionNew ? createNpmAlias(name, versionNew) : versionNew
       }

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -174,6 +174,7 @@ export const latest: GetVersion = async (packageName: string, currentVersion: Ve
   const latest = await viewOne(packageName, 'dist-tags.latest', currentVersion, {
     registry: options.registry,
     timeout: options.timeout,
+    retry: options.retry,
   }) as unknown as Packument // known type based on dist-tags.latest
 
   // latest should not be deprecated

--- a/src/types.ts
+++ b/src/types.ts
@@ -289,6 +289,11 @@ export interface RunOptions {
   timeout?: number,
 
   /**
+   * Global request retries. (default: 3).
+   */
+  retry?: number,
+
+  /**
    * Overwrite package file with upgraded versions instead of just outputting to console.
    */
   upgrade?: boolean,

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,6 +267,11 @@ export interface RunOptions {
   removeRange?: boolean,
 
   /**
+   * Number of times to retry failed requests for package info. (default: 3)
+   */
+  retry?: number,
+
+  /**
    * DEPRECATED. Renamed to --target.
    *
    * @deprecated
@@ -287,11 +292,6 @@ export interface RunOptions {
    * Global timeout in milliseconds. (default: no global timeout and 30 seconds per npm-registry-fetch).
    */
   timeout?: number,
-
-  /**
-   * Global request retries. (default: 3).
-   */
-  retry?: number,
 
   /**
    * Overwrite package file with upgraded versions instead of just outputting to console.


### PR DESCRIPTION
Closes: https://github.com/raineorshine/npm-check-updates/issues/959

This PR adds an option to automatically retry when a query version fails