### PR TITLE
Reduce the bundle size by removing some `lodash` usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,15 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
         '@typescript-eslint/no-use-before-define': 'error',
-        '@typescript-eslint/no-unused-vars': 'error',
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            // using destructuring to omit properties from objects
+            destructuredArrayIgnorePattern: '^_',
+            argsIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+          },
+        ],
         '@typescript-eslint/array-type': [
           'error',
           {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import isString from 'lodash/isString'
 import path from 'path'
 import prompts from 'prompts-ncu'
 import spawn from 'spawn-please'
@@ -296,7 +295,7 @@ export async function run(
   let timeout: NodeJS.Timeout | undefined
   let timeoutPromise: Promise<void> = new Promise(() => null)
   if (options.timeout) {
-    const timeoutMs = isString(options.timeout) ? Number.parseInt(options.timeout, 10) : options.timeout
+    const timeoutMs = typeof options.timeout === 'string' ? Number.parseInt(options.timeout, 10) : options.timeout
     timeoutPromise = new Promise((resolve, reject) => {
       timeout = setTimeout(() => {
         // must catch the error and reject explicitly since we are in a setTimeout

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -1,5 +1,3 @@
-import flatten from 'lodash/flatten'
-import map from 'lodash/map'
 import os from 'os'
 import path from 'path'
 import { rcFile } from 'rc-config-loader'
@@ -61,19 +59,17 @@ async function getNcuRc({
 
   // flatten config object into command line arguments to be read by commander
   const args = result
-    ? flatten(
-        map(result.config, (value, name) =>
-          // if a boolean option is true, include only the nullary option --${name}
-          // an option is considered boolean if its type is explicitly set to boolean, or if it is has a proper Javascript boolean value
-          value === true || (cliOptionsMap[name]?.type === 'boolean' && value)
-            ? [`--${name}`]
-            : // if a boolean option is false, exclude it
-              value === false || (cliOptionsMap[name]?.type === 'boolean' && !value)
-              ? []
-              : // otherwise render as a 2-tuple
-                [`--${name}`, value],
-        ),
-      )
+    ? Object.entries(result.config).flatMap(([name, value]): string[] =>
+      // if a boolean option is true, include only the nullary option --${name}
+      // an option is considered boolean if its type is explicitly set to boolean, or if it is has a proper Javascript boolean value
+      value === true || (cliOptionsMap[name]?.type === 'boolean' && value)
+        ? [`--${name}`]
+        : // if a boolean option is false, exclude it
+        value === false || (cliOptionsMap[name]?.type === 'boolean' && !value)
+          ? []
+          : // otherwise render as a 2-tuple
+          [`--${name}`, String(value)],
+    )
     : []
 
   return result ? { ...result, args } : null

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -1,6 +1,5 @@
 import flatten from 'lodash/flatten'
 import map from 'lodash/map'
-import omit from 'lodash/omit'
 import os from 'os'
 import path from 'path'
 import { rcFile } from 'rc-config-loader'
@@ -36,10 +35,17 @@ async function getNcuRc({
     programError(options, `Config file ${configFileName} not found in ${configFilePath || process.cwd()}`)
   }
 
+  let rawConfigWithoutSchema = {};
+  if (rawResult?.config) {
+    // @ts-expect-error -- rawResult.config is not typed thus TypeScript does not know that it has a $schema property
+    const { $schema, ...rest } = rawResult.config
+    rawConfigWithoutSchema = rest
+  }
+
   const result = {
     filePath: rawResult?.filePath,
     // Prevent the cli tool from choking because of an unknown option "$schema"
-    config: omit(rawResult?.config, '$schema'),
+    config: rawConfigWithoutSchema,
   }
 
   // validate arguments here to provide a better error message

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -33,12 +33,8 @@ async function getNcuRc({
     programError(options, `Config file ${configFileName} not found in ${configFilePath || process.cwd()}`)
   }
 
-  let rawConfigWithoutSchema = {}
-  if (rawResult?.config) {
-    // @ts-expect-error -- rawResult.config is not typed thus TypeScript does not know that it has a $schema property
-    const { $schema: _, ...rest } = rawResult.config
-    rawConfigWithoutSchema = rest
-  }
+  // @ts-expect-error -- rawResult.config is not typed thus TypeScript does not know that it has a $schema property
+  const { $schema: _, ...rawConfigWithoutSchema } = rawResult?.config || {}
 
   const result = {
     filePath: rawResult?.filePath,
@@ -59,7 +55,7 @@ async function getNcuRc({
 
   // flatten config object into command line arguments to be read by commander
   const args = result
-    ? Object.entries(result.config).flatMap(([name, value]): string[] =>
+    ? Object.entries(result.config).flatMap(([name, value]): any[] =>
         // if a boolean option is true, include only the nullary option --${name}
         // an option is considered boolean if its type is explicitly set to boolean, or if it is has a proper Javascript boolean value
         value === true || (cliOptionsMap[name]?.type === 'boolean' && value)
@@ -68,7 +64,7 @@ async function getNcuRc({
             value === false || (cliOptionsMap[name]?.type === 'boolean' && !value)
             ? []
             : // otherwise render as a 2-tuple
-              [`--${name}`, String(value)],
+              [`--${name}`, value],
       )
     : []
 

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -33,10 +33,10 @@ async function getNcuRc({
     programError(options, `Config file ${configFileName} not found in ${configFilePath || process.cwd()}`)
   }
 
-  let rawConfigWithoutSchema = {};
+  let rawConfigWithoutSchema = {}
   if (rawResult?.config) {
     // @ts-expect-error -- rawResult.config is not typed thus TypeScript does not know that it has a $schema property
-    const { $schema, ...rest } = rawResult.config
+    const { $schema: _, ...rest } = rawResult.config
     rawConfigWithoutSchema = rest
   }
 
@@ -60,16 +60,16 @@ async function getNcuRc({
   // flatten config object into command line arguments to be read by commander
   const args = result
     ? Object.entries(result.config).flatMap(([name, value]): string[] =>
-      // if a boolean option is true, include only the nullary option --${name}
-      // an option is considered boolean if its type is explicitly set to boolean, or if it is has a proper Javascript boolean value
-      value === true || (cliOptionsMap[name]?.type === 'boolean' && value)
-        ? [`--${name}`]
-        : // if a boolean option is false, exclude it
-        value === false || (cliOptionsMap[name]?.type === 'boolean' && !value)
-          ? []
-          : // otherwise render as a 2-tuple
-          [`--${name}`, String(value)],
-    )
+        // if a boolean option is true, include only the nullary option --${name}
+        // an option is considered boolean if its type is explicitly set to boolean, or if it is has a proper Javascript boolean value
+        value === true || (cliOptionsMap[name]?.type === 'boolean' && value)
+          ? [`--${name}`]
+          : // if a boolean option is false, exclude it
+            value === false || (cliOptionsMap[name]?.type === 'boolean' && !value)
+            ? []
+            : // otherwise render as a 2-tuple
+              [`--${name}`, String(value)],
+      )
     : []
 
   return result ? { ...result, args } : null

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -2,7 +2,6 @@
  * Loggin functions.
  */
 import Table from 'cli-table3'
-import transform from 'lodash/transform'
 import { IgnoredUpgrade } from '../types/IgnoredUpgrade'
 import { Index } from '../types/IndexType'
 import { Options } from '../types/Options'
@@ -87,13 +86,10 @@ export function printSimpleJoinedString(object: any, join: string) {
 /** Prints an object sorted by key. */
 export function printSorted<T extends { [key: string]: any }>(options: Options, obj: T, loglevel: LogLevel) {
   const sortedKeys = Object.keys(obj).sort() as (keyof T)[]
-  const objSorted = transform(
-    sortedKeys,
-    (accum, key) => {
-      accum[key] = obj[key]
-    },
-    {} as T,
-  )
+  const objSorted = sortedKeys.reduce<T>((accum, key) => {
+    accum[key] = obj[key]
+    return accum
+  }, {} as T)
   print(options, objSorted, loglevel)
 }
 

--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -1,6 +1,5 @@
 import fs from 'fs/promises'
 import jph from 'json-parse-helpfulerror'
-import get from 'lodash/get'
 import pick from 'lodash/pick'
 import prompts from 'prompts-ncu'
 import nodeSemver from 'semver'
@@ -178,7 +177,7 @@ async function runLocal(
   print(options, current, 'verbose')
 
   if (options.enginesNode) {
-    options.nodeEngineVersion = get(pkg, 'engines.node')
+    options.nodeEngineVersion = pkg?.engines?.node
   }
 
   if (options.peer) {

--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -1,7 +1,6 @@
 import fs from 'fs/promises'
 import jph from 'json-parse-helpfulerror'
 import get from 'lodash/get'
-import isEmpty from 'lodash/isEmpty'
 import pick from 'lodash/pick'
 import prompts from 'prompts-ncu'
 import nodeSemver from 'semver'
@@ -249,7 +248,7 @@ async function runLocal(
     )
     if (options.peer) {
       const ignoredUpdates = await getIgnoredUpgrades(current, upgraded, upgradedPeerDependencies!, options)
-      if (!isEmpty(ignoredUpdates)) {
+      if (Object.keys(ignoredUpdates).length > 0) {
         printIgnoredUpdates(options, ignoredUpdates)
       }
     }

--- a/src/lib/upgradePackageDefinitions.ts
+++ b/src/lib/upgradePackageDefinitions.ts
@@ -1,4 +1,3 @@
-import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
 import pickBy from 'lodash/pickBy'
 import { satisfies } from 'semver'
@@ -48,7 +47,7 @@ export async function upgradePackageDefinitions(
 
   const filteredLatestDependencies = pickBy(latestVersions, (spec, dep) => filteredUpgradedDependencies[dep])
 
-  if (options.peer && !isEmpty(filteredUpgradedDependencies)) {
+  if (options.peer && Object.keys(filteredLatestDependencies).length > 0) {
     const upgradedPeerDependencies = await getPeerDependenciesFromRegistry(filteredLatestDependencies, options)
     const peerDependencies = { ...options.peerDependencies, ...upgradedPeerDependencies }
     if (!isEqual(options.peerDependencies, peerDependencies)) {

--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -2,7 +2,6 @@ import ary from 'lodash/ary'
 import curry from 'lodash/curry'
 import flow from 'lodash/flow'
 import intersection from 'lodash/intersection'
-import last from 'lodash/last'
 import propertyOf from 'lodash/propertyOf'
 import reject from 'lodash/reject'
 import sortBy from 'lodash/sortBy'
@@ -333,7 +332,7 @@ export function findGreatestByLevel(versions: string[], current: string, level: 
     )
   })
 
-  return last(versionsSorted) || null
+  return versionsSorted.at(-1) || null
 }
 
 /**

--- a/src/package-managers/filters.ts
+++ b/src/package-managers/filters.ts
@@ -1,4 +1,3 @@
-import get from 'lodash/get'
 import overEvery from 'lodash/overEvery'
 import semver from 'semver'
 import * as versionUtil from '../lib/version-util'
@@ -36,9 +35,9 @@ export function allowPreOrIsNotPre(versionResult: Partial<Packument>, options: O
  */
 export function satisfiesNodeEngine(versionResult: Partial<Packument>, nodeEngineVersion: Maybe<string>): boolean {
   if (!nodeEngineVersion) return true
-  const minVersion = get(semver.minVersion(nodeEngineVersion), 'version')
+  const minVersion = semver.minVersion(nodeEngineVersion)?.version
   if (!minVersion) return true
-  const versionNodeEngine: string | undefined = get(versionResult, 'engines.node')
+  const versionNodeEngine: string | undefined = versionResult?.engines?.node
   return !versionNodeEngine || semver.satisfies(minVersion, versionNodeEngine)
 }
 

--- a/src/package-managers/gitTags.ts
+++ b/src/package-managers/gitTags.ts
@@ -87,7 +87,6 @@ export const patch = greatestLevel('patch')
 
 /** All git tags are exact versions, so --target semver should never upgrade git tags. */
 // https://github.com/raineorshine/npm-check-updates/pull/1368
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const semver: GetVersion = async (_name: string, _declaration: VersionSpec, _options?: Options) => {
   return { version: null }
 }

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -1,12 +1,12 @@
 import memoize from 'fast-memoize'
 import fs from 'fs'
 import ini from 'ini'
-import uniq from 'lodash/uniq'
 import camelCase from 'lodash/camelCase'
 import filter from 'lodash/filter'
 import isEqual from 'lodash/isEqual'
 import last from 'lodash/last'
 import sortBy from 'lodash/sortBy'
+import uniq from 'lodash/uniq'
 import npmRegistryFetch from 'npm-registry-fetch'
 import path from 'path'
 import nodeSemver from 'semver'
@@ -370,7 +370,7 @@ export const mockFetchUpgradedPackument =
       ...(isPackument(partialPackument) ? partialPackument : null),
     }
 
-    const { versions, ...packumentWithoutVersions } = packument
+    const { versions: _, ...packumentWithoutVersions } = packument
 
     return Promise.resolve({
       ...packument,
@@ -405,32 +405,32 @@ const mergeNpmConfigs = memoize(
 
     if (npmConfigWorkspaceProject && Object.keys(npmConfigWorkspaceProject).length > 0) {
       print(options, `\nnpm config (workspace project):`, 'verbose')
-      const { cache, ...npmConfigWorkspaceProjectWithoutCache } = npmConfigWorkspaceProject
+      const { cache: _, ...npmConfigWorkspaceProjectWithoutCache } = npmConfigWorkspaceProject
       printSorted(options, npmConfigWorkspaceProjectWithoutCache, 'verbose')
     }
 
     if (npmConfigUser && Object.keys(npmConfigUser).length > 0) {
       print(options, `\nnpm config (user):`, 'verbose')
-      const { cache, ...npmConfigUserWithoutCache } = npmConfigUser
+      const { cache: _, ...npmConfigUserWithoutCache } = npmConfigUser
       printSorted(options, npmConfigUserWithoutCache, 'verbose')
     }
 
     if (npmConfigLocal && Object.keys(npmConfigLocal).length > 0) {
       print(options, `\nnpm config (local override):`, 'verbose')
-      const { cache, ...npmConfigLocalWithoutCache } = npmConfigLocal
+      const { cache: _, ...npmConfigLocalWithoutCache } = npmConfigLocal
       printSorted(options, npmConfigLocalWithoutCache, 'verbose')
     }
 
     if (npmConfigProject && Object.keys(npmConfigProject).length > 0) {
       print(options, `\nnpm config (project: ${npmConfigProjectPath}):`, 'verbose')
-      const { cache, ...npmConfigProjectWithoutCache } = npmConfigProject
+      const { cache: _, ...npmConfigProjectWithoutCache } = npmConfigProject
       printSorted(options, npmConfigProjectWithoutCache, 'verbose')
     }
 
     if (npmConfigCWD && Object.keys(npmConfigCWD).length > 0) {
       print(options, `\nnpm config (cwd: ${npmConfigCWDPath}):`, 'verbose')
       // omit cache since it is added to every config
-      const { cache, ...npmConfigCWDWithoutCache } = npmConfigCWD
+      const { cache: _, ...npmConfigCWDWithoutCache } = npmConfigCWD
       printSorted(options, npmConfigCWDWithoutCache, 'verbose')
     }
 
@@ -449,7 +449,7 @@ const mergeNpmConfigs = memoize(
       print(options, `\nmerged npm config:`, 'verbose')
       // omit cache since it is added to every config
       // @ts-expect-error -- though not typed, but the "cache" property does exist on the object and needs to be omitted
-      const { cache, ...npmConfigMergedWithoutCache } = npmConfigMerged
+      const { cache: _, ...npmConfigMergedWithoutCache } = npmConfigMerged
       printSorted(options, npmConfigMergedWithoutCache, 'verbose')
     }
 
@@ -537,7 +537,7 @@ export const fetchUpgradedPackumentMemo = memoize(fetchUpgradedPackument, {
     npmConfigWorkspaceProject,
   ]: Parameters<typeof fetchUpgradedPackument>) => {
     // packageFile varies by cwd in workspaces/deep mode, so we do not want to memoize on that
-    const { packageFile, ...optionsWithoutPackageFile } = options
+    const { packageFile: _, ...optionsWithoutPackageFile } = options
     return JSON.stringify([
       packageName,
       fields,
@@ -548,9 +548,9 @@ export const fetchUpgradedPackumentMemo = memoize(fetchUpgradedPackument, {
       retried,
       npmConfigLocal,
       npmConfigWorkspaceProject,
-    ]);
-  }) as (args: any[]) => string
-});
+    ])
+  }) as (args: any[]) => string,
+})
 
 /**
  * Spawns npm with --json. Handles different commands for Window and Linux/OSX.

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -2,7 +2,6 @@ import memoize from 'fast-memoize'
 import fs from 'fs'
 import ini from 'ini'
 import camelCase from 'lodash/camelCase'
-import filter from 'lodash/filter'
 import isEqual from 'lodash/isEqual'
 import sortBy from 'lodash/sortBy'
 import uniq from 'lodash/uniq'
@@ -837,7 +836,9 @@ export const minor: GetVersion = async (
     await fetchUpgradedPackumentMemo(packageName, ['versions'], currentVersion, options, 0, npmConfig, npmConfigProject)
   )?.versions as Index<Packument>
   const version = versionUtil.findGreatestByLevel(
-    filter(versions, filterPredicate(options)).map(o => o.version),
+    Object.values(versions || {})
+      .filter(filterPredicate(options))
+      .map(o => o.version),
     currentVersion,
     'minor',
   )
@@ -863,7 +864,9 @@ export const patch: GetVersion = async (
     await fetchUpgradedPackumentMemo(packageName, ['versions'], currentVersion, options, 0, npmConfig, npmConfigProject)
   )?.versions as Index<Packument>
   const version = versionUtil.findGreatestByLevel(
-    filter(versions, filterPredicate(options)).map(o => o.version),
+    Object.values(versions || {})
+      .filter(filterPredicate(options))
+      .map(o => o.version),
     currentVersion,
     'patch',
   )
@@ -891,7 +894,9 @@ export const semver: GetVersion = async (
   // ignore explicit version ranges
   if (isExplicitRange(currentVersion)) return { version: null }
 
-  const versionsFiltered = filter(versions, filterPredicate(options)).map(o => o.version)
+  const versionsFiltered = Object.values(versions || {})
+    .filter(filterPredicate(options))
+    .map(o => o.version)
   // TODO: Upgrading within a prerelease does not seem to work.
   // { includePrerelease: true } does not help.
   const version = nodeSemver.maxSatisfying(versionsFiltered, currentVersion)

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -4,7 +4,6 @@ import ini from 'ini'
 import camelCase from 'lodash/camelCase'
 import filter from 'lodash/filter'
 import isEqual from 'lodash/isEqual'
-import last from 'lodash/last'
 import sortBy from 'lodash/sortBy'
 import uniq from 'lodash/uniq'
 import npmRegistryFetch from 'npm-registry-fetch'
@@ -646,11 +645,10 @@ export const greatest: GetVersion = async (
 
   return {
     version:
-      last(
-        filter(versions, filterPredicate(options))
-          .map(o => o.version)
-          .sort(versionUtil.compareVersions),
-      ) || null,
+      filter(versions, filterPredicate(options))
+        .map(o => o.version)
+        .sort(versionUtil.compareVersions)
+        .at(-1) || null,
   }
 }
 
@@ -816,7 +814,7 @@ export const newest: GetVersion = async (
   // sort by timestamp (entry[1]) and map versions
   const versionsSortedByTime = sortBy(Object.entries(timesSatisfyingNodeEngine), 1).map(([version]) => version)
 
-  return { version: last(versionsSortedByTime) }
+  return { version: versionsSortedByTime.at(-1) }
 }
 
 /**

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -643,9 +643,14 @@ export const greatest: GetVersion = async (
     await fetchUpgradedPackumentMemo(packageName, ['versions'], currentVersion, options, 0, npmConfig, npmConfigProject)
   )?.versions
 
+  if (!versions) {
+    return { version: null }
+  }
+
   return {
     version:
-      filter(versions, filterPredicate(options))
+      Object.values(versions)
+        .filter(filterPredicate(options))
         .map(o => o.version)
         .sort(versionUtil.compareVersions)
         .at(-1) || null,

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -643,13 +643,9 @@ export const greatest: GetVersion = async (
     await fetchUpgradedPackumentMemo(packageName, ['versions'], currentVersion, options, 0, npmConfig, npmConfigProject)
   )?.versions
 
-  if (!versions) {
-    return { version: null }
-  }
-
   return {
     version:
-      Object.values(versions)
+      Object.values(versions || {})
         .filter(filterPredicate(options))
         .map(o => o.version)
         .sort(versionUtil.compareVersions)


### PR DESCRIPTION
Since `npm-check-updates@17`, the code and all the direct dependencies are now bundled together by the Vite.

Currently, the bundle size of the `npm-check-updates` is 7.1 MiB:

```shell
$ npm run build && du -sh build
# ....
7.1M	build
```

Since `npm-check-updates@17` now targets Node.js 18+, we can replace some lodash usage with the native ES6 syntax and features. By doing so, the PR reduces the final bundle size to `6.2 MiB`:

```sh
$ npm run build && du -sh build
# ....
6.2M	build
```