### PR TITLE
Chore: add bundle analyzer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "update-notifier": "^7.0.0",
         "verdaccio": "^5.30.2",
         "vite": "^5.2.6",
+        "vite-bundle-analyzer": "^0.9.3",
         "vite-node": "^1.4.0",
         "vite-plugin-dts": "^3.8.0",
         "yarn": "^1.22.22"
@@ -12129,6 +12130,25 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-bundle-analyzer": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/vite-bundle-analyzer/-/vite-bundle-analyzer-0.9.3.tgz",
+      "integrity": "sha512-gizc6zMOYXBcqJH8XBNj7uWO3Qxsd9KkY4VS/d4/GSiOnIvXsPBYvZ6bCcIG1dbO1erNJ7QqPGIH6Ki6UOKeAw==",
+      "dev": true,
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "source-map": "^0.7.4"
+      }
+    },
+    "node_modules/vite-bundle-analyzer/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/vite-node": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "rimraf build && npm run build:options && vite build",
     "build:options": "vite-node src/scripts/build-options.ts",
+    "build:analyze": "rimraf build && npm run build:options && ANALYZER=true vite build",
     "lint": "cross-env FORCE_COLOR=1 npm-run-all --parallel --aggregate-output lint:*",
     "lint:lockfile": "lockfile-lint",
     "lint:markdown": "markdownlint \"**/*.md\" --ignore node_modules --ignore build --config .markdownlint.js",
@@ -136,6 +137,7 @@
     "update-notifier": "^7.0.0",
     "verdaccio": "^5.30.2",
     "vite": "^5.2.6",
+    "vite-bundle-analyzer": "^0.9.3",
     "vite-node": "^1.4.0",
     "vite-plugin-dts": "^3.8.0",
     "yarn": "^1.22.22"

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,5 +1,6 @@
 import { nodeExternals } from 'rollup-plugin-node-externals'
 import { defineConfig } from 'vite'
+import { analyzer } from 'vite-bundle-analyzer'
 import dts from 'vite-plugin-dts'
 
 export default defineConfig(({ mode }) => ({
@@ -10,6 +11,7 @@ export default defineConfig(({ mode }) => ({
       include: ['src'],
     }),
     nodeExternals(),
+    process.env.ANALYZER && analyzer(),
   ],
   ssr: {
     // bundle and treeshake everything


### PR DESCRIPTION
Follow up of #1394.

A bundle analyzer can assist us in reducing the size of the bundle in the areas that matter.

<img width="2486" alt="image" src="https://github.com/raineorshine/npm-check-updates/assets/40715044/554bfa05-1bca-4cb3-87cf-73ab1df2f565">
