### PR TITLE
Support npm config cafile which includes a tilde

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "semver-utils": "^1.1.4",
         "source-map-support": "^0.5.21",
         "spawn-please": "^1.0.0",
+        "untildify": "^4.0.0",
         "update-notifier": "^6.0.2",
         "yaml": "^2.1.1"
       },
@@ -7590,6 +7591,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
@@ -13559,6 +13568,11 @@
       "requires": {
         "crypto-random-string": "^4.0.0"
       }
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
     },
     "update-browserslist-db": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "semver-utils": "^1.1.4",
     "source-map-support": "^0.5.21",
     "spawn-please": "^1.0.0",
+    "untildify": "^4.0.0",
     "update-notifier": "^6.0.2",
     "yaml": "^2.1.1"
   },

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -13,6 +13,7 @@ import pacote from 'pacote'
 import path from 'path'
 import semver from 'semver'
 import spawn from 'spawn-please'
+import untildify from 'untildify'
 import { keyValueBy } from '../lib/keyValueBy'
 import libnpmconfig from '../lib/libnpmconfig'
 import { print } from '../lib/logging'
@@ -43,7 +44,7 @@ const normalizeNpmConfig = (npmConfig: NpmConfig): NpmConfig => {
       if (!path) return
       // synchronous since it is loaded once on startup, and to avoid complexity in libnpmconfig.read
       // https://github.com/raineorshine/npm-check-updates/issues/636?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDc0Njk2NjAzMjo3NTAyNzY%3D
-      const cadata = fs.readFileSync(path, 'utf8')
+      const cadata = fs.readFileSync(untildify(path), 'utf8')
       const delim = '-----END CERTIFICATE-----'
       const output = cadata
         .split(delim)


### PR DESCRIPTION
**Problem**

npm-check-updates fails when reading in the npm configuration if cafile setting points to a file relative to the user‘s home directory, i.e. starts with a tilde.

**Why**

In corporate environment you often have no direct access to npmjs.org and have to use a proxy instead. As such internal proxies often use self signed certificate, you need to configure npm to use your own ca for verification. It is not unusual to distribute a general .npmrc config file that contains something like

> registry=https://my.private.npm.proxy
> cafile=~/path/to/ca.pem

Where npm is working fine, npm-check-updates fails to locate the ca file as it cannot interpret the tilde for the current user‘s home and exits with an error:

> Error: ENOENT: no such file or directory, open '~/path/to/ca.pem'

This pull request adds the npm module [untildify](https://github.com/sindresorhus/untildify) to convert such kind of path to an absolute one so that the referenced file can be read successfully by ncu.