### PR TITLE
Sanitize spawn calls which contain .cmd for win32

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ const install = async (
               // See: https://github.com/raineorshine/npm-check-updates/issues/1191
               ...(packageManager === 'pnpm' ? { npm_config_strict_peer_dependencies: false } : null),
             },
+            shell: process.platform === 'win32',
           },
         )
         print(options, stdout)

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -586,7 +586,6 @@ async function spawnNpm(
   spawnOptions: Index<any> = {},
 ): Promise<any> {
   const cmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-  const sanitizedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
   const fullArgs = [
     ...(npmOptions.global ? [`--global`] : []),
@@ -594,7 +593,7 @@ async function spawnNpm(
     '--json',
     ...(Array.isArray(args) ? args : [args]),
   ]
-  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, sanitizedSpawnOptions)
+  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, spawnOptions)
   return stdout
 }
 

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -586,6 +586,7 @@ async function spawnNpm(
   spawnOptions: Index<any> = {},
 ): Promise<any> {
   const cmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  const sanitizedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
   const fullArgs = [
     ...(npmOptions.global ? [`--global`] : []),
@@ -593,7 +594,7 @@ async function spawnNpm(
     '--json',
     ...(Array.isArray(args) ? args : [args]),
   ]
-  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, spawnOptions)
+  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, sanitizedSpawnOptions)
   return stdout
 }
 
@@ -609,15 +610,17 @@ export async function defaultPrefix(options: Options): Promise<string | undefine
   if (options.prefix) {
     return Promise.resolve(options.prefix)
   }
+  const spawnOptions = {}
 
   const cmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  const sanitizedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
   let prefix: string | undefined
 
   // catch spawn error which can occur on Windows
   // https://github.com/raineorshine/npm-check-updates/issues/703
   try {
-    const { stdout } = await spawn(cmd, ['config', 'get', 'prefix'])
+    const { stdout } = await spawn(cmd, ['config', 'get', 'prefix'], {}, sanitizedSpawnOptions)
     prefix = stdout
   } catch (e: any) {
     const message = (e.message || e || '').toString()

--- a/src/package-managers/pnpm.ts
+++ b/src/package-managers/pnpm.ts
@@ -56,9 +56,11 @@ export const list = async (options: Options = {}): Promise<Index<string | undefi
   // use npm for local ls for completeness
   // this should never happen since list is only called in runGlobal -> getInstalledPackages
   if (!options.global) return npm.list(options)
+  const spawnOptions = {}
 
   const cmd = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-  const { stdout } = await spawn(cmd, ['ls', '-g', '--json'])
+  const sanitzedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
+  const { stdout } = await spawn(cmd, ['ls', '-g', '--json'], {}, sanitzedSpawnOptions)
   const result = JSON.parse(stdout) as PnpmList
   const list = keyValueBy(result[0].dependencies || {}, (name, { version }) => ({
     [name]: version,
@@ -91,10 +93,11 @@ export const semver = withNpmWorkspaceConfig(npm.semver)
 async function spawnPnpm(
   args: string | string[],
   npmOptions: NpmOptions = {},
-  spawnOptions?: SpawnOptions,
+  spawnOptions: SpawnOptions = {},
   spawnPleaseOptions?: SpawnPleaseOptions,
 ): Promise<string> {
   const cmd = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+  const sanitzedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
   const fullArgs = [
     ...(npmOptions.global ? 'global' : []),
@@ -102,7 +105,7 @@ async function spawnPnpm(
     ...(npmOptions.prefix ? `--prefix=${npmOptions.prefix}` : []),
   ]
 
-  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, spawnOptions)
+  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, sanitzedSpawnOptions)
 
   return stdout
 }

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -196,6 +196,7 @@ async function spawnYarn(
   spawnOptions: SpawnOptions = {},
 ): Promise<string> {
   const cmd = process.platform === 'win32' ? 'yarn.cmd' : 'yarn'
+  const sanitizedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
   const fullArgs = [
     ...(yarnOptions.global ? ['global'] : []),
@@ -208,7 +209,7 @@ async function spawnYarn(
     ...(Array.isArray(args) ? args : [args]),
   ]
 
-  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, spawnOptions)
+  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, sanitizedSpawnOptions)
 
   return stdout
 }
@@ -225,10 +226,12 @@ export async function defaultPrefix(options: Options): Promise<string | null> {
   if (options.prefix) {
     return Promise.resolve(options.prefix)
   }
+  const spawnOptions = {}
 
   const cmd = process.platform === 'win32' ? 'yarn.cmd' : 'yarn'
+  const sanitizedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
-  const { stdout: prefix } = await spawn(cmd, ['global', 'dir'])
+  const { stdout: prefix } = await spawn(cmd, ['global', 'dir'], {}, sanitizedSpawnOptions)
     // yarn 2.0 does not support yarn global
     // catch error to prevent process from crashing
     // https://github.com/raineorshine/npm-check-updates/issues/873

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -196,7 +196,6 @@ async function spawnYarn(
   spawnOptions: SpawnOptions = {},
 ): Promise<string> {
   const cmd = process.platform === 'win32' ? 'yarn.cmd' : 'yarn'
-  const sanitizedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
   const fullArgs = [
     ...(yarnOptions.global ? ['global'] : []),
@@ -209,7 +208,7 @@ async function spawnYarn(
     ...(Array.isArray(args) ? args : [args]),
   ]
 
-  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, sanitizedSpawnOptions)
+  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, spawnOptions)
 
   return stdout
 }

--- a/src/types/SpawnOptions.ts
+++ b/src/types/SpawnOptions.ts
@@ -4,4 +4,5 @@ import { Index } from './IndexType'
 export interface SpawnOptions {
   cwd?: string
   env?: Index<string>
+  shell?: boolean
 }


### PR DESCRIPTION
See https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2 and 
https://github.com/raineorshine/npm-check-updates/issues/1429