### PR TITLE
Breaking change! camelcase `logLevel` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ ncu "/^(?!react-).*$/" # windows
                              `devDependencies`, `optionalDependencies`, etc
                              of the new package data.
 --jsonUpgraded               Output upgraded dependencies in json.
--l, --loglevel <n>           Amount to log: silent, error, minimal, warn,
+-l, --logLevel <n>           Amount to log: silent, error, minimal, warn,
                              info, verbose, silly. (default: "warn")
 --mergeConfig                Merges nested configs with the root config file
                              for --deep or --packageFile options (default:
@@ -205,7 +205,7 @@ ncu "/^(?!react-).*$/" # windows
 --retry <n>                  Number of times to retry failed requests for
                              package info. (default: 3)
 --semverLevel <value>        DEPRECATED. Renamed to --target.
--s, --silent                 Don't output anything (--loglevel silent).
+-s, --silent                 Don't output anything (--logLevel silent).
 -t, --target <value>         Target version to upgrade to: latest, newest,
                              greatest, minor, patch. Run "ncu --help
                              --target" for details.` (default: "latest")
@@ -300,7 +300,7 @@ console.log(upgraded) // { "mypackage": "^2.0.0", ... }
 ## Known Issues
 
 - If `ncu` prints output that does not seem related to this package, it may be conflicting with another executable such as `ncu-weather-cli` or Nvidia CUDA. Try using the long name instead: `npm-check-updates`.
-- Windows: If npm-check-updates hangs, try setting the package file explicitly: `ncu --packageFile package.json`. You can run `ncu --loglevel verbose` to confirm that it was incorrectly waiting for stdin. See [#136](https://github.com/raineorshine/npm-check-updates/issues/136#issuecomment-155721102).
+- Windows: If npm-check-updates hangs, try setting the package file explicitly: `ncu --packageFile package.json`. You can run `ncu --logLevel verbose` to confirm that it was incorrectly waiting for stdin. See [#136](https://github.com/raineorshine/npm-check-updates/issues/136#issuecomment-155721102).
 
 ## Problems?
 

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -226,7 +226,7 @@ As a comparison: without using the --peer option, ncu will suggest the latest ve
     description: 'Output upgraded dependencies in json.',
   },
   {
-    long: 'loglevel',
+    long: 'logLevel',
     short: 'l',
     arg: 'n',
     description: 'Amount to log: silent, error, minimal, warn, info, verbose, silly.',
@@ -317,7 +317,7 @@ As a comparison: without using the --peer option, ncu will suggest the latest ve
   {
     long: 'silent',
     short: 's',
-    description: 'Don\'t output anything (--loglevel silent).',
+    description: 'Don\'t output anything (--logLevel silent).',
   },
   {
     long: 'target',

--- a/src/lib/getIgnoredUpgrades.ts
+++ b/src/lib/getIgnoredUpgrades.ts
@@ -6,7 +6,7 @@ import { IgnoredUpgrade, Index, Options, Version, VersionSpec } from '../types'
 export async function getIgnoredUpgrades(current: Index<VersionSpec>, upgraded: Index<VersionSpec>, upgradedPeerDependencies: Index<Index<Version>>, options: Options = {}) {
   const [upgradedLatestVersions, latestVersions] = await upgradePackageDefinitions(
     current,
-    { ...options, peer: false, peerDependencies: undefined, loglevel: 'silent' }
+    { ...options, peer: false, peerDependencies: undefined, logLevel: 'silent' }
   )
 
   return Object.entries(upgradedLatestVersions)

--- a/src/lib/getPeerDependenciesFromRegistry.ts
+++ b/src/lib/getPeerDependenciesFromRegistry.ts
@@ -15,7 +15,7 @@ async function getPeerDependenciesFromRegistry(packageMap: Index<VersionSpec>, o
 
   const numItems = Object.keys(packageMap).length
   let bar: ProgressBar
-  if (!options.json && options.loglevel !== 'silent' && options.loglevel !== 'verbose' && numItems > 0) {
+  if (!options.json && options.logLevel !== 'silent' && options.logLevel !== 'verbose' && numItems > 0) {
     bar = new ProgressBar('[:bar] :current/:total :percent', { total: numItems, width: 20 })
     bar.render()
   }

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -25,7 +25,7 @@ function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): O
     // set default options that are specific to module usage
     const moduleDefaults: Options = {
       jsonUpgraded: true,
-      silent: runOptions.silent || runOptions.loglevel === undefined,
+      silent: runOptions.silent || runOptions.logLevel === undefined,
       args: []
     }
 
@@ -38,13 +38,13 @@ function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): O
     ...runOptions.packageData && typeof runOptions.packageData !== 'string' ? { packageData: JSON.stringify(runOptions.packageData, null, 2) } : null,
   } as Options
 
-  const loglevel = options.silent ? 'silent' : options.loglevel
+  const logLevel = options.silent ? 'silent' : options.logLevel
 
   const json = Object.keys(options)
     .filter(option => option.startsWith('json'))
     .some(_.propertyOf(options))
 
-  if (!json && loglevel !== 'silent' && options.rcConfigPath && !options.doctor) {
+  if (!json && logLevel !== 'silent' && options.rcConfigPath && !options.doctor) {
     print(options, `Using config file ${options.rcConfigPath}`)
   }
 
@@ -101,8 +101,8 @@ function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): O
     ...format.length > 0 ? { format } : null,
     // add shortcut for any keys that start with 'json'
     json,
-    // convert silent option to loglevel silent
-    loglevel,
+    // convert silent option to logLevel silent
+    logLevel,
     minimal: options.minimal === undefined ? false : options.minimal,
     // default to false, except when newest or greatest are set
     ...options.pre != null || autoPre

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -24,7 +24,7 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
   const packageManager = getPackageManager(options.packageManager)
 
   let bar: ProgressBar
-  if (!options.json && options.loglevel !== 'silent' && options.loglevel !== 'verbose' && packageList.length > 0) {
+  if (!options.json && options.logLevel !== 'silent' && options.logLevel !== 'verbose' && packageList.length > 0) {
     bar = new ProgressBar('[:bar] :current/:total :percent', { total: packageList.length, width: 20 })
     bar.render()
   }

--- a/src/lib/upgradePackageDefinitions.ts
+++ b/src/lib/upgradePackageDefinitions.ts
@@ -29,7 +29,7 @@ export async function upgradePackageDefinitions(currentDependencies: Index<Versi
     if (!_.isEqual(options.peerDependencies, peerDependencies)) {
       const [newUpgradedDependencies, newLatestVersions, newPeerDependencies] = await upgradePackageDefinitions(
         { ...currentDependencies, ...filteredUpgradedDependencies },
-        { ...options, peerDependencies, loglevel: 'silent' }
+        { ...options, peerDependencies, logLevel: 'silent' }
       )
       return [
         { ...filteredUpgradedDependencies, ...newUpgradedDependencies },

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -20,25 +20,25 @@ const logLevels = {
 }
 
 /**
- * Prints a message if it is included within options.loglevel.
+ * Prints a message if it is included within options.logLevel.
  *
- * @param options    Command line options. These will be compared to the loglevel parameter to determine if the message gets printed.
+ * @param options    Command line options. These will be compared to the logLevel parameter to determine if the message gets printed.
  * @param message    The message to print
- * @param loglevel   silent|error|warn|info|verbose|silly
+ * @param logLevel   silent|error|warn|info|verbose|silly
  * @param method     The console method to call. Default: 'log'.
  */
-export function print(options: Options, message: any, loglevel: 'silent' | 'error' | 'warn' | 'info' | 'verbose' | 'silly' | null = null, method: 'log' | 'warn' | 'info' | 'error' = 'log') {
+export function print(options: Options, message: any, logLevel: 'silent' | 'error' | 'warn' | 'info' | 'verbose' | 'silly' | null = null, method: 'log' | 'warn' | 'info' | 'error' = 'log') {
   // not in json mode
   // not silent
-  // not at a loglevel under minimum specified
-  if (!options.json && options.loglevel !== 'silent' && (loglevel == null || logLevels[options.loglevel as unknown as keyof typeof logLevels] >= logLevels[loglevel])) {
+  // not at a logLevel under minimum specified
+  if (!options.json && options.logLevel !== 'silent' && (logLevel == null || logLevels[options.logLevel as unknown as keyof typeof logLevels] >= logLevels[logLevel])) {
     console[method](message)
   }
 }
 
 /** Pretty print a JSON object. */
 export function printJson(options: Options, object: any) {
-  if (options.loglevel !== 'silent') {
+  if (options.logLevel !== 'silent') {
     console.log(JSON.stringify(object, null, 2))
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,7 +197,7 @@ export interface RunOptions {
   /**
    * Amount to log: silent, error, minimal, warn, info, verbose, silly. (default: "warn")
    */
-  loglevel?: string,
+  logLevel?: string,
 
   /**
    * Merges nested configs with the root config file for --deep or --packageFile options (default: false)
@@ -286,7 +286,7 @@ export interface RunOptions {
   semverLevel?: string,
 
   /**
-   * Don't output anything (--loglevel silent).
+   * Don't output anything (--logLevel silent).
    */
   silent?: boolean,
 

--- a/test/queryVersions.test.ts
+++ b/test/queryVersions.test.ts
@@ -9,46 +9,46 @@ process.env.NCU_TESTS = 'true'
 describe('queryVersions', function () {
 
   it('valid single package', () => {
-    const latestVersions = queryVersions({ async: '1.5.1' }, { loglevel: 'silent' })
+    const latestVersions = queryVersions({ async: '1.5.1' }, { logLevel: 'silent' })
     return latestVersions.should.eventually.have.property('async')
   })
 
   it('valid packages', () => {
-    const latestVersions = queryVersions({ async: '1.5.1', npm: '3.10.3' }, { loglevel: 'silent' })
+    const latestVersions = queryVersions({ async: '1.5.1', npm: '3.10.3' }, { logLevel: 'silent' })
     latestVersions.should.eventually.have.property('async')
     latestVersions.should.eventually.have.property('npm')
     return latestVersions
   })
 
   it('unavailable packages should be ignored', () => {
-    return queryVersions({ abchdefntofknacuifnt: '1.2.3' }, { loglevel: 'silent' })
+    return queryVersions({ abchdefntofknacuifnt: '1.2.3' }, { logLevel: 'silent' })
       .should.eventually.deep.equal({})
   })
 
   it('local file urls should be ignored', () => {
-    return queryVersions({ 'eslint-plugin-internal': 'file:devtools/eslint-rules' }, { loglevel: 'silent' })
+    return queryVersions({ 'eslint-plugin-internal': 'file:devtools/eslint-rules' }, { logLevel: 'silent' })
       .should.eventually.deep.equal({})
   })
 
   it('set the target explicitly to latest', () => {
-    return queryVersions({ async: '1.5.1' }, { target: 'latest', loglevel: 'silent' })
+    return queryVersions({ async: '1.5.1' }, { target: 'latest', logLevel: 'silent' })
       .should.eventually.have.property('async')
   })
 
   it('set the target to greatest', () => {
-    return queryVersions({ async: '1.5.1' }, { target: 'greatest', loglevel: 'silent' })
+    return queryVersions({ async: '1.5.1' }, { target: 'greatest', logLevel: 'silent' })
       .should.eventually.have.property('async')
   })
 
   it('return an error for an unsupported target', () => {
-    const a = queryVersions({ async: '1.5.1' }, { target: 'foo', loglevel: 'silent' } as any)
+    const a = queryVersions({ async: '1.5.1' }, { target: 'foo', logLevel: 'silent' } as any)
     return a.should.be.rejected
   })
 
   it('npm aliases should upgrade the installed package', () => {
     return queryVersions({
       request: 'npm:ncu-test-v2@1.0.0'
-    }, { loglevel: 'silent' })
+    }, { logLevel: 'silent' })
       .should.eventually.deep.equal({
         request: 'npm:ncu-test-v2@2.0.0'
       })
@@ -59,7 +59,7 @@ describe('queryVersions', function () {
     it('github urls should upgrade the embedded version tag', async () => {
       const upgrades = await queryVersions({
         'ncu-test-v2': 'https://github.com/raineorshine/ncu-test-v2#v1.0.0'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
 
       upgrades.should.deep.equal({
         'ncu-test-v2': 'https://github.com/raineorshine/ncu-test-v2#v2.0.0'
@@ -69,7 +69,7 @@ describe('queryVersions', function () {
     it('git+https urls should upgrade the embedded version tag', async () => {
       const upgrades = await queryVersions({
         'ncu-test-v2': 'git+https://github.com/raineorshine/ncu-test-v2#v1.0.0'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
 
       upgrades.should.deep.equal({
         'ncu-test-v2': 'git+https://github.com/raineorshine/ncu-test-v2#v2.0.0'
@@ -81,7 +81,7 @@ describe('queryVersions', function () {
       // this repo has tag "1.0" which is not a valid version
       const upgrades1 = await queryVersions({
         'ncu-test-invalid-tag': 'raineorshine/ncu-test-invalid-tag.git#v3.0.0'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
 
       upgrades1.should.deep.equal({
         'ncu-test-invalid-tag': 'raineorshine/ncu-test-invalid-tag.git#v3.0.5'
@@ -90,7 +90,7 @@ describe('queryVersions', function () {
       // this repo has tag "v0.1.3a" which is not a valid version
       const upgrades2 = await queryVersions({
         'angular-toasty': 'git+https://github.com/raineorshine/ncu-test-v0.1.3a.git#1.0.0'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
 
       upgrades2.should.deep.equal({
         'angular-toasty': 'git+https://github.com/raineorshine/ncu-test-v0.1.3a.git#1.0.7'
@@ -102,7 +102,7 @@ describe('queryVersions', function () {
       const upgrades = await queryVersions({
         // this repo has tag "1.0" which is not valid semver
         'ncu-test-invalid-tag': 'git+https://github.com/raineorshine/ncu-test-simple-tag#v1'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
 
       upgrades.should.deep.equal({
         'ncu-test-invalid-tag': 'git+https://github.com/raineorshine/ncu-test-simple-tag#v3'
@@ -113,7 +113,7 @@ describe('queryVersions', function () {
       const upgrades = await queryVersions({
         // this repo has tag "1.0" which is not valid semver
         'ncu-test-invalid-tag': 'git+https://github.com/raineorshine/ncu-test-no-tags#v1'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
       upgrades.should.deep.equal({})
     })
 
@@ -123,7 +123,7 @@ describe('queryVersions', function () {
         'ncu-test-private': 'https://github.com/ncu-test/ncu-test-private#v999.9.9',
         'ncu-return-version': 'git+https://raineorshine@github.com/ncu-return-version#v999.9.9',
         'ncu-test-v2': '^1.0.0'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
 
       upgrades.should.deep.equal({
         'ncu-test-v2': '2.0.0',
@@ -133,7 +133,7 @@ describe('queryVersions', function () {
     it('github urls should upgrade the embedded semver version range', async () => {
       const upgrades = await queryVersions({
         'ncu-test-v2': 'https://github.com/raineorshine/ncu-test-v2#semver:^1.0.0'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
 
       upgrades.should.deep.equal({
         'ncu-test-v2': 'https://github.com/raineorshine/ncu-test-v2#semver:^2.0.0'
@@ -143,7 +143,7 @@ describe('queryVersions', function () {
     it('github urls should support --target greatest', async () => {
       const upgrades = await queryVersions({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^1.0.0'
-      }, { loglevel: 'silent', target: 'newest' })
+      }, { logLevel: 'silent', target: 'newest' })
 
       upgrades.should.deep.equal({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^2.0.0-beta'
@@ -153,7 +153,7 @@ describe('queryVersions', function () {
     it('github urls should support --target newest', async () => {
       const upgrades = await queryVersions({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^1.0.0'
-      }, { loglevel: 'silent', target: 'newest' })
+      }, { logLevel: 'silent', target: 'newest' })
 
       upgrades.should.deep.equal({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^2.0.0-beta'
@@ -163,7 +163,7 @@ describe('queryVersions', function () {
     it('github urls should support --target minor', async () => {
       const upgrades = await queryVersions({
         'ncu-test-return-version': 'https://github.com/raineorshine/ncu-test-return-version#semver:^0.1.0'
-      }, { loglevel: 'silent', target: 'minor' })
+      }, { logLevel: 'silent', target: 'minor' })
 
       upgrades.should.deep.equal({
         'ncu-test-return-version': 'https://github.com/raineorshine/ncu-test-return-version#semver:^0.2.0'
@@ -173,7 +173,7 @@ describe('queryVersions', function () {
     it('github urls should support --target patch', async () => {
       const upgrades = await queryVersions({
         'ncu-test-return-version': 'https://github.com/raineorshine/ncu-test-return-version#semver:^1.0.0'
-      }, { loglevel: 'silent', target: 'patch' })
+      }, { logLevel: 'silent', target: 'patch' })
 
       upgrades.should.deep.equal({
         'ncu-test-return-version': 'https://github.com/raineorshine/ncu-test-return-version#semver:^1.0.1'
@@ -183,7 +183,7 @@ describe('queryVersions', function () {
     it('github urls should not upgrade embedded semver version ranges to prereleases by default', async () => {
       const upgrades = await queryVersions({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^1.0.0'
-      }, { loglevel: 'silent' })
+      }, { logLevel: 'silent' })
 
       upgrades.should.deep.equal({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^1.0.1'
@@ -194,7 +194,7 @@ describe('queryVersions', function () {
 
       const upgradesNewest = await queryVersions({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^1.0.0'
-      }, { loglevel: 'silent', target: 'newest' })
+      }, { logLevel: 'silent', target: 'newest' })
 
       upgradesNewest.should.deep.equal({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^2.0.0-beta'
@@ -202,7 +202,7 @@ describe('queryVersions', function () {
 
       const upgradesGreatest = await queryVersions({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^1.0.0'
-      }, { loglevel: 'silent', target: 'greatest' })
+      }, { logLevel: 'silent', target: 'greatest' })
 
       upgradesGreatest.should.deep.equal({
         'ncu-test-greatest-not-newest': 'https://github.com/raineorshine/ncu-test-greatest-not-newest#semver:^2.0.0-beta'


### PR DESCRIPTION
CLI option `loglevel` is the only one not using camelcase, but lowercase.

This PR changes it to camelcase: `--logLevel`, `"logLevel": …,`.