### PR TITLE
fix: remove colon from git+ssh paths

### DIFF
--- a/src/package-managers/gitTags.ts
+++ b/src/package-managers/gitTags.ts
@@ -20,13 +20,15 @@ const getSortedVersions = async (name: string, declaration: VersionSpec, options
   const protocolKnown = protocol != null
   if (protocolKnown) {
     tagsPromise = tagsPromise.then(() =>
-      remoteGitTags(`${protocol ? protocol.replace('git+', '') : 'https:'}//${auth ? auth + '@' : ''}${host}/${path}`),
+      remoteGitTags(
+        `${protocol ? protocol.replace('git+', '') : 'https:'}//${auth ? auth + '@' : ''}${host}/${path?.replace(/^:/, '')}`,
+      ),
     )
   } else {
     // try ssh first, then https on failure
     tagsPromise = tagsPromise
       .then(() => remoteGitTags(`ssh://git@${host}/${path}`))
-      .catch(() => remoteGitTags(`https://${auth ? auth + '@' : ''}${host}/${path}`))
+      .catch(() => remoteGitTags(`https://${auth ? auth + '@' : ''}${host}/${path?.replace(/^:/, '')}`))
   }
 
   // fetch remote tags


### PR DESCRIPTION
```
    "ncu-test-v2": "git+ssh://git@github.com/raineorshine/ncu-test-v2#semver:^2.0.0"
```
works fine

but
```
    "ncu-test-v2": "git+ssh://git@github.com:raineorshine/ncu-test-v2#semver:^2.0.0"
``` 

does not



This should work with both now.