### PR TITLE
Fix incorrect URL building

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -59,9 +59,9 @@ const fetchPartialPackument = async (
     accept: opts.fullMetadata ? fullDoc : corgiDoc,
     ...opts.headers,
   }
-  let url = path.join(registry, name)
+  const url = new URL(encodeURIComponent(name), registry)
   if (version) {
-    url = path.join(url, version)
+    url.pathname += `/${version}`
   }
   const fetchOptions = {
     ...opts,
@@ -71,11 +71,11 @@ const fetchPartialPackument = async (
 
   try {
     if (opts.fullMetadata) {
-      return npmRegistryFetch.json(url, fetchOptions)
+      return npmRegistryFetch.json(url.href, fetchOptions)
     } else {
       tag = tag || 'latest'
       // typescript does not type async iteratable stream correctly so we need to cast it
-      const stream = npmRegistryFetch.json.stream(url, '$*', fetchOptions) as unknown as IterableIterator<{
+      const stream = npmRegistryFetch.json.stream(url.href, '$*', fetchOptions) as unknown as IterableIterator<{
         key: keyof Packument
         value: Packument[keyof Packument]
       }>


### PR DESCRIPTION
Scoped package names were not URL encoded as they should be meaning the scope was treated as the package name and the package name was treated as the version by some registry implementations.

The usage of `node:path` rather than a proper URL API resulted in the stripping of one of the slashes after `http(s)://`

Comparing the behaviour of npm-check-update v16 vs v17 before this patch

v16 generated URLs like `https://registry/@scope%2fname`\
v17 generated URLs like `https:/registry/@scope/name`

fixes #1436