### PR TITLE
Override jsonparse to fix deprecated new Buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7328,8 +7328,7 @@
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "resolved": "git+ssh://git@github.com/ARitz-Cracker/jsonparse.git#f29abd390b281eceb7fcb25b892eaaf1e00ba5ea",
       "dev": true,
       "engines": [
         "node >= 0.2.0"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "url": "https://github.com/raineorshine/npm-check-updates/issues"
   },
   "overrides": {
+    "jsonparse": "https://github.com/ARitz-Cracker/jsonparse/tree/patch-1",
     "@yarnpkg/parsers": "2.6.0"
   },
   "devDependencies": {
@@ -145,10 +146,12 @@
   ],
   "lockfile-lint": {
     "allowed-schemes": [
-      "https:"
+      "https:",
+      "git+ssh:"
     ],
     "allowed-hosts": [
-      "npm"
+      "npm",
+      "github.com"
     ],
     "empty-hostname": false,
     "type": "npm ",


### PR DESCRIPTION
A deprecation warning snuck in via npm-registry-fetch → minipass-json-stream → jsonparse

> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead. (Use `node --trace-deprecation ...` to show where the warning was created)

Override `jsonparse` with the fix from https://github.com/ARitz-Cracker/jsonparse/commit/f29abd390b281eceb7fcb25b892eaaf1e00ba5ea until PR https://github.com/creationix/jsonparse/pull/45 is merged.