### PR TITLE
feat: remove scoped package / when pattern without /

### DIFF
--- a/src/lib/filterAndReject.ts
+++ b/src/lib/filterAndReject.ts
@@ -31,7 +31,14 @@ function composeFilter(filterPattern: FilterRejectPattern): (name: string, versi
     // glob string
     else {
       const patterns = filterPattern.split(/[\s,]+/)
-      predicate = (dependencyName: string) => patterns.some(pattern => minimatch(dependencyName, pattern))
+      predicate = (dependencyName: string) =>
+        patterns.some(
+          pattern =>
+            minimatch(dependencyName, pattern) ||
+            (!pattern.includes('/') &&
+              dependencyName.includes('/') &&
+              minimatch(dependencyName.replace(/\//g, '_'), pattern)),
+        )
     }
   }
   // array

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -42,52 +42,47 @@ describe('filter', () => {
   })
 
   it('filter with wildcard for scoped package', async () => {
-    // eslint-disable-next-line jsdoc/require-jsdoc
-    const withFilter = (filter: string[]) =>
-      ncu({
-        packageData: {
-          dependencies: {
-            vite: '1.0.0',
-            '@vitejs/plugin-react': '1.0.0',
-            '@vitejs/plugin-vue': '1.0.0',
-          },
-        },
-        filter,
-      }) as Promise<Index<string>>
-
-    {
-      const upgraded = await withFilter(['vite'])
-      upgraded.should.have.property('vite')
-      upgraded.should.not.have.property('@vitejs/plugin-react')
-      upgraded.should.not.have.property('@vitejs/plugin-vue')
+    const pkg = {
+      dependencies: {
+        vite: '1.0.0',
+        '@vitejs/plugin-react': '1.0.0',
+        '@vitejs/plugin-vue': '1.0.0',
+      },
     }
 
     {
-      const upgraded = await withFilter(['@vite*'])
-      upgraded.should.not.have.property('vite')
-      upgraded.should.have.property('@vitejs/plugin-react')
-      upgraded.should.have.property('@vitejs/plugin-vue')
+      const upgraded = await ncu({ packageData: pkg, filter: ['vite'] })
+      upgraded!.should.have.property('vite')
+      upgraded!.should.not.have.property('@vitejs/plugin-react')
+      upgraded!.should.not.have.property('@vitejs/plugin-vue')
     }
 
     {
-      const upgraded = await withFilter(['*vite*'])
-      upgraded.should.have.property('vite')
-      upgraded.should.have.property('@vitejs/plugin-react')
-      upgraded.should.have.property('@vitejs/plugin-vue')
+      const upgraded = await ncu({ packageData: pkg, filter: ['@vite*'] })
+      upgraded!.should.not.have.property('vite')
+      upgraded!.should.have.property('@vitejs/plugin-react')
+      upgraded!.should.have.property('@vitejs/plugin-vue')
     }
 
     {
-      const upgraded = await withFilter(['*vite*/*react*'])
-      upgraded.should.not.have.property('vite')
-      upgraded.should.have.property('@vitejs/plugin-react')
-      upgraded.should.not.have.property('@vitejs/plugin-vue')
+      const upgraded = await ncu({ packageData: pkg, filter: ['*vite*'] })
+      upgraded!.should.have.property('vite')
+      upgraded!.should.have.property('@vitejs/plugin-react')
+      upgraded!.should.have.property('@vitejs/plugin-vue')
     }
 
     {
-      const upgraded = await withFilter(['*vite*vue*'])
-      upgraded.should.not.have.property('vite')
-      upgraded.should.not.have.property('@vitejs/plugin-react')
-      upgraded.should.have.property('@vitejs/plugin-vue')
+      const upgraded = await ncu({ packageData: pkg, filter: ['*vite*/*react*'] })
+      upgraded!.should.not.have.property('vite')
+      upgraded!.should.have.property('@vitejs/plugin-react')
+      upgraded!.should.not.have.property('@vitejs/plugin-vue')
+    }
+
+    {
+      const upgraded = await ncu({ packageData: pkg, filter: ['*vite*vue*'] })
+      upgraded!.should.not.have.property('vite')
+      upgraded!.should.not.have.property('@vitejs/plugin-react')
+      upgraded!.should.have.property('@vitejs/plugin-vue')
     }
   })
 

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -41,6 +41,56 @@ describe('filter', () => {
     upgraded.should.have.property('lodash.filter')
   })
 
+  it('filter with wildcard for scoped package', async () => {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    const withFilter = (filter: string[]) =>
+      ncu({
+        packageData: {
+          dependencies: {
+            vite: '1.0.0',
+            '@vitejs/plugin-react': '1.0.0',
+            '@vitejs/plugin-vue': '1.0.0',
+          },
+        },
+        filter,
+      }) as Promise<Index<string>>
+
+    {
+      const upgraded = await withFilter(['vite'])
+      upgraded.should.have.property('vite')
+      upgraded.should.not.have.property('@vitejs/plugin-react')
+      upgraded.should.not.have.property('@vitejs/plugin-vue')
+    }
+
+    {
+      const upgraded = await withFilter(['@vite*'])
+      upgraded.should.not.have.property('vite')
+      upgraded.should.have.property('@vitejs/plugin-react')
+      upgraded.should.have.property('@vitejs/plugin-vue')
+    }
+
+    {
+      const upgraded = await withFilter(['*vite*'])
+      upgraded.should.have.property('vite')
+      upgraded.should.have.property('@vitejs/plugin-react')
+      upgraded.should.have.property('@vitejs/plugin-vue')
+    }
+
+    {
+      const upgraded = await withFilter(['*vite*/*react*'])
+      upgraded.should.not.have.property('vite')
+      upgraded.should.have.property('@vitejs/plugin-react')
+      upgraded.should.not.have.property('@vitejs/plugin-vue')
+    }
+
+    {
+      const upgraded = await withFilter(['*vite*vue*'])
+      upgraded.should.not.have.property('vite')
+      upgraded.should.not.have.property('@vitejs/plugin-react')
+      upgraded.should.have.property('@vitejs/plugin-vue')
+    }
+  })
+
   it('filter with negated wildcard', async () => {
     const upgraded = (await ncu({
       packageData: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4067115/180565130-650e869c-01e4-45b8-a563-5b723e22a9f0.png)

the reason for the screenshot is that `minimatch` treats `/` as a directory.
and if we want to update a scoped package, we must use a explicit slash like `*keyword*/*subkeyword*`

a solution may be:
if provided pattern does not include a slash, and the dep is a scoped package with a slash.
then replace `/` with `_`, so `@scope/name` turns to `@scope_name`, so that `*` can finally match the "slash"

an other solution may be, split the `@scope/name` and let split partial to match pattern,
like
```
(!pattern.includes('/') &&
              dependencyName.includes('/') &&
              dependencyName.split('/').some(partial => minimatch(partial, pattern)))
```


