### PR TITLE
Sort latest packages so 1.10.x comes after 1.9.x

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -340,10 +340,7 @@ export const latest: GetVersion = async (packageName, currentVersion, options = 
   // or latest is deprecated
   // find the next valid version
   // known type based on dist-tags.latest
-  const versions = await viewOne(packageName, 'versions', currentVersion) as Packument[]
-  const validVersions = _.filter(versions, filterPredicate(options))
-
-  return _.last(validVersions.map(o => o.version)) || null
+  return await greatest(packageName, currentVersion, options)
 }
 
 /**


### PR DESCRIPTION
Fixes a bug where the latest package version isn't identified for due to strings not sorting the same as semver.

We use a private github npm repository (not whatever your "git tags" handler is checking) and I recently noticed several of my packages no longer being detected as out of date. After upgrading `npm-check-updates` from 12.5 to 13, it was still happening, so I poked around a bit in the code. I don't know how long this has been going on (e.g. some packages still detect properly so maybe github occasionally pre-sorts package versions?) but many of my packages with more than a `10` patch release are now showing the latest version as some variant of `1.9.9`.

When debugging [`validVersions`](https://github.com/raineorshine/npm-check-updates/blob/main/src/package-managers/npm.ts#L346) the actual value comes back as:

```json
["1.0.0","1.0.1","1.0.10","1.0.2","1.0.3","1.0.4","1.0.5","1.0.6","1.0.7","1.0.8","1.0.9","1.1.0","1.1.1","1.1.2","1.1.3","1.1.4","1.10.0","1.11.0","1.11.1","1.11.2","1.12.0","1.12.1","1.12.2","1.13.0","1.13.1","1.13.2","1.13.3","1.14.0","1.14.1","1.14.2","1.15.0","1.15.1","1.15.2","1.16.1","1.16.4","1.16.5","1.17.0","1.18.0","1.19.0","1.2.0","1.2.1","1.2.2","1.2.3","1.20.0","1.21.0","1.22.0","1.22.1","1.23.0","1.23.1","1.24.0","1.25.0","1.26.0","1.26.1","1.26.2","1.27.0","1.28.0","1.28.1","1.28.2","1.28.5","1.29.0","1.3.0","1.3.1","1.30.0","1.30.1","1.30.2","1.31.0","1.31.1","1.31.2","1.32.0","1.32.1","1.33.0","1.33.1","1.33.2","1.33.3","1.34.0","1.34.1","1.34.10","1.34.12","1.34.13","1.34.2","1.34.3","1.34.4","1.34.5","1.34.6","1.35.0","1.36.0","1.36.1","1.36.2","1.36.3","1.36.4","1.36.5","1.37.0","1.37.1","1.37.2","1.38.0","1.38.1","1.39.0","1.39.1","1.39.2","1.4.0","1.4.1","1.4.2","1.4.3","1.4.4","1.4.5","1.40.0","1.40.1","1.40.2","1.40.3","1.40.4","1.5.0","1.5.1","1.5.10","1.5.11","1.5.12","1.5.13","1.5.2","1.5.3","1.5.4","1.5.5","1.5.6","1.5.7","1.5.8","1.5.9","1.6.0","1.6.1","1.6.2","1.6.3","1.6.4","1.6.5","1.6.6","1.6.7","1.6.8","1.6.9","1.7.0","1.7.1","1.7.10","1.7.11","1.7.12","1.7.13","1.7.14","1.7.15","1.7.16","1.7.17","1.7.18","1.7.19","1.7.2","1.7.20","1.7.21","1.7.3","1.7.4","1.7.5","1.7.6","1.7.7","1.7.8","1.8.0","1.8.1","1.8.2","1.8.3","1.8.4","1.8.5","1.8.6","1.9.0","1.9.1","1.9.10","1.9.11","1.9.12","1.9.2","1.9.3","1.9.4","1.9.5","1.9.6","1.9.7","1.9.8","1.9.9"]
```

Note that `1.40.4` is present and sorted  after `1.4.5` and after some patch releases, before `1.5.0`.

I applied this fix to the compiled javascript locally, and I've confirmed my packages are now being detected properly as being in need of an update. I'm also not sure if there are other places this needs to be added (or if it's worth backporting the fix to 12.5.x for people who use version pinning and may not notice that 13.x has been released)
