### PR TITLE
Replace get-stdin with built-in stream consumer

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -4,8 +4,6 @@ module.exports = {
     // ESM only modules
     // https://github.com/microsoft/TypeScript/issues/46452
     'find-up',
-    'get-stdin',
-    'globby',
     /* pin to 4.0.0 to match make-fetch-happen/cacache. */
     'p-map',
     'remote-git-tags',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "fast-memoize": "^2.5.2",
         "find-up": "5.0.0",
         "fp-and-or": "^1.0.2",
-        "get-stdin": "^8.0.0",
         "hosted-git-info": "^5.1.0",
         "ini": "^4.1.1",
         "js-yaml": "^4.1.0",
@@ -4377,18 +4376,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-stdin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "fast-memoize": "^2.5.2",
     "find-up": "5.0.0",
     "fp-and-or": "^1.0.2",
-    "get-stdin": "^8.0.0",
     "hosted-git-info": "^5.1.0",
     "ini": "^4.1.1",
     "js-yaml": "^4.1.0",

--- a/src/lib/findPackage.ts
+++ b/src/lib/findPackage.ts
@@ -1,6 +1,6 @@
 import findUp from 'find-up'
 import fs from 'fs/promises'
-import getstdin from 'get-stdin'
+import { text } from 'node:stream/consumers'
 import path from 'path'
 import { print } from '../lib/logging'
 import { Options } from '../types/Options'
@@ -65,7 +65,7 @@ async function findPackage(options: Options): Promise<{
 
     // get data from stdin
     // trim stdin to account for \r\n
-    const stdinData = await getstdin()
+    const stdinData = await text(process.stdin)
     const data = stdinData.trim().length > 0 ? stdinData : null
 
     // if no stdin content fall back to searching for package.json from pwd and up to root


### PR DESCRIPTION
Since Node.js 16.7.0, node introduced stream consumers and with that the ability to parse a stream to [text](https://nodejs.org/api/webstreams.html#streamconsumerstextstream). I found out about this as Sindre updated his [README](https://github.com/sindresorhus/get-stdin?tab=readme-ov-file#tip) of get-stdin on his github, but not on NPM. This explains why he hasn't maintained the package since then.