### PR TITLE
fix: npm alias parsing with complex version strings

### DIFF
--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -415,7 +415,14 @@ export const upgradeNpmAlias = (declaration: string, upgraded: string) => {
  */
 export const isGithubUrl = (declaration: string | null) => {
   if (!declaration) return false
-  const parsed = parseGithubUrl(declaration)
+  let parsed = null
+  try {
+    parsed = parseGithubUrl(declaration)
+  } catch {
+    // Strings like `npm:postman-request@2.88.1-postman.33` can throw errors instead of simply returning null
+    // In node 18.17+ due to url.parse regressison: https://github.com/nodejs/node/issues/49330
+    // So if this throws, we can assume it's not a valid Github URL.
+  }
   if (!parsed || !parsed.branch) return false
 
   const version = decodeURIComponent(parsed.branch).replace(/^semver:/, '')

--- a/test/version-util.test.ts
+++ b/test/version-util.test.ts
@@ -498,6 +498,7 @@ describe('version-util', () => {
       it('return true if an npm alias', () => {
         should.equal(versionUtil.isNpmAlias('npm:chalk@1.0.0'), true)
         should.equal(versionUtil.isNpmAlias('npm:chalk@^1.0.0'), true)
+        should.equal(versionUtil.isNpmAlias('npm:postman-request@2.88.1-postman.33'), true)
       })
 
       it('return false if not an npm alias', () => {
@@ -509,6 +510,9 @@ describe('version-util', () => {
     describe('upgradeNpmAlias', () => {
       it('replace embedded version', () => {
         versionUtil.upgradeNpmAlias('npm:chalk@^1.0.0', '2.0.0')!.should.equal('npm:chalk@2.0.0')
+        versionUtil
+          .upgradeNpmAlias('npm:postman-request@2.88.1-postman.32', '2.88.1-postman.33')!
+          .should.equal('npm:postman-request@2.88.1-postman.33')
       })
     })
   })


### PR DESCRIPTION
`parseGithubURL('npm:chalk@1.0.0')` returns `null`, whereas `parseGithubURL('npm:chalk@1.0.0-dasda.2')` throws an error in Node 18.17+.

This would mean that dependencies like `npm:postman-request@2.88.1-postman.33` would crash the process with an `ERR_INVALID_URL` error.

For details on the Node.js regression, see https://github.com/nodejs/node/issues/49330. Given how `url.parse` is a deprecated stability-0 method though, it's very possible this won't be fixed. Thus handling it here with a `try...catch` might be the best solution.

Fixes #1318 