### PR TITLE
fix: updates hosted-git-info to version 5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "fp-and-or": "^0.1.3",
         "get-stdin": "^8.0.0",
         "globby": "^11.0.4",
-        "hosted-git-info": "^4.1.0",
+        "hosted-git-info": "^5.0.0",
         "json-parse-helpfulerror": "^1.0.3",
         "jsonlines": "^0.1.1",
         "libnpmconfig": "^1.2.1",
@@ -3078,14 +3078,22 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.0.0.tgz",
+      "integrity": "sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==",
       "dependencies": {
-        "lru-cache": "^6.0.0"
+        "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+      "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/html-escaper": {
@@ -4576,6 +4584,17 @@
         "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
+    "node_modules/npm-package-arg/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/npm-packlist": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-3.0.0.tgz",
@@ -5309,6 +5328,17 @@
       "dependencies": {
         "json-parse-even-better-errors": "^2.3.0",
         "npm-normalize-package-bin": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/read-package-json/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -8867,11 +8897,18 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.0.0.tgz",
+      "integrity": "sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==",
       "requires": {
-        "lru-cache": "^6.0.0"
+        "lru-cache": "^7.5.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+          "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+        }
       }
     },
     "html-escaper": {
@@ -9991,6 +10028,16 @@
         "hosted-git-info": "^4.1.0",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^3.0.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "npm-packlist": {
@@ -10514,6 +10561,14 @@
         "npm-normalize-package-bin": "^1.0.0"
       },
       "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "normalize-package-data": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "fp-and-or": "^0.1.3",
     "get-stdin": "^8.0.0",
     "globby": "^11.0.4",
-    "hosted-git-info": "^4.1.0",
+    "hosted-git-info": "^5.0.0",
     "json-parse-helpfulerror": "^1.0.3",
     "jsonlines": "^0.1.1",
     "libnpmconfig": "^1.2.1",


### PR DESCRIPTION
 Version 4.x of hosted-git-info has a dependency on a broken version of the lru-cache module, which causes the error "ReferenceError: AbortController is not defined". The lru-cache module has been fixed, and hosted-g
it-info has been updated to use the fixed version, but that update is only on version 5.x of hosted-git-info. This change updates to version 5.x of hosted-git-info to pull in that fix, although 5.x is a breaking chan
ge, the only breaking aspect is that versions of node prior to 12 LTS are no longer supported. This should not be an issue as npm-check-updates doesn't support older versions of node.