### PR TITLE
Update guide message with current options on done

### DIFF
--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -173,7 +173,9 @@ async function runLocal(
         })
       } else {
         const ncuCmd = process.env.npm_lifecycle_event === 'npx' ? 'npx npm-check-updates' : 'ncu'
-        print(options, `\nRun ${chalk.cyan(`${ncuCmd} -u`)} to upgrade ${getPackageFileName(options)}`)
+        const argv = process.argv.slice(2).join(' ')
+        const ncuOptions = argv ? ' ' + argv : argv
+        print(options, `\nRun ${chalk.cyan(`${ncuCmd}${ncuOptions} -u`)} to upgrade ${getPackageFileName(options)}`)
       }
     }
 


### PR DESCRIPTION
This commit will make the instruction command after running it more clear.

For example, with the user case using:
```bash
$ ncu -t minor -u 
```

The best suggestions are:
```bash
Run `ncu -t minor -u` to upgrade package.json
```
instead of (as it is):
```bash
Run `ncu -u` to upgrade package.json
```

After the PR is merged, you get the following output.
![image](https://user-images.githubusercontent.com/9839768/177252972-4a688724-c3da-4c55-ab9d-c9a8379277af.png)
