### PR TITLE
fix: Add types of semver-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@yarnpkg/parsers": "2.6.0"
   },
   "dependencies": {
+    "@types/semver-utils": "^1.1.3",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "chalk": "^5.3.0",
@@ -117,7 +118,6 @@
     "@types/prompts": "^2.4.9",
     "@types/remote-git-tags": "^4.0.2",
     "@types/semver": "^7.5.8",
-    "@types/semver-utils": "^1.1.3",
     "@types/sinon": "^17.0.3",
     "@types/update-notifier": "^6.0.8",
     "c8": "^9.1.0",


### PR DESCRIPTION
_npm-check-updates_ uses _semver-utils_ types (e.g. in [`FilterFunction.ts`](https://github.com/raineorshine/npm-check-updates/blob/3f28ecd/src/types/FilterFunction.ts)), but they aren't included in the release.

I move `@types/semver-utils` in prod dependencies.

---

To reproduce the error:

- `package.json`

  ```JSON
  {
    "name": "testcase",
    "version": "1.0.0",
    "type": "module",
    "dependencies": {
      "npm-check-updates": "16.14.17",
      "typescript": "5.4.3"
    }
  }
  ```

- `index.ts`

  ```TypeScript
  import ncu from "npm-check-updates";

  console.log(ncu);
  ```

1. `npm install`
2. `npx tsc --strict index.ts`

```
node_modules/npm-check-updates/build/src/types/FilterFunction.d.ts:1:24 - error TS7016: Could not find a declaration file for module 'semver-utils'. '/home/regseb/dev/testcase/node_modules/semver-utils/semver-utils.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/semver-utils` if it exists or add a new declaration (.d.ts) file containing `declare module 'semver-utils';`

1 import { SemVer } from 'semver-utils';
                         ~~~~~~~~~~~~~~

node_modules/npm-check-updates/build/src/types/FilterResultsFunction.d.ts:1:24 - error TS7016: Could not find a declaration file for module 'semver-utils'. '/home/regseb/dev/testcase/node_modules/semver-utils/semver-utils.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/semver-utils` if it exists or add a new declaration (.d.ts) file containing `declare module 'semver-utils';`

1 import { SemVer } from 'semver-utils';
                         ~~~~~~~~~~~~~~

node_modules/npm-check-updates/build/src/types/GroupFunction.d.ts:1:24 - error TS7016: Could not find a declaration file for module 'semver-utils'. '/home/regseb/dev/testcase/node_modules/semver-utils/semver-utils.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/semver-utils` if it exists or add a new declaration (.d.ts) file containing `declare module 'semver-utils';`

1 import { SemVer } from 'semver-utils';
                         ~~~~~~~~~~~~~~

node_modules/npm-check-updates/build/src/types/TargetFunction.d.ts:1:24 - error TS7016: Could not find a declaration file for module 'semver-utils'. '/home/regseb/dev/testcase/node_modules/semver-utils/semver-utils.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/semver-utils` if it exists or add a new declaration (.d.ts) file containing `declare module 'semver-utils';`

1 import { SemVer } from 'semver-utils';
                         ~~~~~~~~~~~~~~


Found 4 errors in 4 files.

Errors  Files
     1  node_modules/npm-check-updates/build/src/types/FilterFunction.d.ts:1
     1  node_modules/npm-check-updates/build/src/types/FilterResultsFunction.d.ts:1
     1  node_modules/npm-check-updates/build/src/types/GroupFunction.d.ts:1
     1  node_modules/npm-check-updates/build/src/types/TargetFunction.d.ts:1
```