### PR TITLE
fix: yarn package manager is missing getPeerDependencies #1419

### DIFF
--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -294,3 +294,5 @@ export const patch = withNpmConfigFromYarn(npm.patch)
 export const semver = withNpmConfigFromYarn(npm.semver)
 
 export default spawnYarn
+
+export { getPeerDependencies, packageAuthorChanged } from './npm'


### PR DESCRIPTION
fix: #1419