### PR TITLE
Revert "Sanitize spawn calls which contain .cmd for win32"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,6 @@ const install = async (
               // See: https://github.com/raineorshine/npm-check-updates/issues/1191
               ...(packageManager === 'pnpm' ? { npm_config_strict_peer_dependencies: false } : null),
             },
-            shell: process.platform === 'win32',
           },
         )
         print(options, stdout)

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -609,17 +609,15 @@ export async function defaultPrefix(options: Options): Promise<string | undefine
   if (options.prefix) {
     return Promise.resolve(options.prefix)
   }
-  const spawnOptions = {}
 
   const cmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-  const sanitizedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
   let prefix: string | undefined
 
   // catch spawn error which can occur on Windows
   // https://github.com/raineorshine/npm-check-updates/issues/703
   try {
-    const { stdout } = await spawn(cmd, ['config', 'get', 'prefix'], {}, sanitizedSpawnOptions)
+    const { stdout } = await spawn(cmd, ['config', 'get', 'prefix'])
     prefix = stdout
   } catch (e: any) {
     const message = (e.message || e || '').toString()

--- a/src/package-managers/pnpm.ts
+++ b/src/package-managers/pnpm.ts
@@ -56,11 +56,9 @@ export const list = async (options: Options = {}): Promise<Index<string | undefi
   // use npm for local ls for completeness
   // this should never happen since list is only called in runGlobal -> getInstalledPackages
   if (!options.global) return npm.list(options)
-  const spawnOptions = {}
 
   const cmd = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-  const sanitzedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
-  const { stdout } = await spawn(cmd, ['ls', '-g', '--json'], {}, sanitzedSpawnOptions)
+  const { stdout } = await spawn(cmd, ['ls', '-g', '--json'])
   const result = JSON.parse(stdout) as PnpmList
   const list = keyValueBy(result[0].dependencies || {}, (name, { version }) => ({
     [name]: version,
@@ -93,11 +91,10 @@ export const semver = withNpmWorkspaceConfig(npm.semver)
 async function spawnPnpm(
   args: string | string[],
   npmOptions: NpmOptions = {},
-  spawnOptions: SpawnOptions = {},
+  spawnOptions?: SpawnOptions,
   spawnPleaseOptions?: SpawnPleaseOptions,
 ): Promise<string> {
   const cmd = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-  const sanitzedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
   const fullArgs = [
     ...(npmOptions.global ? 'global' : []),
@@ -105,7 +102,7 @@ async function spawnPnpm(
     ...(npmOptions.prefix ? `--prefix=${npmOptions.prefix}` : []),
   ]
 
-  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, sanitzedSpawnOptions)
+  const { stdout } = await spawn(cmd, fullArgs, spawnPleaseOptions, spawnOptions)
 
   return stdout
 }

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -225,12 +225,10 @@ export async function defaultPrefix(options: Options): Promise<string | null> {
   if (options.prefix) {
     return Promise.resolve(options.prefix)
   }
-  const spawnOptions = {}
 
   const cmd = process.platform === 'win32' ? 'yarn.cmd' : 'yarn'
-  const sanitizedSpawnOptions = process.platform === 'win32' ? { ...spawnOptions, shell: true } : spawnOptions
 
-  const { stdout: prefix } = await spawn(cmd, ['global', 'dir'], {}, sanitizedSpawnOptions)
+  const { stdout: prefix } = await spawn(cmd, ['global', 'dir'])
     // yarn 2.0 does not support yarn global
     // catch error to prevent process from crashing
     // https://github.com/raineorshine/npm-check-updates/issues/873

--- a/src/types/SpawnOptions.ts
+++ b/src/types/SpawnOptions.ts
@@ -4,5 +4,4 @@ import { Index } from './IndexType'
 export interface SpawnOptions {
   cwd?: string
   env?: Index<string>
-  shell?: boolean
 }


### PR DESCRIPTION
Reverts raineorshine/npm-check-updates#1465

We need to revert this otherwise Windows machines will break - https://github.com/raineorshine/npm-check-updates/pull/1465#issuecomment-2417958200

I suspect the fix may take a bit more time. I wouldn't mind spending a weekend on replacing `cross-spawn` if you'd like. 