### PR TITLE
build: add missing dependency ini

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "get-stdin": "^8.0.0",
         "globby": "^11.0.4",
         "hosted-git-info": "^5.1.0",
+        "ini": "^3.0.1",
         "json-parse-helpfulerror": "^1.0.3",
         "jsonlines": "^0.1.1",
         "lodash": "^4.17.21",
@@ -2485,6 +2486,11 @@
         "proto-list": "~1.2.1"
       }
     },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "node_modules/configstore": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
@@ -4405,9 +4411,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.1.tgz",
+      "integrity": "sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -6617,6 +6626,11 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -6878,15 +6892,6 @@
       },
       "bin": {
         "run-con": "cli.js"
-      }
-    },
-    "node_modules/run-con/node_modules/ini": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.0.tgz",
-      "integrity": "sha512-TxYQaeNW/N8ymDvwAxPyRbhMBtnEwuvaTYpOQkFx1nSeusgezHniEc/l35Vo4iCq/mMiTJbpD7oYxN98hFlfmw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/run-parallel": {
@@ -9873,6 +9878,13 @@
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+        }
       }
     },
     "configstore": {
@@ -11266,9 +11278,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.1.tgz",
+      "integrity": "sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -12882,6 +12894,11 @@
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+        },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -13083,14 +13100,6 @@
         "ini": "~3.0.0",
         "minimist": "^1.2.6",
         "strip-json-comments": "~3.1.1"
-      },
-      "dependencies": {
-        "ini": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.0.tgz",
-          "integrity": "sha512-TxYQaeNW/N8ymDvwAxPyRbhMBtnEwuvaTYpOQkFx1nSeusgezHniEc/l35Vo4iCq/mMiTJbpD7oYxN98hFlfmw==",
-          "dev": true
-        }
       }
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "get-stdin": "^8.0.0",
     "globby": "^11.0.4",
     "hosted-git-info": "^5.1.0",
+    "ini": "^3.0.1",
     "json-parse-helpfulerror": "^1.0.3",
     "jsonlines": "^0.1.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
We are importing `ini` directly, but missing in dependencies. This will cause an error when installing ncu with pnpm.

https://github.com/raineorshine/npm-check-updates/blob/fd2f566baf7e74a668e94f8e1e14a43966341c4e/src/package-managers/npm.ts#L3

<img width="489" alt="image" src="https://user-images.githubusercontent.com/18205362/198503446-83ba313f-1e8a-48fd-9ed6-c5074c4ae3d5.png">

