### PR TITLE
feat: allow switching from pre-releases back to latest

### DIFF
--- a/src/lib/isUpgradeable.ts
+++ b/src/lib/isUpgradeable.ts
@@ -9,9 +9,10 @@ import { fixPseudoVersion, isComparable, isWildCard, stringify } from './version
  *
  * @param current
  * @param latest
+ * @param downgrade  Allow downgrading
  * @returns
  */
-function isUpgradeable(current: VersionSpec, latest: Version) {
+function isUpgradeable(current: VersionSpec, latest: Version, { downgrade }: { downgrade?: boolean } = {}): boolean {
   // do not upgrade non-npm version declarations (such as git tags)
   // do not upgrade wildcards
   if (!semver.validRange(current) || isWildCard(current)) {
@@ -43,7 +44,7 @@ function isUpgradeable(current: VersionSpec, latest: Version) {
     // allow an upgrade if two prerelease versions can't be compared by semver
     (!isComparable(latestNormalized, version) ||
       (!semver.satisfies(latestNormalized, range.operator === '<' ? current : version) &&
-        !semver.ltr(latestNormalized, version)))
+        (downgrade || !semver.ltr(latestNormalized, version))))
   )
 }
 

--- a/src/lib/upgradeDependencies.ts
+++ b/src/lib/upgradeDependencies.ts
@@ -76,7 +76,7 @@ function upgradeDependencies(
     // pick the packages that are upgradeable
     deps =>
       pickBy(deps, ({ current, currentParsed, latest, latestParsed }: any) =>
-        isUpgradeable(currentParsed || current, latestParsed || latest),
+        options.target === '@latest' ? true : isUpgradeable(currentParsed || current, latestParsed || latest),
       ),
     // pack embedded versions: npm aliases and git urls
     deps =>

--- a/src/lib/upgradeDependencies.ts
+++ b/src/lib/upgradeDependencies.ts
@@ -31,6 +31,8 @@ function upgradeDependencies(
   latestVersions: Index<Version>,
   options: Options = {},
 ): Index<VersionSpec> {
+  const targetOption = options.target || 'latest'
+
   // filter out dependencies with empty values
   currentDependencies = filterObject(currentDependencies, (key, value) => !!value)
 
@@ -75,9 +77,13 @@ function upgradeDependencies(
       }),
     // pick the packages that are upgradeable
     deps =>
-      pickBy(deps, ({ current, currentParsed, latest, latestParsed }: any) =>
-        options.target === '@latest' ? true : isUpgradeable(currentParsed || current, latestParsed || latest),
-      ),
+      pickBy(deps, ({ current, currentParsed, latest, latestParsed }: MappedDependencies, name: string) => {
+        // allow downgrades from prereleases when explicit tag is given
+        const downgrade: boolean =
+          versionUtil.isPre(current) &&
+          (typeof targetOption === 'string' ? targetOption : targetOption(name, parseRange(current))).startsWith('@')
+        return isUpgradeable(currentParsed || current, latestParsed || latest, { downgrade })
+      }),
     // pack embedded versions: npm aliases and git urls
     deps =>
       mapValues(deps, ({ current, currentParsed, latest, latestParsed }: MappedDependencies) => {

--- a/src/lib/upgradePackageDefinitions.ts
+++ b/src/lib/upgradePackageDefinitions.ts
@@ -33,6 +33,7 @@ export async function upgradePackageDefinitions(
   )
 
   const upgradedDependencies = upgradeDependencies(currentDependencies, latestVersions, {
+    target: options.target,
     removeRange: options.removeRange,
   })
 

--- a/src/lib/upgradePackageDefinitions.ts
+++ b/src/lib/upgradePackageDefinitions.ts
@@ -32,10 +32,7 @@ export async function upgradePackageDefinitions(
       : null,
   )
 
-  const upgradedDependencies = upgradeDependencies(currentDependencies, latestVersions, {
-    target: options.target,
-    removeRange: options.removeRange,
-  })
+  const upgradedDependencies = upgradeDependencies(currentDependencies, latestVersions, options)
 
   const filteredUpgradedDependencies = pickBy(upgradedDependencies, (v, dep) => {
     return !options.jsonUpgraded || !options.minimal || !satisfies(latestVersions[dep], currentDependencies[dep])

--- a/test/target.test.ts
+++ b/test/target.test.ts
@@ -318,16 +318,54 @@ describe('distTag as target', () => {
     upgraded!.should.not.have.property('ncu-test-tag')
   })
 
-  it('do not downgrade to latest with lower version', async () => {
+  it('do not downgrade to latest with lower version by default', async () => {
     const upgraded = await ncu({
-      target: 'latest',
       packageData: {
         dependencies: {
-          'ncu-test-tag': '1.1.1-beta.0',
+          'ncu-test-tag': '^1.1.1-beta.0',
         },
       },
     })
 
     upgraded!.should.not.have.property('ncu-test-tag')
+  })
+
+  it('do not downgrade to latest with lower version with --target latest', async () => {
+    const upgraded = await ncu({
+      target: 'latest',
+      packageData: {
+        dependencies: {
+          'ncu-test-tag': '^1.1.1-beta.0',
+        },
+      },
+    })
+
+    upgraded!.should.not.have.property('ncu-test-tag')
+  })
+
+  it('downgrade to latest with lower version with explicit --target @latest', async () => {
+    const upgraded = (await ncu({
+      target: '@latest',
+      packageData: {
+        dependencies: {
+          'ncu-test-tag': '^1.1.1-beta.0',
+        },
+      },
+    })) as Index<Version>
+
+    upgraded['ncu-test-tag'].should.equal('^1.1.0')
+  })
+
+  it('downgrade to latest with lower version with target function returning @latest', async () => {
+    const upgraded = (await ncu({
+      target: () => '@latest',
+      packageData: {
+        dependencies: {
+          'ncu-test-tag': '^1.1.1-beta.0',
+        },
+      },
+    })) as Index<Version>
+
+    upgraded['ncu-test-tag'].should.equal('^1.1.0')
   })
 }) // end 'distTag as target'

--- a/test/upgradeDependencies.test.ts
+++ b/test/upgradeDependencies.test.ts
@@ -35,6 +35,12 @@ describe('upgradeDependencies', () => {
     upgradeDependencies({ mongodb: '^2.0.7' }, { mongodb: '1.4.30' }).should.eql({})
   })
 
+  it('allow to update to latest via @latest tag', () => {
+    upgradeDependencies({ mongodb: '^1.5.0-alpha.1' }, { mongodb: '1.4.30' }, { target: '@latest' }).should.eql({
+      mongodb: '^1.4.30',
+    })
+  })
+
   it('use the preferred wildcard when converting <, closed, or mixed ranges', () => {
     upgradeDependencies({ a: '1.*', mongodb: '<1.0' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '3.*' })
     upgradeDependencies({ a: '1.x', mongodb: '<1.0' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '3.x' })


### PR DESCRIPTION
Dear maintainers, 
we discovered a small limitation while we used ncu. We notice it while we tested an actual pre-release on our branch and later after we tested it we liked to switch back to `latest`. Unfortunately that wasn't working out of the box so we hope to enable this functionality by providing this PR.

 
