### PR TITLE
Use npx in upgrade message if invoked via npx

### DIFF
--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -156,7 +156,8 @@ async function runLocal(options: Options, pkgData?: Maybe<string>, pkgFile?: May
           })
       }
       else {
-        print(options, `\nRun ${chalk.cyan('ncu -u')} to upgrade ${getPackageFileName(options)}`)
+        const ncuCmd = process.env.npm_lifecycle_event === 'npx' ? 'npx npm-check-updates' : 'ncu'
+        print(options, `\nRun ${chalk.cyan(`${ncuCmd} -u`)} to upgrade ${getPackageFileName(options)}`)
       }
     }
 


### PR DESCRIPTION
This pull request checks if npm-check-updates was invoked via `npx npm-check-updates` and adjusts the package.json upgrade message.

This replaces what appears to be the only instance of `ncu` which is part of a complete command in output, it doesn't seem to make sense to replace other instances of `ncu` in output and help messages.

Relates to https://github.com/raineorshine/npm-check-updates/issues/626.