### PR TITLE
Fix Yarn `setNpmAuthToken` bug when registry URL contains trailing slash

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -134,6 +134,8 @@ export async function packageAuthorChanged(packageName: string, currentVersion: 
   return false
 }
 
+interface ViewOptions { registry?: string, timeout?: number, retry?: number }
+
 /**
  * Returns an object of specified values retrieved by npm view.
  *
@@ -142,7 +144,7 @@ export async function packageAuthorChanged(packageName: string, currentVersion: 
  * @param               currentVersion
  * @returns             Promised result
  */
-export async function viewMany(packageName: string, fields: string[], currentVersion: Version, { registry, timeout, retry }: { registry?: string, timeout?: number, retry?: number } = {}, retryed = 0, npmConfigLocal?: Index<string | boolean>) {
+export async function viewMany(packageName: string, fields: string[], currentVersion: Version, { registry, timeout, retry }: ViewOptions = {}, retryed = 0, npmConfigLocal?: Index<string | boolean>) {
   if (currentVersion && (!semver.validRange(currentVersion) || versionUtil.isWildCard(currentVersion))) {
     return Promise.resolve({} as Packument)
   }
@@ -185,7 +187,7 @@ export const viewManyMemoized = memoize(viewMany)
  * @param currentVersion
  * @returns            Promised result
  */
-export async function viewOne(packageName: string, field: string, currentVersion: Version, options: Options = {}, npmConfigLocal?: Index<string | boolean>) {
+export async function viewOne(packageName: string, field: string, currentVersion: Version, options: ViewOptions = {}, npmConfigLocal?: Index<string | boolean>) {
   const result = await viewManyMemoized(packageName, [field], currentVersion, options, 0, npmConfigLocal)
   return result && result[field as keyof Packument]
 }

--- a/test/package-managers/yarn/index.test.ts
+++ b/test/package-managers/yarn/index.test.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import * as yarn from '../../../src/package-managers/yarn'
+import { Index } from '../../../src/types'
 
 chai.should()
 chai.use(chaiAsPromised)
@@ -48,4 +49,28 @@ describe('yarn', function () {
       .should.eventually.be.rejectedWith(lockFileErrorMessage)
   })
 
+  describe('setNpmAuthToken', () => {
+    /** Run the test for the given registry server URL. */
+    function testCore(npmRegistryServer: string): void {
+      const npmConfig: Index<string|boolean> = { '@fortawesome:registry': 'https://npm.fontawesome.com/' }
+      const dep = 'fortawesome'
+      const scopedConfig: yarn.NpmScope = {
+        npmAlwaysAuth: true,
+        npmAuthToken: 'MY-AUTH-TOKEN',
+        npmRegistryServer
+      }
+
+      yarn.setNpmAuthToken(npmConfig, [dep, scopedConfig])
+
+      npmConfig['//npm.fontawesome.com/:_authToken'].should.equal('MY-AUTH-TOKEN')
+    }
+
+    it('npmRegistryServer does not have trailing slash', () => {
+      testCore('https://npm.fontawesome.com')
+    })
+
+    it('npmRegistryServer has trailing slash', () => {
+      testCore('https://npm.fontawesome.com/')
+    })
+  })
 })


### PR DESCRIPTION
Closes #1109. 

- The error occurred if the `npmRegistryServer` in `.yarnrc.yml` contained a trailing slash. 
- This caused the `setNpmAuthToken` function in `yarn.ts` to add the key `//npm.fontawesome.com//:_authToken` to the `npmConfig`.
- The double slash before `:_authToken` is incorrect and resulted in the auth token not being included in the request.