### PR TITLE
Add `determinePackageManager`, fix Yarn detection when using workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prepare": "husky install",
     "prepublishOnly": "npm run build",
     "prettier": "prettier .",
+    "mocha": "mocha",
     "test": "npm run test:src && npm run test:timeout",
     "test:src": "mocha test src/test test/package-managers/npm test/package-managers/yarn test/package-managers/staticRegistry",
     "test:timeout": "mocha --exit test/timeout",

--- a/src/lib/determinePackageManager.test.ts
+++ b/src/lib/determinePackageManager.test.ts
@@ -1,0 +1,87 @@
+import chai from 'chai'
+import { determinePackageManager } from './determinePackageManager'
+
+chai.should()
+
+it('returns options.packageManager if set', () => {
+  determinePackageManager({ packageManager: 'fake' }).should.equal('fake')
+})
+
+it('returns yarn if yarn.lock exists in cwd', () => {
+  /** Mock for filesystem calls. */
+  function readdirSyncMock(path: string): string[] {
+    switch (path) {
+      case '/home/test-repo':
+        return ['yarn.lock']
+    }
+
+    throw new Error(`Mock cannot handle path: ${path}.`)
+  }
+
+  determinePackageManager(
+    {
+      cwd: '/home/test-repo',
+    },
+    readdirSyncMock,
+  ).should.equal('yarn')
+})
+
+it('returns yarn if yarn.lock exists in an ancestor directory', () => {
+  /** Mock for filesystem calls. */
+  function readdirSyncMock(path: string): string[] {
+    switch (path) {
+      case '/home/test-repo/packages/package-a':
+        return ['index.ts']
+      case '/home/test-repo/packages':
+        return []
+      case '/home/test-repo':
+        return ['yarn.lock']
+    }
+
+    throw new Error(`Mock cannot handle path: ${path}.`)
+  }
+
+  determinePackageManager(
+    {
+      cwd: '/home/test-repo/packages/package-a',
+    },
+    readdirSyncMock,
+  ).should.equal('yarn')
+})
+
+it('returns npm if package-lock.json found before yarn.lock', () => {
+  /** Mock for filesystem calls. */
+  function readdirSyncMock(path: string): string[] {
+    switch (path) {
+      case '/home/test-repo/packages/package-a':
+        return ['index.ts']
+      case '/home/test-repo/packages':
+        return ['package-lock.json']
+      case '/home/test-repo':
+        return ['yarn.lock']
+    }
+
+    throw new Error(`Mock cannot handle path: ${path}.`)
+  }
+
+  determinePackageManager(
+    {
+      cwd: '/home/test-repo/packages/package-a',
+    },
+    readdirSyncMock,
+  ).should.equal('npm')
+})
+
+it('does not loop infinitely if no lockfile found', () => {
+  /** Mock for filesystem calls. */
+  function readdirSyncMock(): string[] {
+    return []
+  }
+
+  determinePackageManager(
+    {
+      cwd: '/home/test-repo/packages/package-a',
+    },
+    readdirSyncMock,
+  ).should.equal('npm')
+})

--- a/src/lib/determinePackageManager.ts
+++ b/src/lib/determinePackageManager.ts
@@ -1,0 +1,49 @@
+import fs from 'fs'
+import path from 'path'
+import { print } from '../logging'
+import { Options } from '../types/Options'
+
+const defaultPackageManager = 'npm'
+
+/**
+ * If the packageManager option was not provided, look at the lockfiles to
+ * determine which package manager is being used.
+ *
+ * @param readdirSync This is only a parameter so that it can be used in tests.
+ */
+export function determinePackageManager(
+  options: Options,
+  readdirSync: (_path: string) => string[] = fs.readdirSync,
+): string {
+  if (options.packageManager) return options.packageManager
+  if (options.global) return defaultPackageManager
+
+  try {
+    let currentPath: string
+
+    if (options.cwd) {
+      currentPath = options.cwd
+    } else if (options.packageFile) {
+      currentPath = path.dirname(options.packageFile)
+    } else {
+      currentPath = '.'
+    }
+
+    // eslint-disable-next-line fp/no-loops
+    while (true) {
+      const files = readdirSync(currentPath)
+
+      if (files.includes('package-lock.json')) return 'npm'
+      if (files.includes('yarn.lock')) return 'yarn'
+
+      const newPath = path.resolve(currentPath, '..')
+      if (newPath === currentPath) break
+
+      currentPath = newPath
+    }
+  } catch (e) {
+    print(options, `Encountered error while determining package manager: ${e}`, 'verbose', 'warn')
+  }
+
+  return defaultPackageManager
+}

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -8,6 +8,7 @@ import { print } from '../logging'
 import { Options } from '../types/Options'
 import { RunOptions } from '../types/RunOptions'
 import { Target } from '../types/Target'
+import { determinePackageManager } from './determinePackageManager'
 
 /** Initializes, validates, sets defaults, and consolidates program options. */
 function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): Options {
@@ -115,11 +116,9 @@ function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): O
 
   const format = options.format || []
 
-  // autodetect yarn
-  const files = fs.readdirSync(options.cwd || '.')
-  const autoYarn =
-    !options.packageManager && !options.global && files.includes('yarn.lock') && !files.includes('package-lock.json')
-  if (autoYarn) {
+  const packageManager = determinePackageManager(options)
+
+  if (!options.packageManager && packageManager === 'yarn') {
     print(options, 'Using yarn')
   }
 
@@ -138,7 +137,7 @@ function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = {}): O
     target,
     // imply upgrade in interactive mode when json is not specified as the output
     ...(options.interactive && options.upgrade === undefined ? { upgrade: !json } : null),
-    ...(!options.packageManager && { packageManager: autoYarn ? 'yarn' : 'npm' }),
+    packageManager,
   }
 }
 


### PR DESCRIPTION
## Issues Addressed

- Resolves https://github.com/raineorshine/npm-check-updates/issues/1120.
- Resolves an issue I noticed during implementation: if the `packageFile` option was passed, the code still looked in `.` (current directory) when checking for a `yarn.lock`. Now it starts looking in the directory of the package file. I believe this is the correct behavior.

## Notes

- I put the new test file in the same directory as the file being tested. This is my preferred pattern ([rationale here](https://kentcdodds.com/blog/colocation)), but I know this differs from the organization used for the other test files in the repo. I'm happy to move the test file if you tell me where it should go.
- I added a `mocha` script to enable running a single test file, e.g. `npm run mocha -- src/lib/determinePackageManager.test.ts`
- If you'd like to test this change against a "real" repository that uses Yarn workspaces, you can clone https://github.com/srmagura/npm-check-updates-1120-test.