### PR TITLE
fix: yarn getPeerDependencies doesnt work on private reporsitories wh…

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -298,7 +298,7 @@ const npmConfig = findNpmConfig()
  * @param data
  * @returns
  */
-function parseJson<R>(result: string, data: { command?: string; packageName?: string }): R {
+export function parseJson<R>(result: string, data: { command?: string; packageName?: string }): R {
   let json
   try {
     json = JSON.parse(result)

--- a/test/package-managers/npm/index.test.ts
+++ b/test/package-managers/npm/index.test.ts
@@ -26,8 +26,8 @@ describe('npm', function () {
   })
 
   it('getPeerDependencies', async () => {
-    await npm.getPeerDependencies('ncu-test-return-version', '1.0').should.eventually.deep.equal({})
-    await npm.getPeerDependencies('ncu-test-peer', '1.0').should.eventually.deep.equal({
+    await npm.getPeerDependencies('ncu-test-return-version', '1.0.0').should.eventually.deep.equal({})
+    await npm.getPeerDependencies('ncu-test-peer', '1.0.0').should.eventually.deep.equal({
       'ncu-test-return-version': '1.x',
     })
   })

--- a/test/package-managers/yarn/index.test.ts
+++ b/test/package-managers/yarn/index.test.ts
@@ -46,6 +46,13 @@ describe('yarn', function () {
     await yarn.list({ cwd: testDir }, localYarnSpawnOptions).should.eventually.be.rejectedWith(lockFileErrorMessage)
   })
 
+  it('getPeerDependencies', async () => {
+    await yarn.getPeerDependencies('ncu-test-return-version', '1.0.0').should.eventually.deep.equal({})
+    await yarn.getPeerDependencies('ncu-test-peer', '1.0.0').should.eventually.deep.equal({
+      'ncu-test-return-version': '1.x',
+    })
+  })
+
   describe('npmAuthTokenKeyValue', () => {
     it('npmRegistryServer with trailing slash', () => {
       const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {


### PR DESCRIPTION
…en credentials are only set for yarn and not npm 

fix: #1470