### PR TITLE
chore(type): specify that programError() never returns, aiding typing

### DIFF
--- a/src/lib/programError.ts
+++ b/src/lib/programError.ts
@@ -2,7 +2,7 @@ import { print } from '../lib/logging'
 import { Options } from '../types/Options'
 
 /** Print an error. Exit the process if in CLI mode. */
-function programError(options: Options, message: string) {
+function programError(options: Options, message: string): never {
   if (options.cli) {
     print(options, message, null, 'error')
     process.exit(1)


### PR DESCRIPTION
This extra type spec means we don't have to add 'undefined' to functions that don't explicitly return when calling programError()