### PR TITLE
chore: type Target using string literals and export type RunOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,3 +145,5 @@ export async function run(runOptions: RunOptions = {}, { cli }: { cli?: boolean 
 }
 
 export default run
+
+export type { RunOptions }

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -6,7 +6,7 @@ import { deepPatternPrefix } from '../constants'
 import programError from './programError'
 import getPackageFileName from './getPackageFileName'
 import { print } from '../logging'
-import { Options, RunOptions } from '../types'
+import { Options, RunOptions, Target } from '../types'
 
 /** Initializes, validates, sets defaults, and consolidates program options. */
 function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): Options {
@@ -76,9 +76,9 @@ function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): O
     programError(options, chalk.red(`Cannot specify both --packageFile and --deep. --deep is an alias for --packageFile '${deepPatternPrefix}package.json'`))
   }
 
-  const target = options.newest ? 'newest'
+  const target: Target = options.newest ? 'newest'
     : options.greatest ? 'greatest'
-    : options.target || options.semverLevel || 'latest'
+    : options.target || (options as any).semverLevel || 'latest'
 
   const autoPre = target === 'newest' || target === 'greatest'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,8 @@ export type FilterFunction = (packageName: string, versionRange: SemVer[]) => bo
 export type FilterRejectPattern = string | string[] | RegExp | RegExp[] | FilterFunction
 
 export type TargetFunction = (packageName: string, versionRange: SemVer[]) => string
-export type Target = string | TargetFunction
+export type TargetString = 'latest' | 'newest' | 'greatest' | 'minor' | 'patch'
+export type Target = TargetString | TargetFunction
 
 export interface Packument {
   name: string,

--- a/test/queryVersions.test.ts
+++ b/test/queryVersions.test.ts
@@ -41,7 +41,7 @@ describe('queryVersions', function () {
   })
 
   it('return an error for an unsupported target', () => {
-    const a = queryVersions({ async: '1.5.1' }, { target: 'foo', loglevel: 'silent' })
+    const a = queryVersions({ async: '1.5.1' }, { target: 'foo', loglevel: 'silent' } as any)
     return a.should.be.rejected
   })
 


### PR DESCRIPTION
I'm using this tool programmatically to maintain package versions in a mono repo and had to provide my own types for RunOptions and additional typing for the explicit strings that are allowed for `Target`.  Would be great if I can just grab these from the library. 