### PR TITLE
fix: prevent cli tool from choking because of $schema property in rc json file

### DIFF
--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -1,5 +1,6 @@
 import flatten from 'lodash/flatten'
 import map from 'lodash/map'
+import omit from 'lodash/omit'
 import path from 'path'
 import { rcFile } from 'rc-config-loader'
 import { cliOptionsMap } from '../cli-options'
@@ -24,14 +25,17 @@ async function getNcuRc({ color, configFileName, configFilePath, packageFile }: 
   const { default: chalkDefault, Chalk } = await import('chalk')
   const chalk = color ? new Chalk({ level: 1 }) : chalkDefault
 
-  const result = rcFile('ncurc', {
+  const rawResult = rcFile('ncurc', {
     configFileName: configFileName || '.ncurc',
     defaultExtension: ['.json', '.yml', '.js'],
     cwd: configFilePath || (packageFile ? path.dirname(packageFile) : undefined),
   })
 
-  // Prevent the cli tool from choking because of an unknown argument
-  delete (result?.config as any)['$schema']
+  const result = {
+    filePath: rawResult?.filePath,
+    // Prevent the cli tool from choking because of an unknown option "$schema"
+    config: omit(rawResult?.config, '$schema'),
+  };
 
   // validate arguments here to provide a better error message
   const unknownOptions = Object.keys(result?.config || {}).filter(arg => !cliOptionsMap[arg])

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -35,7 +35,7 @@ async function getNcuRc({ color, configFileName, configFilePath, packageFile }: 
     filePath: rawResult?.filePath,
     // Prevent the cli tool from choking because of an unknown option "$schema"
     config: omit(rawResult?.config, '$schema'),
-  };
+  }
 
   // validate arguments here to provide a better error message
   const unknownOptions = Object.keys(result?.config || {}).filter(arg => !cliOptionsMap[arg])

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -31,7 +31,7 @@ async function getNcuRc({ color, configFileName, configFilePath, packageFile }: 
   })
 
   // Prevent the cli tool from choking because of an unknown argument
-  delete result['$schema'];
+  delete (result?.config as any)['$schema']
 
   // validate arguments here to provide a better error message
   const unknownOptions = Object.keys(result?.config || {}).filter(arg => !cliOptionsMap[arg])

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -30,6 +30,9 @@ async function getNcuRc({ color, configFileName, configFilePath, packageFile }: 
     cwd: configFilePath || (packageFile ? path.dirname(packageFile) : undefined),
   })
 
+  // Prevent the cli tool from choking because of an unknown argument
+  delete result["$schema"];
+
   // validate arguments here to provide a better error message
   const unknownOptions = Object.keys(result?.config || {}).filter(arg => !cliOptionsMap[arg])
   if (unknownOptions.length > 0) {

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -31,7 +31,7 @@ async function getNcuRc({ color, configFileName, configFilePath, packageFile }: 
   })
 
   // Prevent the cli tool from choking because of an unknown argument
-  delete result["$schema"];
+  delete result['$schema'];
 
   // validate arguments here to provide a better error message
   const unknownOptions = Object.keys(result?.config || {}).filter(arg => !cliOptionsMap[arg])

--- a/test/rc-config.test.ts
+++ b/test/rc-config.test.ts
@@ -209,15 +209,11 @@ describe('rc-config', () => {
     const configFile = path.join(tempDir, '.ncurc.json')
     const pkgFile = path.join(tempDir, 'package.json')
     await fs.writeFile(configFile, JSON.stringify({ $schema: 'schema url' }), 'utf-8')
-    await fs.writeFile(
-      pkgFile,
-      JSON.stringify({ dependencies: { 'axios': '1.0.0' } }),
-      'utf-8',
-    )
+    await fs.writeFile(pkgFile, JSON.stringify({ dependencies: { axios: '1.0.0' } }), 'utf-8')
 
     try {
       // awkwardly, we have to set mergeConfig to enable autodetecting the rcconfig because otherwise it is explicitly disabled for tests
-      await spawn('node', [bin, '--mergeConfig'], { cwd: tempDir });
+      await spawn('node', [bin, '--mergeConfig'], { cwd: tempDir })
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true })
     }

--- a/test/rc-config.test.ts
+++ b/test/rc-config.test.ts
@@ -203,4 +203,23 @@ describe('rc-config', () => {
       await fs.rm(tempDir, { recursive: true, force: true })
     }
   })
+
+  it('should not crash if because of $schema property', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+    const configFile = path.join(tempDir, '.ncurc.json')
+    const pkgFile = path.join(tempDir, 'package.json')
+    await fs.writeFile(configFile, JSON.stringify({ $schema: 'schema url' }), 'utf-8')
+    await fs.writeFile(
+      pkgFile,
+      JSON.stringify({ dependencies: { 'axios': '1.0.0' } }),
+      'utf-8',
+    )
+
+    try {
+      // awkwardly, we have to set mergeConfig to enable autodetecting the rcconfig because otherwise it is explicitly disabled for tests
+      await spawn('node', [bin, '--mergeConfig'], { cwd: tempDir });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## Why?

Adding the `$schema` property in the `.ncurc.json` file for IDE schema validation, chokes the cli tool because `$schema` is not a known option.

## Why not use [Vs code schema configuration][vscode-configuration]?

Adding the `$schema` property to JSON file is a standard way and most of the IDEs respect this. This way, we can also avoid lot of IDE specific configurations.

## How was this tested?

The test case fails if we remove the changes in the `getNcuRc.ts` file and passes after making those changes.

## Footer

Let me know if you feel this is not the right way to address this issue. I would be happy to update my PR. 

PS: Thanks for this amazing tool 🦄⚡️

  [vscode-configuration]: https://github.com/raineorshine/npm-check-updates/blob/89bb7ca3068e019745c8c75323a08f928fbb0c89/README.md?plain=1#L639-L656