### PR TITLE
Refactor .ncurc loading 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -212,7 +212,7 @@ async function runUpgrades(options: Options, timeout?: NodeJS.Timeout): Promise<
         const packages = await previousPromise
         // copy object to prevent share .ncurc options between different packageFile, to prevent unpredictable behavior
         const rcResult = await getNcuRc({ packageFile: packageInfo.filepath, options })
-        let rcConfig = rcResult && rcResult.config ? rcResult.config : {}
+        let rcConfig = rcResult.config
         if (options.mergeConfig && Object.keys(rcConfig).length) {
           // Merge config options.
           rcConfig = mergeOptions(options, rcConfig)

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -37,9 +37,9 @@ async function getNcuRc({
   }
 
   // convert the config to valid options by removing $schema and parsing format
-  const { $schema: _, format, ...rawConfig } = rawResult?.config || {}
+  const { $schema: _, ...rawConfig } = rawResult?.config || {}
   const config: Options = rawConfig
-  if (typeof format === 'string') config.format = format.split(',')
+  if (typeof config.format === 'string') config.format = cliOptionsMap.format.parse!(config.format)
 
   // validate arguments here to provide a better error message
   const unknownOptions = Object.keys(config).filter(arg => !cliOptionsMap[arg])

--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { rcFile } from 'rc-config-loader'
 import { cliOptionsMap } from '../cli-options'
 import { Options } from '../types/Options'
+import { RcOptions } from '../types/RcOptions'
 import programError from './programError'
 
 /** Loads the .ncurc config file. */
@@ -23,52 +24,47 @@ async function getNcuRc({
   const { default: chalkDefault, Chalk } = await import('chalk')
   const chalk = options?.color ? new Chalk({ level: 1 }) : chalkDefault
 
-  const rawResult = rcFile('ncurc', {
+  const rawResult = rcFile<RcOptions>('ncurc', {
     configFileName: configFileName || '.ncurc',
     defaultExtension: ['.json', '.yml', '.js'],
     cwd: configFilePath || (global ? os.homedir() : packageFile ? path.dirname(packageFile) : undefined),
   })
 
-  if (configFileName && !rawResult?.filePath) {
+  // ensure a file was found if expected
+  const filePath = rawResult?.filePath
+  if (configFileName && !filePath) {
     programError(options, `Config file ${configFileName} not found in ${configFilePath || process.cwd()}`)
   }
 
-  // @ts-expect-error -- rawResult.config is not typed thus TypeScript does not know that it has a $schema property
-  const { $schema: _, ...rawConfigWithoutSchema } = rawResult?.config || {}
-
-  const result = {
-    filePath: rawResult?.filePath,
-    // Prevent the cli tool from choking because of an unknown option "$schema"
-    config: rawConfigWithoutSchema,
-  }
+  // convert the config to valid options by removing $schema and parsing format
+  const { $schema: _, format, ...rawConfig } = rawResult?.config || {}
+  const config: Options = rawConfig
+  if (typeof format === 'string') config.format = format.split(',')
 
   // validate arguments here to provide a better error message
-  const unknownOptions = Object.keys(result?.config || {}).filter(arg => !cliOptionsMap[arg])
+  const unknownOptions = Object.keys(config).filter(arg => !cliOptionsMap[arg])
   if (unknownOptions.length > 0) {
     console.error(
       chalk.red(`Unknown option${unknownOptions.length === 1 ? '' : 's'} found in config file:`),
       chalk.gray(unknownOptions.join(', ')),
     )
-    console.info('Using config file ' + result!.filePath)
+    console.info('Using config file ' + filePath)
     console.info(`You can change the config file path with ${chalk.blue('--configFilePath')}`)
   }
 
   // flatten config object into command line arguments to be read by commander
-  const args = result
-    ? Object.entries(result.config).flatMap(([name, value]): any[] =>
-        // if a boolean option is true, include only the nullary option --${name}
-        // an option is considered boolean if its type is explicitly set to boolean, or if it is has a proper Javascript boolean value
-        value === true || (cliOptionsMap[name]?.type === 'boolean' && value)
-          ? [`--${name}`]
-          : // if a boolean option is false, exclude it
-            value === false || (cliOptionsMap[name]?.type === 'boolean' && !value)
-            ? []
-            : // otherwise render as a 2-tuple
-              [`--${name}`, value],
-      )
-    : []
+  const args = Object.entries(config).flatMap(([name, value]): any[] => {
+    // render boolean options as a single parameter
+    // an option is considered boolean if its type is explicitly set to boolean, or if it is has a proper Javascript boolean value
+    if (typeof value === 'boolean' || cliOptionsMap[name]?.type === 'boolean') {
+      // if the boolean option is true, include only the nullary option --${name}, otherwise exclude it
+      return value ? [`--${name}`] : []
+    }
+    // otherwise render as a 2-tuple with name and value
+    return [`--${name}`, value]
+  })
 
-  return result ? { ...result, args } : null
+  return { filePath, args, config }
 }
 
 export default getNcuRc

--- a/src/types/RcOptions.ts
+++ b/src/types/RcOptions.ts
@@ -1,0 +1,10 @@
+import { RunOptions } from './RunOptions'
+
+/** Options that would make no sense in a .ncurc file */
+type Nonsensical = 'configFileName' | 'configFilePath' | 'cwd' | 'packageData' | 'stdin'
+
+/** Expected options that might be found in an .ncurc file. Since the config is external, this cannot be guaranteed */
+export type RcOptions = Omit<RunOptions, Nonsensical> & {
+  $schema?: string
+  format?: string | string[] // Format is often set as a string, but needs to be an array
+}


### PR DESCRIPTION
My primary intent here was to fix #1452. Internally, `format` is expected to be an array. However, when it's loaded outside the cli (in `runUpgrades`) it's not parsed as such. The _correct_ answer probably would have been to validate it and throw an error. However, since even this repo's own `.ncurc` file uses a string, that would definitely be a breaking change.

While this fixes the problem, I recommend refactoring the app to validate the loaded `.ncurc` file every time one is loaded, and avoid passing into commander as arguments. There remain a number of type-safety issues with invalid configs that are outside the scope of this PR.

The code to set `args` didn't _need_ to change, but I'd already cleaned it up while chasing a red herring, so I figured I'd leave it.

I didn't see commit guidelines anywhere, but let me know if you'd prefer a semantic-commit format and I can change it.


Oh, and thanks for this incredibly helpful tool!