### PR TITLE
feature: cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ ncu "/^(?!react-).*$/" # windows
 ## Options
 
 ```text
+--cache                      Cache versions to the cache file (default:
+                             false)
+--cacheExpiration <time>     Cache expiration in minutes (default: 10)
+--cacheFile <path>           Filepath for the cache file (default:
+                             "~/.ncu-cache.json")
 --color                      Force color in terminal
 --concurrency <n>            Max number of concurrent HTTP requests to
                              registry. (default: 8)

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -1,6 +1,8 @@
 import Table from 'cli-table'
 import sortBy from 'lodash/sortBy'
+import path from 'path'
 import chalk from './lib/chalk'
+import { defaultCacheFile } from './lib/getCacher'
 import { Index } from './types/IndexType'
 
 export interface CLIOption<T = any> {
@@ -272,6 +274,28 @@ As a comparison: without using the --peer option, ncu will suggest the latest ve
 
 // store CLI options separately from bin file so that they can be used to build type definitions
 const cliOptions: CLIOption[] = [
+  {
+    long: 'cache',
+    description: 'Cache versions to the cache file',
+    default: false,
+    type: 'boolean',
+  },
+  {
+    long: 'cacheExpiration',
+    arg: 'time',
+    description: 'Cache expiration in minutes',
+    parse: s => parseInt(s, 10),
+    default: 10,
+    type: 'number',
+  },
+  {
+    long: 'cacheFile',
+    arg: 'path',
+    description: 'Filepath for the cache file',
+    parse: s => (path.isAbsolute(s) ? s : path.join(process.cwd(), s)),
+    default: defaultCacheFile,
+    type: 'string',
+  },
   {
     long: 'color',
     description: 'Force color in terminal',

--- a/src/lib/getCacher.ts
+++ b/src/lib/getCacher.ts
@@ -49,7 +49,7 @@ export default function getCacher(runOptions: RunOptions): Cacher | undefined {
     const expired = checkCacheExpiration(cacheData, runOptions.cacheExpiration)
     if (expired) {
       // reset cache
-      fs.rmSync(cacheFile)
+      fs.promises.rm(cacheFile)
       cacheData = {}
     }
   } catch (error) {
@@ -70,8 +70,8 @@ export default function getCacher(runOptions: RunOptions): Cacher | undefined {
       return cacheData.packages ? cacheData.packages[key] : undefined
     },
     set: (key, value) => {
-      if (!key) return
-      cacheData.packages![key] = value
+      if (!key || !cacheData.packages) return
+      cacheData.packages[key] = value
     },
     save: async () => {
       await fs.promises.writeFile(cacheFile, JSON.stringify(cacheData))

--- a/src/lib/getCacher.ts
+++ b/src/lib/getCacher.ts
@@ -1,0 +1,80 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { CacheData, Cacher } from '../types/Cacher'
+import { RunOptions } from '../types/RunOptions'
+
+/**
+ * Check if cache is expired if timestamp is set
+ *
+ * @param cacheData
+ * @param cacheExpiration
+ * @returns
+ */
+function checkCacheExpiration(cacheData: CacheData, cacheExpiration = 10) {
+  if (typeof cacheData.timestamp !== 'number') {
+    return false
+  }
+
+  const unixMinuteMS = 60 * 1000
+  const expirationLimit = cacheData.timestamp + cacheExpiration * unixMinuteMS
+  return expirationLimit < Date.now()
+}
+
+export const defaultCacheFilename = '.ncu-cache.json'
+export const defaultCacheFile = `~/${defaultCacheFilename}`
+export const resolvedDefaultCacheFile = path.join(os.homedir(), defaultCacheFilename)
+
+/**
+ * The cacher stores key (name + version) - value (new version) pairs
+ * for quick updates across `ncu` calls.
+ *
+ * @returns
+ */
+export default function getCacher(runOptions: RunOptions): Cacher | undefined {
+  if (!runOptions.cache) {
+    return
+  }
+
+  const file = runOptions.cacheFile
+  if (!file) {
+    return
+  }
+  const cacheFile = file === defaultCacheFile ? resolvedDefaultCacheFile : file
+  let cacheData: CacheData = {}
+
+  try {
+    cacheData = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'))
+
+    const expired = checkCacheExpiration(cacheData, runOptions.cacheExpiration)
+    if (expired) {
+      // reset cache
+      fs.rmSync(cacheFile)
+      cacheData = {}
+    }
+  } catch (error) {
+    // ignore file read/parse/remove errors
+  }
+
+  if (typeof cacheData.timestamp !== 'number') {
+    cacheData.timestamp = Date.now()
+  }
+  if (!cacheData.packages) {
+    cacheData.packages = {}
+  }
+
+  return {
+    key: (name, version) => name + version,
+    get: key => {
+      if (!key) return
+      return cacheData.packages ? cacheData.packages[key] : undefined
+    },
+    set: (key, value) => {
+      if (!key) return
+      cacheData.packages![key] = value
+    },
+    save: async () => {
+      await fs.promises.writeFile(cacheFile, JSON.stringify(cacheData))
+    },
+  } as Cacher
+}

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -6,6 +6,7 @@ import { RunOptions } from '../types/RunOptions'
 import { Target } from '../types/Target'
 import determinePackageManager from './determinePackageManager'
 import exists from './exists'
+import getCacher from './getCacher'
 import getPackageFileName from './getPackageFileName'
 import programError from './programError'
 
@@ -41,6 +42,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
     ...(runOptions.packageData && typeof runOptions.packageData !== 'string'
       ? { packageData: JSON.stringify(runOptions.packageData, null, 2) as any }
       : null),
+    cacher: getCacher(runOptions),
     cli,
   }
 

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -141,7 +141,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
     ...(options.interactive && options.upgrade === undefined ? { upgrade: !json } : null),
     packageManager,
   }
-  resolvedOptions.cacher = getCacher(resolvedOptions)
+  resolvedOptions.cacher = await getCacher(resolvedOptions)
 
   return resolvedOptions
 }

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -42,7 +42,6 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
     ...(runOptions.packageData && typeof runOptions.packageData !== 'string'
       ? { packageData: JSON.stringify(runOptions.packageData, null, 2) as any }
       : null),
-    cacher: getCacher(runOptions),
     cli,
   }
 
@@ -126,7 +125,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
     print(options, 'Using yarn')
   }
 
-  return {
+  const resolvedOptions = {
     ...options,
     ...(options.deep ? { packageFile: `**/${getPackageFileName(options)}` } : null),
     ...((options.args || []).length > 0 ? { filter: options.args!.join(' ') } : null),
@@ -142,6 +141,9 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
     ...(options.interactive && options.upgrade === undefined ? { upgrade: !json } : null),
     packageManager,
   }
+  resolvedOptions.cacher = getCacher(resolvedOptions)
+
+  return resolvedOptions
 }
 
 export default initOptions

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -28,19 +28,10 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
   const packageList = Object.keys(packageMap)
   const globalPackageManager = getPackageManager(options.packageManager)
 
-  let bar: ProgressBar
+  let bar: ProgressBar | undefined
   if (!options.json && options.loglevel !== 'silent' && options.loglevel !== 'verbose' && packageList.length > 0) {
     bar = new ProgressBar('[:bar] :current/:total :percent', { total: packageList.length, width: 20 })
     bar.render()
-  }
-
-  /**
-   * Bar utility to avoid code duplication
-   */
-  function barTick() {
-    if (bar) {
-      bar.tick()
-    }
   }
 
   /**
@@ -57,7 +48,7 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
     const cacheKey = options.cacher?.key(name, version)
     const cached = options.cacher?.get(cacheKey)
     if (cached) {
-      barTick()
+      bar?.tick()
 
       return {
         version: cached,
@@ -129,7 +120,7 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
       }
     }
 
-    barTick()
+    bar?.tick()
 
     if (versionNew) {
       options.cacher?.set(cacheKey, versionNew)

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -135,6 +135,7 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
 
   // save cacher only after pMap handles cacher.set
   await options.cacher?.save()
+  options.cacher?.log()
 
   const versionResultObject = keyValueBy(versionResultList, (versionResult, i) =>
     versionResult.version || versionResult.error

--- a/src/types/Cacher.ts
+++ b/src/types/Cacher.ts
@@ -8,4 +8,5 @@ export type Cacher = {
   get(key: string | undefined): string | undefined
   set(key: string | undefined, value: string): void
   save(): Promise<void>
+  log(): void
 }

--- a/src/types/Cacher.ts
+++ b/src/types/Cacher.ts
@@ -1,0 +1,11 @@
+export interface CacheData {
+  timestamp?: number
+  packages?: Record<string, string | undefined>
+}
+
+export type Cacher = {
+  key(name: string, version: string): string
+  get(key: string | undefined): string | undefined
+  set(key: string | undefined, value: string): void
+  save(): Promise<void>
+}

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -1,3 +1,4 @@
+import { Cacher } from './Cacher'
 import { Index } from './IndexType'
 import { RunOptions } from './RunOptions'
 import { VersionSpec } from './VersionSpec'
@@ -5,6 +6,7 @@ import { VersionSpec } from './VersionSpec'
 /** Internal, normalized options for all ncu behavior. Includes RunOptions that are specified in the CLI or passed to the ncu module, as well as meta information including CLI arguments, package information, and ncurc config. */
 export type Options = RunOptions & {
   args?: any[]
+  cacher?: Cacher
   cli?: boolean
   distTag?: string
   json?: boolean

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -6,6 +6,15 @@ import { TargetFunction } from './TargetFunction'
 
 /** Options that can be given on the CLI or passed to the ncu module to control all behavior. */
 export interface RunOptions {
+  /** Cache versions to the cache file */
+  cache?: boolean
+
+  /** Cache expiration in minutes (default: 10) */
+  cacheExpiration?: number
+
+  /** Filepath for the cache file (default: "~/.ncu-cache.json") */
+  cacheFile?: string
+
   /** Force color in terminal */
   color?: boolean
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,10 +1,11 @@
-import chai from 'chai'
+import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import chaiString from 'chai-string'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import * as ncu from '../src/'
+import { resolvedDefaultCacheFile } from '../src/lib/getCacher'
 import { FilterFunction } from '../src/types/FilterFunction'
 import { Index } from '../src/types/IndexType'
 import { TargetFunction } from '../src/types/TargetFunction'
@@ -291,6 +292,69 @@ describe('run', function () {
         },
       }),
     ])
+  })
+
+  describe('cache', () => {
+    /**
+     * Utility
+     */
+    const cacheCleanup = async () => {
+      try {
+        await fs.rm(resolvedDefaultCacheFile)
+      } catch (error) {}
+    }
+
+    it('generates a cache file', async () => {
+      const packageData = {
+        dependencies: {
+          chalk: '^5.0.1',
+          'cli-table': '^0.3.11',
+          commander: '^9.4.0',
+          'fast-memoize': '^2.5.2',
+          'find-up': '5.0.0',
+          'fp-and-or': '^0.1.3',
+          'get-stdin': '^8.0.0',
+          globby: '^11.0.4',
+          'hosted-git-info': '^5.0.0',
+          'json-parse-helpfulerror': '^1.0.3',
+          jsonlines: '^0.1.1',
+          lodash: '^4.17.21',
+          minimatch: '^5.1.0',
+          'p-map': '^4.0.0',
+          pacote: '^13.6.1',
+          'parse-github-url': '^1.0.2',
+          progress: '^2.0.3',
+          'prompts-ncu': '^2.5.1',
+          'rc-config-loader': '^4.1.0',
+          'remote-git-tags': '^3.0.0',
+          rimraf: '^3.0.2',
+          semver: '^7.3.7',
+          'semver-utils': '^1.1.4',
+          'source-map-support': '^0.5.21',
+          'spawn-please': '^1.0.0',
+          'update-notifier': '^6.0.2',
+          yaml: '^2.1.1',
+        },
+      }
+
+      await cacheCleanup()
+
+      await ncu.run({
+        packageData,
+        cache: true,
+      })
+
+      const cacheFileText = await fs.readFile(resolvedDefaultCacheFile, 'utf-8')
+      const cacheFileData = JSON.parse(cacheFileText)
+      expect(cacheFileData.timestamp).lessThanOrEqual(Date.now())
+
+      const packageDataCached = Object.keys(packageData.dependencies)
+        .map(key => cacheFileText.includes(key))
+        .some(value => value !== false)
+      expect(packageDataCached).eq(true)
+
+      await cacheCleanup()
+    })
   })
 
   describe('deprecated', () => {


### PR DESCRIPTION
The `--cache` feature decreases significantly the `ncu` update time (at least 50%) when running `ncu` over multiple projects using similar packages. The feature is especially useful when running `ncu` programatically over many packages in a short amount of time. The `--cacheExpiration` and `--cacheFile` args can be used to control the caching behavior.

Example running `ncu --cache` on a new `create-react-app`:

![ncu-cache](https://user-images.githubusercontent.com/13864427/187747698-2c36c12f-0d6c-4f1f-9b50-af544740698e.png)
