### PR TITLE
chore(extra coverage): adds extra coverage for yarn.npmAuthTokenKeyValue

### DIFF
--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -201,7 +201,9 @@ describe('--deep with nested ncurc files', function () {
     deepJsonOut['pkg/sub3/sub32/package.json'].should.have.property('fp-and-or')
     deepJsonOut['pkg/sub3/sub32/package.json'].should.have.property('ncu-test-v2')
   })
+})
 
+describe('mergeOptions', function () {
   it('merge options', () => {
     /** Asserts that merging two options object deep equals the given result object. */
     const eq = (

--- a/test/package-managers/yarn/index.test.ts
+++ b/test/package-managers/yarn/index.test.ts
@@ -1,10 +1,10 @@
-import chai, { should } from 'chai'
+import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import path from 'path'
 import * as yarn from '../../../src/package-managers/yarn'
 import { getPathToLookForYarnrc } from '../../../src/package-managers/yarn'
 
-chai.should()
+const should = chai.should()
 chai.use(chaiAsPromised)
 process.env.NCU_TESTS = 'true'
 
@@ -74,24 +74,24 @@ describe('yarn', function () {
       })
     })
 
-    it('does nothing when no npmAlwaysAuth', () => {
+    it('returns null when no npmAlwaysAuth', () => {
       const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {
         npmAlwaysAuth: true,
         // undefined: npmAuthToken: 'MY-AUTH-TOKEN',
         npmRegistryServer: 'https://npm.fontawesome.com/',
       })
 
-      authToken!.should.deep.equal(null)
+      should.equal(authToken, null)
     })
 
-    it('does nothing when no registry server', () => {
+    it('returns null when no registry server', () => {
       const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {
         npmAlwaysAuth: true,
         npmAuthToken: 'MY-AUTH-TOKEN',
         // undefined: npmRegistryServer: 'https://npm.fontawesome.com/',
       })
 
-      authToken!.should.deep.equal(null)
+      should.equal(authToken, null)
     })
   })
 })
@@ -122,7 +122,7 @@ describe('getPathToLookForLocalYarnrc', () => {
       readdirMock,
     )
 
-    should().exist(yarnrcPath)
+    should.exist(yarnrcPath)
     yarnrcPath!.should.equal(isWindows ? 'C:\\home\\test-repo\\.yarnrc.yml' : '/home/test-repo/.yarnrc.yml')
   })
 })

--- a/test/package-managers/yarn/index.test.ts
+++ b/test/package-managers/yarn/index.test.ts
@@ -73,6 +73,26 @@ describe('yarn', function () {
         '//npm.fontawesome.com/:_authToken': 'MY-AUTH-TOKEN',
       })
     })
+
+    it('does nothing when no npmAlwaysAuth', () => {
+      const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {
+        npmAlwaysAuth: true,
+        // undefined: npmAuthToken: 'MY-AUTH-TOKEN',
+        npmRegistryServer: 'https://npm.fontawesome.com/',
+      })
+
+      authToken!.should.deep.equal(null)
+    })
+
+    it('does nothing when no registry server', () => {
+      const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {
+        npmAlwaysAuth: true,
+        npmAuthToken: 'MY-AUTH-TOKEN',
+        // undefined: npmRegistryServer: 'https://npm.fontawesome.com/',
+      })
+
+      authToken!.should.deep.equal(null)
+    })
   })
 })
 


### PR DESCRIPTION
A couple of commits from a WIP-branch where I was exploring the code.

It just adds and reorganises tests, including moving merge tests out of --deep tests.