### PR TITLE
Add installedVersion format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
   </tr>
   <tr>
     <td><a href="#format">--format &lt;value&gt;</a></td>
-    <td>Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines. (default: [])</td>
+    <td>Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, exactCurrentVersion. (default: [])</td>
   </tr>
   <tr>
     <td>-g, --global</td>
@@ -544,6 +544,7 @@ Modify the output formatting or show additional information. Specify one or more
   <tr><td>repo</td><td>Infers and displays links to the package's source code repository. Requires packages to be installed.</td></tr>
   <tr><td>time</td><td>Shows the publish time of each upgrade.</td></tr>
   <tr><td>lines</td><td>Prints name@version on separate lines. Useful for piping to npm install.</td></tr>
+  <tr><td>exactCurrentVersion</td><td>Prints the exact current version number instead of a range.</td></tr>
 </table>
 
 ## groupFunction

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
   </tr>
   <tr>
     <td><a href="#format">--format &lt;value&gt;</a></td>
-    <td>Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, exactCurrentVersion. (default: [])</td>
+    <td>Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, installedVersion. (default: [])</td>
   </tr>
   <tr>
     <td>-g, --global</td>
@@ -544,7 +544,7 @@ Modify the output formatting or show additional information. Specify one or more
   <tr><td>repo</td><td>Infers and displays links to the package's source code repository. Requires packages to be installed.</td></tr>
   <tr><td>time</td><td>Shows the publish time of each upgrade.</td></tr>
   <tr><td>lines</td><td>Prints name@version on separate lines. Useful for piping to npm install.</td></tr>
-  <tr><td>exactCurrentVersion</td><td>Prints the exact current version number instead of a range.</td></tr>
+  <tr><td>installedVersion</td><td>Prints the exact current version number instead of a range.</td></tr>
 </table>
 
 ## groupFunction

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -176,7 +176,7 @@ const extendedHelpFormat: ExtendedHelp = ({ markdown }) => {
       ['repo', `Infers and displays links to the package's source code repository. Requires packages to be installed.`],
       ['time', 'Shows the publish time of each upgrade.'],
       ['lines', 'Prints name@version on separate lines. Useful for piping to npm install.'],
-      ['exactCurrentVersion', 'Prints the exact current version number instead of a range.'],
+      ['installedVersion', 'Prints the exact current version number instead of a range.'],
     ],
   })
 
@@ -665,11 +665,11 @@ const cliOptions: CLIOption[] = [
     long: 'format',
     arg: 'value',
     description:
-      'Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, exactCurrentVersion.',
+      'Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, installedVersion.',
     parse: value => (typeof value === 'string' ? value.split(',') : value),
     default: [],
     type: 'string[]',
-    choices: ['group', 'ownerChanged', 'repo', 'time', 'lines', 'exactCurrentVersion'],
+    choices: ['group', 'ownerChanged', 'repo', 'time', 'lines', 'installedVersion'],
     help: extendedHelpFormat,
   },
   {

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -176,6 +176,7 @@ const extendedHelpFormat: ExtendedHelp = ({ markdown }) => {
       ['repo', `Infers and displays links to the package's source code repository. Requires packages to be installed.`],
       ['time', 'Shows the publish time of each upgrade.'],
       ['lines', 'Prints name@version on separate lines. Useful for piping to npm install.'],
+      ['exactCurrentVersion', 'Prints the exact current version number instead of a range.'],
     ],
   })
 
@@ -664,11 +665,11 @@ const cliOptions: CLIOption[] = [
     long: 'format',
     arg: 'value',
     description:
-      'Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines.',
+      'Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, exactCurrentVersion.',
     parse: value => (typeof value === 'string' ? value.split(',') : value),
     default: [],
     type: 'string[]',
-    choices: ['group', 'ownerChanged', 'repo', 'time', 'lines'],
+    choices: ['group', 'ownerChanged', 'repo', 'time', 'lines', 'exactCurrentVersion'],
     help: extendedHelpFormat,
   },
   {

--- a/src/lib/getPackageJson.ts
+++ b/src/lib/getPackageJson.ts
@@ -1,0 +1,34 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { PackageFile } from '../types/PackageFile'
+import exists from './exists'
+
+/** Gets the package.json contents of an installed package. */
+async function getPackageJson(
+  packageName: string,
+  {
+    pkgFile,
+  }: {
+    /** Specify the package file location to add to the node_modules search paths. Needed in workspaces/deep mode. */
+    pkgFile?: string
+  } = {},
+): Promise<PackageFile | null> {
+  const requirePaths = require.resolve.paths(packageName) || []
+  const pkgFileNodeModules = pkgFile ? [path.join(path.dirname(pkgFile), 'node_modules')] : []
+  const localNodeModules = [path.join(process.cwd(), 'node_modules')]
+  const nodeModulePaths = [...pkgFileNodeModules, ...localNodeModules, ...requirePaths]
+
+  for (const basePath of nodeModulePaths) {
+    const packageJsonPath = path.join(basePath, packageName, 'package.json')
+    if (await exists(packageJsonPath)) {
+      try {
+        const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'))
+        return packageJson
+      } catch (e) {}
+    }
+  }
+
+  return null
+}
+
+export default getPackageJson

--- a/src/lib/getPackageVersion.ts
+++ b/src/lib/getPackageVersion.ts
@@ -1,0 +1,27 @@
+import { PackageFile } from '../types/PackageFile'
+import getPackageJson from './getPackageJson'
+
+/**
+ * @param packageName A package name as listed in package.json's dependencies list
+ * @param packageJson Optional param to specify a object representation of a package.json file instead of loading from node_modules
+ * @returns The package version or null if a version could not be determined
+ */
+async function getPackageVersion(
+  packageName: string,
+  packageJson?: PackageFile,
+  {
+    pkgFile,
+  }: {
+    /** Specify the package file location to add to the node_modules search paths. Needed in workspaces/deep mode. */
+    pkgFile?: string
+  } = {},
+) {
+  if (packageJson) {
+    return packageJson.version
+  }
+
+  const loadedPackageJson = await getPackageJson(packageName, { pkgFile })
+  return loadedPackageJson?.version ?? null
+}
+
+export default getPackageVersion

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -10,6 +10,7 @@ import { VersionResult } from '../types/VersionResult'
 import { VersionSpec } from '../types/VersionSpec'
 import chalk from './chalk'
 import filterObject from './filterObject'
+import getPackageVersion from './getPackageVersion'
 import getRepoUrl from './getRepoUrl'
 import {
   colorizeDiff,
@@ -168,7 +169,10 @@ export async function toDependencyTable({
       Object.keys(toDeps)
         .sort()
         .map(async dep => {
-          const from = fromDeps[dep] || ''
+          const from =
+            (format?.includes('exactCurrentVersion')
+              ? await getPackageVersion(dep, undefined, { pkgFile })
+              : fromDeps[dep]) || ''
           const toRaw = toDeps[dep] || ''
           const to = getVersion(toRaw)
           const ownerChanged = ownersChangedDeps

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -170,7 +170,7 @@ export async function toDependencyTable({
         .sort()
         .map(async dep => {
           const from =
-            (format?.includes('exactCurrentVersion')
+            (format?.includes('installedVersion')
               ? await getPackageVersion(dep, undefined, { pkgFile })
               : fromDeps[dep]) || ''
           const toRaw = toDeps[dep] || ''

--- a/src/types/PackageFile.ts
+++ b/src/types/PackageFile.ts
@@ -22,4 +22,5 @@ export interface PackageFile {
   repository?: string | PackageFileRepository
   scripts?: Index<string>
   workspaces?: string[] | { packages: string[] }
+  version?: string
 }

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -68,6 +68,9 @@
           "$ref": "#/definitions/Index<string>",
           "description": "A very generic object."
         },
+        "version": {
+          "type": "string"
+        },
         "workspaces": {
           "anyOf": [
             {
@@ -284,7 +287,7 @@
       "description": "Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run \"ncu --help --filterVersion\" for details."
     },
     "format": {
-      "description": "Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines. Run \"ncu --help --format\" for details.",
+      "description": "Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, exactCurrentVersion. Run \"ncu --help --format\" for details.",
       "items": {
         "type": "string"
       },

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -287,7 +287,7 @@
       "description": "Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run \"ncu --help --filterVersion\" for details."
     },
     "format": {
-      "description": "Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, exactCurrentVersion. Run \"ncu --help --format\" for details.",
+      "description": "Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, installedVersion. Run \"ncu --help --format\" for details.",
       "items": {
         "type": "string"
       },

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -85,7 +85,7 @@ export interface RunOptions {
   /** Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filterVersion" for details. */
   filterVersion?: string | RegExp | (string | RegExp)[] | FilterFunction
 
-  /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines. Run "ncu --help --format" for details. */
+  /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, exactCurrentVersion. Run "ncu --help --format" for details. */
   format?: string[]
 
   /** Check global packages instead of in the current project. */

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -85,7 +85,7 @@ export interface RunOptions {
   /** Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filterVersion" for details. */
   filterVersion?: string | RegExp | (string | RegExp)[] | FilterFunction
 
-  /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, exactCurrentVersion. Run "ncu --help --format" for details. */
+  /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, installedVersion. Run "ncu --help --format" for details. */
   format?: string[]
 
   /** Check global packages instead of in the current project. */

--- a/test/getIgnoredUpgradesDueToEnginesNode.test.ts
+++ b/test/getIgnoredUpgradesDueToEnginesNode.test.ts
@@ -27,7 +27,7 @@ describe('getIgnoredUpgradesDueToEnginesNode', function () {
       '@typescript-eslint/eslint-plugin': {
         enginesNode: '^18.18.0 || ^20.9.0 || >=21.1.0',
         from: '^7.18.0',
-        to: '^8.0.1',
+        to: '^8.2.0',
       },
       del: {
         enginesNode: '>=14.16',


### PR DESCRIPTION
A new format option called exactCurrentVersion has been added. This option replaces the usual version range copied from the project's package.json file with the exact version of the installed package. For instance, this feature might be helpful if you need to generate a release changelog gist for the updated package.