### PR TITLE
Fix module usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,9 +322,9 @@ For example, `.ncurc.json`:
 npm-check-updates can be imported as a module:
 
 ```js
-import * as ncu from 'npm-check-updates'
+import ncu from 'npm-check-updates'
 
-const upgraded = await ncu.run({
+const upgraded = await ncu({
   // Pass any cli option
   packageFile: '../package.json',
   upgrade: true,

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ For example, `.ncurc.json`:
 npm-check-updates can be imported as a module:
 
 ```js
-import ncu from 'npm-check-updates'
+import * as ncu from 'npm-check-updates'
 
 const upgraded = await ncu.run({
   // Pass any cli option


### PR DESCRIPTION
When using `ncu` as module in TypeScript, follow the docs usage will get a type error:

![image](https://user-images.githubusercontent.com/40221744/192240054-5f6e9873-3610-49ed-8955-0e44620b7a44.png)

Because the type exports of default is only the `run` method.

I think it may better to change the usage to `import * as ncu from 'npm-check-updates'`.