### PR TITLE
Add code coverage test-run

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 build/
+coverage/

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prettier": "prettier .",
     "test": "npm run test:src && npm run test:timeout",
     "test:src": "mocha test test/package-managers/npm test/package-managers/yarn test/package-managers/staticRegistry",
+    "test:src:cov": "npm run c8 npm run test:src",
     "test:timeout": "mocha --exit test/timeout",
     "ncu": "node build/src/bin/cli.js"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ const getPackageManagerForInstall = async (options: Options, pkgFile: string) =>
   return pnpm ? 'pnpm' : 'npm'
 }
 
-/** Either suggest an install command based on the package manager, or in interactive mode, prompt to autoinstall. */
+/** Either suggest an install command based on the package manager, or in interactive mode, prompt to auto-install. */
 const npmInstall = async (
   pkgs: string[],
   analysis: Index<PackageFile> | PackageFile,
@@ -85,8 +85,8 @@ const npmInstall = async (
   const someUpgraded = Object.values(analysisNormalized).some(upgrades => Object.keys(upgrades).length > 0)
   if (!someUpgraded) return
 
-  // for the purpose of the install hint, just use the package manager used in the first subproject
-  // if autoinstalling, the actual package manager in each subproject will be used
+  // for the purpose of the install hint, just use the package manager used in the first sub-project
+  // if auto-installing, the actual package manager in each sub-project will be used
   const packageManager = await getPackageManagerForInstall(options, pkgs[0])
 
   // by default, show an install hint after upgrading
@@ -111,7 +111,7 @@ const npmInstall = async (
       },
     })
 
-    // autoinstall
+    // auto-install
     if (response.value) {
       pkgs.forEach(async pkgFile => {
         const packageManager = await getPackageManagerForInstall(options, pkgFile)
@@ -129,7 +129,7 @@ const npmInstall = async (
                     // When pnpm install is run directly from the terminal, this error does not occur.
                     // When pnpm install is run from a simple spawn script, this error does not occur.
                     // The issue only seems to be when pnpm install is executed from npm-check-updates, but it's not clear what configuration or environmental factors are causing this.
-                    // For now, turn off strict-peer-dependencies on pnpm autoinstall.
+                    // For now, turn off strict-peer-dependencies on pnpm auto-install.
                     // See: https://github.com/raineorshine/npm-check-updates/issues/1191
                     npm_config_strict_peer_dependencies: false,
                   },
@@ -149,7 +149,7 @@ const npmInstall = async (
     }
   }
 
-  // show the install hint unless autoinstall occurred
+  // show the install hint unless auto-install occurred
   else {
     print(options, `\n${installHint}.`)
   }
@@ -169,7 +169,7 @@ export async function run(
 ): Promise<PackageFile | Index<VersionSpec> | void> {
   const options = await initOptions(runOptions, { cli })
 
-  // chalk may already have been intialized in cli.ts, but when imported as a module
+  // chalk may already have been initialized in cli.ts, but when imported as a module
   // chalkInit is idempotent
   await chalkInit(options.color)
 
@@ -335,7 +335,7 @@ export async function run(
         printJson(options, analysis)
       }
     } else {
-      // Mutate packageFile when glob patern finds only single package
+      // Mutate packageFile when glob pattern finds only single package
       if (pkgs.length === 1 && pkgs[0] !== defaultPackageFilename) {
         options.packageFile = pkgs[0]
       }
@@ -344,7 +344,7 @@ export async function run(
     }
     clearTimeout(timeout)
 
-    // suggest install command or autoinstall
+    // suggest install command or auto-install
     if (options.upgrade) {
       // if workspaces, install from root project folder
       await npmInstall(isWorkspace ? ['package.json'] : pkgs, analysis, options)

--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -36,7 +36,7 @@ const setupDeepTest = async () => {
   // write root package file
   await fs.writeFile(path.join(tempDir, 'package.json'), pkgData, 'utf-8')
 
-  // write subproject package files
+  // write sub-project package files
   await fs.mkdir(path.join(tempDir, 'packages/sub1'), { recursive: true })
   await fs.writeFile(path.join(tempDir, 'packages/sub1/package.json'), pkgData, 'utf-8')
   await fs.mkdir(path.join(tempDir, 'packages/sub2'), { recursive: true })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -42,7 +42,7 @@ describe('run', function () {
     stub.restore()
   })
 
-  it('do not suggest upgrades to versions within the specified version range if jsonUpgraded is true and minimial is true', async () => {
+  it('do not suggest upgrades to versions within the specified version range if jsonUpgraded is true and minimal is true', async () => {
     const stub = stubNpmView('2.1.1')
 
     const upgraded = await ncu.run({

--- a/test/interactive.test.ts
+++ b/test/interactive.test.ts
@@ -34,7 +34,7 @@ describe('--interactive', () => {
 
       should.equal(/^Upgrading/m.test(stdout), true)
 
-      // do not show install hint when choosing autoinstall
+      // do not show install hint when choosing auto-install
       should.equal(/^Run npm install to install new versions.$/m.test(stdout), false)
 
       const upgradedPkg = JSON.parse(await fs.readFile(pkgFile, 'utf-8'))


### PR DESCRIPTION
chore(coverage): adds code coverage to tests

Rather than replace the existing test, which would require merging the
coverage output of the two test-run phases (`test:src` and `test:timeout`),
we add a new 'test:src:cov' script.

There's a couple of things we notice doing this; the first is that some
of the tests, especially doctor tests, do not report coverage because
they use sub-procs via spawn. This leads us to realise that the
test-types sometimes veer into 'integration' type tests.

We configure the coverage to:
 * cover test-code in addition to run-time code.
 * use high- and low-tide marks that seem reasonable for the library.
 * set a global pass threshold that currently passes but should catch
   most regressions.
 * print coverage results to the console.
 * create a nice html coverage report in './coverage/index.html'.
 * only show the non-fully covered files in text output