### PR TITLE
Print error if `ncu --global` is used with Volta installed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,36 @@ import initOptions from './lib/initOptions'
 import programError from './lib/programError'
 import runGlobal from './lib/runGlobal'
 import runLocal from './lib/runLocal'
-import { Index, PackageFile, RunOptions, VersionSpec } from './types'
+import { Index, Options, PackageFile, RunOptions, VersionSpec } from './types'
 
 // exit with non-zero error code when there is an unhandled promise rejection
 process.on('unhandledRejection', err => {
   throw err
 })
+
+/**
+ * Volta is a tool for managing JavaScript tooling like Node and npm. Volta has
+ * its own system for installing global packages which circumvents npm, so
+ * commands like `npm ls -g` do not accurately reflect what is installed.
+ *
+ * The ability to use `npm ls -g` is tracked in this Volta issue: https://github.com/volta-cli/volta/issues/1012
+ */
+function checkIfVolta(options: Options): void {
+  // The first check is for macOS/Linux and the second check is for Windows
+  if (options.global && (!!process.env.VOLTA_HOME || process.env.PATH?.includes('\\Volta'))) {
+    const message =
+      'It appears you are using Volta. `npm-check-updates --global` ' +
+      'cannot be used with Volta because Volta has its own system for ' +
+      'managing global packages which circumvents npm.\n\n' +
+      'If you are still receiving this message after uninstalling Volta, ' +
+      'ensure your PATH does not contain an entry for Volta and your ' +
+      'shell profile does not define VOLTA_HOME. You may need to reboot ' +
+      'for changes to your shell profile to take effect.'
+
+    print(options, message, 'error')
+    process.exit(1)
+  }
+}
 
 /** Main entry point.
  *
@@ -35,6 +59,8 @@ export async function run(runOptions: RunOptions = {}, { cli }: { cli?: boolean 
   const chalk = runOptions.color ? new Chalk.Instance({ level: 1 }) : Chalk
 
   const options = initOptions(runOptions, { cli })
+
+  checkIfVolta(options)
 
   print(options, 'Initializing', 'verbose')
 


### PR DESCRIPTION
Closes #1072.

I discovered that Volta has its own fancy system for installing global packages, and that this results in `npm ls -g` returning inaccurate / incomplete results. In particular, `npm ls -g` will typically show a different version of npm than what has been installed by Volta. 

I don't think npm-check-updates should be expected to work in cases where even npm itself does not know what packages are installed. So I've added a check that aborts the program if Volta is installed. Volta has its own CLI for managing globally-installed tools, so Volta users can just use that rather than npm-check-updates.

npm-check-updates should still work fine even if Volta is used as long as the `--global` option is not passed.

Tested on Ubuntu and Windows.