### PR TITLE
fix: use HOME environment variable for npm configuration file lookup

### DIFF
--- a/src/lib/libnpmconfig/index.js
+++ b/src/lib/libnpmconfig/index.js
@@ -23,14 +23,14 @@ const NpmConfig = figgyPudding(
 )
 
 const ConfigOpts = figgyPudding({
-  cache: { default: path.join(os.homedir(), '.npm') },
+  cache: { default: path.join(process.env.HOME || os.homedir(), '.npm') },
   configNames: { default: ['npmrc', '.npmrc'] },
   envPrefix: { default: /^npm_config_/i },
   cwd: { default: () => process.cwd() },
   globalconfig: {
     default: () => path.join(getGlobalPrefix(), 'etc', 'npmrc'),
   },
-  userconfig: { default: path.join(os.homedir(), '.npmrc') },
+  userconfig: { default: path.join(process.env.HOME || os.homedir(), '.npmrc') },
 })
 
 /** Gets the npm config. */


### PR DESCRIPTION
On a Windows machine I am forced to work on, my `$HOME` environment variable is different that what `os.homedir()` returns. This change first looks at `$HOME` to mimic how npm finds the user configuration file.

See: https://github.com/npm/cli/blob/dd39de7d1da743cbd33b671fa96f66667109b451/workspaces/config/lib/index.js#L313

Documentation: https://github.com/npm/cli/blob/7f4e66772ee631158b47fcfcd8e22b7b6b9b9cce/docs/lib/content/using-npm/config.md?plain=1#L48
```
per-user configuration file (defaults to `$HOME/.npmrc`; configurable via CLI
```

