### PR TITLE
Fix node v14 test in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,16 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
 
+      # node v14 cannot install from current package-lock.json, so use npm install instea of npm ci.
+      # Cannot read property 'chalk' of undefined
+      # Regression: e88617964a009dbb9f5e973f64ff76ad289df68c
+      - name: Install npm dependencies
+        run: npm i
+        if: 'matrix.node == 14'
+
       - name: Install npm dependencies
         run: npm ci
+        if: 'matrix.node != 14'
 
       - name: Build
         run: npm run build

--- a/.ncurc.js
+++ b/.ncurc.js
@@ -15,5 +15,7 @@ module.exports = {
     // Waiting for Prettier v3 support in @trivago/prettier-plugin-sort-imports
     // https://github.com/trivago/prettier-plugin-sort-imports/issues/240
     'prettier',
+    // Removed support for node v14 in v0.35.0
+    'makdownlint-cli',
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "eslint-plugin-promise": "^6.1.1",
         "husky": "^8.0.3",
         "lockfile-lint": "^4.10.6",
-        "markdownlint-cli": "^0.35.0",
+        "markdownlint-cli": "0.34.0",
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.8",
@@ -5333,48 +5333,39 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.29.0.tgz",
-      "integrity": "sha512-ASAzqpODstu/Qsk0xW5BPgWnK/qjpBQ4e7IpsSvvFXcfYIjanLTdwFRJK1SIEEh0fGSMKXcJf/qhaZYHyME0wA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.28.2.tgz",
+      "integrity": "sha512-yYaQXoKKPV1zgrFsyAuZPEQoe+JrY9GDag9ObKpk09twx4OCU5lut+0/kZPrQ3W7w82SmgKhd7D8m34aG1unVw==",
       "dev": true,
       "dependencies": {
         "markdown-it": "13.0.1",
-        "markdownlint-micromark": "0.1.5"
+        "markdownlint-micromark": "0.1.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.35.0.tgz",
-      "integrity": "sha512-lVIIIV1MrUtjoocgDqXLxUCxlRbn7Ve8rsWppfwciUNwLlNS28AhNiyQ3PU7jjj4Qvj+rWTTvwkqg7AcdG988g==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.34.0.tgz",
+      "integrity": "sha512-4G9I++VBTZkaye6Yfc/7dU6HQHcyldZEVB+bYyQJLcpJOHKk/q5ZpGqK80oKMIdlxzsA3aWOJLZ4DkoaoUWXbQ==",
       "dev": true,
       "dependencies": {
-        "commander": "~11.0.0",
+        "commander": "~10.0.1",
         "get-stdin": "~9.0.0",
-        "glob": "~10.2.7",
+        "glob": "~10.2.2",
         "ignore": "~5.2.4",
         "js-yaml": "^4.1.0",
         "jsonc-parser": "~3.2.0",
-        "markdownlint": "~0.29.0",
-        "minimatch": "~9.0.1",
+        "markdownlint": "~0.28.2",
+        "minimatch": "~9.0.0",
         "run-con": "~1.2.11"
       },
       "bin": {
         "markdownlint": "markdownlint.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/markdownlint-cli/node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/markdownlint-cli/node_modules/get-stdin": {
@@ -5390,12 +5381,12 @@
       }
     },
     "node_modules/markdownlint-micromark": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.5.tgz",
-      "integrity": "sha512-HvofNU4QCvfUCWnocQP1IAWaqop5wpWrB0mKB6SSh0fcpV0PdmQNS6tdUuFew1utpYlUvYYzz84oDkrD76GB9A==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.2.tgz",
+      "integrity": "sha512-jRxlQg8KpOfM2IbCL9RXM8ZiYWz2rv6DlZAnGv8ASJQpUh6byTBnEsbuMZ6T2/uIgntyf7SKg/mEaEBo1164fQ==",
       "dev": true,
       "engines": {
-        "node": ">=16"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/mdurl": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "husky": "^8.0.3",
     "lockfile-lint": "^4.10.6",
-    "markdownlint-cli": "^0.35.0",
+    "markdownlint-cli": "0.34.0",
     "mocha": "^10.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",


### PR DESCRIPTION
`npm ci` fails on node v14 with the v3 lockfile (added in e88617964a009dbb9f5e973f64ff76ad289df68c)

This PR changes the node v14 workflow to run `npm i` instead of `npm ci` to circumvent the lock file. 

If npm-check-updates v16.x does not work for you on node v14, try using npm-check-updates `v16.10.8`. 

(Side note: Sorry about the sketchy support for v14. A lot of dependencies have dropped support, sometimes without a major version upgrade, so it has been difficult to maintain.)