### PR TITLE
Make it build on Windows by removing `chmod` from `build:ts` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "main": "build/src/index.js",
   "scripts": {
     "build": "npm run build:ts && npm run build:readme",
-    "build:ts": "tsc && chmod u+x ./build/src/bin/cli.js",
+    "build:ts": "tsc",
     "build:readme": "node scripts/buildReadme.js",
     "lint": "cross-env FORCE_COLOR=1 npm-run-all --parallel --aggregate-output lint:*",
     "lint:lockfile": "lockfile-lint",


### PR DESCRIPTION
It's useful to be able to run all of a project's scripts on Windows for two reasons:

- Some contributors will only have access to a Windows PC
- It can be necessary to run the project on Windows for testing or to fix Windows-specific bugs

The `build:ts` script was failing on Windows because `chmod` is only available on Unix. I fixed this by removing the call to `chmod`. This is OK because:

- `cli.js` is still marked as executable when downloading npm-check-updates from the npm registry. I verified this by publishing the package at `@srmagura/npm-check-updates`, downloading it on Linux, and looking at the permissions on `cli.js`.
- If you want to run npm-check-updates in development, you can just do `npm run ncu`.