### PR TITLE
fix: npm get peer deps returns list and not object when using range

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -683,7 +683,8 @@ export const greatest: GetVersion = async (
 export const getPeerDependencies = async (packageName: string, version: Version): Promise<Index<Version>> => {
   const args = ['view', `${packageName}@${version}`, 'peerDependencies']
   const result = await spawnNpm(args, {}, { rejectOnError: false })
-  return result ? parseJson(result, { command: [...args, '--json'].join(' ') }) : {}
+  const parsed = result ? parseJson(result, { command: [...args, '--json'].join(' ') }) : {}
+  return Array.isArray(parsed) ? parsed.at(-1) : parsed
 }
 
 /**

--- a/test/getPeerDependenciesFromRegistry.test.ts
+++ b/test/getPeerDependenciesFromRegistry.test.ts
@@ -15,6 +15,17 @@ describe('getPeerDependenciesFromRegistry', function () {
     })
   })
 
+  it('single package with range', async () => {
+    await chalkInit()
+    const data = await getPeerDependenciesFromRegistry({ 'eslint-plugin-unused-imports': '^4' }, {})
+    data.should.deep.equal({
+      'eslint-plugin-unused-imports': {
+        '@typescript-eslint/eslint-plugin': '^8.0.0-0',
+        eslint: '^9.0.0',
+      },
+    })
+  })
+
   it('single package empty', async () => {
     await chalkInit()
     const data = await getPeerDependenciesFromRegistry({ 'ncu-test-return-version': '1.0' }, {})


### PR DESCRIPTION
Running the test without the fix results in:
```
AssertionError: expected { 'eslint-plugin-unused-imports': [ { eslint: '9', '@typescript-eslint/eslint-plugin': '8' }, { '@typescript-eslint/eslint-plugin': '^8.0.0-0', eslint: '^9.0.0' } ] } to deeply equal { 'eslint-plugin-unused-imports': { '@typescript-eslint/eslint-plugin': '^8.0.0-0', eslint: '^9.0.0' } }
```