### PR TITLE
Update filter type to allow mixed string and RegExp arrays

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -503,7 +503,7 @@ const cliOptions: CLIOption[] = [
     arg: 'p',
     description:
       'Include only package names matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | string[] | RegExp | RegExp[] | FilterFunction',
+    type: 'string | RegExp | (string | RegExp)[] | FilterFunction',
     parse: (value, accum) => [...(accum || []), value],
   },
   {
@@ -518,7 +518,7 @@ const cliOptions: CLIOption[] = [
     long: 'filterVersion',
     arg: 'p',
     description: 'Filter on package version using comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | string[] | RegExp | RegExp[] | FilterFunction',
+    type: 'string | RegExp | (string | RegExp)[] | FilterFunction',
     parse: (value, accum) => [...(accum || []), value],
   },
   {
@@ -659,14 +659,14 @@ const cliOptions: CLIOption[] = [
     arg: 'p',
     description:
       'Exclude packages matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | string[] | RegExp | RegExp[] | FilterFunction',
+    type: 'string | RegExp | (string | RegExp)[] | FilterFunction',
     parse: (value, accum) => [...(accum || []), value],
   },
   {
     long: 'rejectVersion',
     arg: 'p',
     description: 'Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | string[] | RegExp | RegExp[] | FilterFunction',
+    type: 'string | RegExp | (string | RegExp)[] | FilterFunction',
     parse: (value, accum) => [...(accum || []), value],
   },
   {

--- a/src/lib/filterAndReject.ts
+++ b/src/lib/filterAndReject.ts
@@ -49,7 +49,7 @@ function composeFilter(filterPattern: FilterPattern): (name: string, versionSpec
   // array
   else if (Array.isArray(filterPattern)) {
     predicate = (dependencyName: string, versionSpec: string) =>
-      filterPattern.some((subpattern: string | RegExp) => composeFilter(subpattern)(dependencyName, versionSpec))
+      filterPattern.some(subpattern => composeFilter(subpattern)(dependencyName, versionSpec))
   }
   // raw RegExp
   else if (filterPattern instanceof RegExp) {

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -21,7 +21,7 @@ function parseFilterExpression(filterExpression: FilterPattern | undefined): Fil
     Array.isArray(filterExpression) &&
     (filterExpression.length === 0 || typeof filterExpression[0] === 'string')
   ) {
-    const filtered = (filterExpression as string[]).map(s => s.trim()).filter(x => x)
+    const filtered = filterExpression.map(s => (typeof s === 'string' ? s.trim() : s)).filter(x => x)
     return filtered.length > 0 ? filtered : undefined
   } else {
     return filterExpression

--- a/src/types/FilterPattern.ts
+++ b/src/types/FilterPattern.ts
@@ -1,4 +1,4 @@
 import { FilterFunction } from './FilterFunction'
 
 /** Supported patterns for the --filter and --reject options. */
-export type FilterPattern = string | string[] | RegExp | RegExp[] | FilterFunction
+export type FilterPattern = string | RegExp | (string | RegExp)[] | FilterFunction

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -232,18 +232,19 @@
           "$ref": "#/definitions/RegExp"
         },
         {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
           "description": "Supported function for the --filter and --reject options.",
           "type": "object"
         },
         {
           "items": {
-            "$ref": "#/definitions/RegExp"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RegExp"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -263,18 +264,19 @@
           "$ref": "#/definitions/RegExp"
         },
         {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
           "description": "Supported function for the --filter and --reject options.",
           "type": "object"
         },
         {
           "items": {
-            "$ref": "#/definitions/RegExp"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RegExp"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -381,18 +383,19 @@
           "$ref": "#/definitions/RegExp"
         },
         {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
           "description": "Supported function for the --filter and --reject options.",
           "type": "object"
         },
         {
           "items": {
-            "$ref": "#/definitions/RegExp"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RegExp"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -408,18 +411,19 @@
           "$ref": "#/definitions/RegExp"
         },
         {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
           "description": "Supported function for the --filter and --reject options.",
           "type": "object"
         },
         {
           "items": {
-            "$ref": "#/definitions/RegExp"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RegExp"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -74,13 +74,13 @@ export interface RunOptions {
   errorLevel?: number
 
   /** Include only package names matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function. */
-  filter?: string | string[] | RegExp | RegExp[] | FilterFunction
+  filter?: string | RegExp | (string | RegExp)[] | FilterFunction
 
   /** Filters out upgrades based on a user provided function. Run "ncu --help --filterResults" for details. */
   filterResults?: FilterResultsFunction
 
   /** Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. */
-  filterVersion?: string | string[] | RegExp | RegExp[] | FilterFunction
+  filterVersion?: string | RegExp | (string | RegExp)[] | FilterFunction
 
   /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines. Run "ncu --help --format" for details. */
   format?: string[]
@@ -146,10 +146,10 @@ export interface RunOptions {
   registryType?: 'npm' | 'json'
 
   /** Exclude packages matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function. */
-  reject?: string | string[] | RegExp | RegExp[] | FilterFunction
+  reject?: string | RegExp | (string | RegExp)[] | FilterFunction
 
   /** Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function. */
-  rejectVersion?: string | string[] | RegExp | RegExp[] | FilterFunction
+  rejectVersion?: string | RegExp | (string | RegExp)[] | FilterFunction
 
   /** Remove version ranges from the final package version. */
   removeRange?: boolean

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -158,6 +158,25 @@ describe('filter', () => {
       upgraded.should.have.property('fp-and-or')
     })
 
+    it('filter with array of mixed strings and regex', async () => {
+      const upgraded = (await ncu({
+        packageData: {
+          dependencies: {
+            'fp-and-or': '0.1.0',
+            lodash: '2.0.0',
+            'lodash.map': '2.0.0',
+            'lodash.filter': '2.0.0',
+          },
+        },
+        filter: ['fp-and-or', /lodash\..*/],
+      })) as Index<string>
+      upgraded.should.deep.equal({
+        'fp-and-or': '99.9.9',
+        'lodash.map': '99.9.9',
+        'lodash.filter': '99.9.9',
+      })
+    })
+
     it('filter with array of regex strings', async () => {
       const upgraded = (await ncu({
         packageData: {


### PR DESCRIPTION
This PR updates the FilterPattern type to accept mixed string and RegExp arrays. This allows the user to pass an array containing both strings and regular expressions when using npm-check-updates programmatically.

This PR only changes types. It doesn't change any runtime behavior.