### PR TITLE
fix: remove semverLevel completely

### DIFF
--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -66,7 +66,7 @@ function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): O
     programError(options, chalk.red(`Cannot specify both --packageFile and --deep. --deep is an alias for --packageFile '${deepPatternPrefix}package.json'`))
   }
 
-  const target: Target = options.target || (options as any).semverLevel || 'latest'
+  const target: Target = options.target || 'latest'
 
   const autoPre = target === 'newest' || target === 'greatest'
 


### PR DESCRIPTION
`semverLevel` was removed in 13.0.0, and cannot be passed in using the CLI or a typed `Options`. Remove it completely.