### PR TITLE
Use for await in install function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ const install = async (
     const isWorkspace = options.workspaces || !!options.workspace?.length
     const pkgsNormalized = isWorkspace ? ['package.json'] : pkgs
 
-    pkgsNormalized.forEach(async pkgFile => {
+    for await (const pkgFile of pkgsNormalized) {
       const packageManager = await getPackageManagerForInstall(options, pkgFile)
       const cmd = packageManager + (process.platform === 'win32' ? '.cmd' : '')
       const cwd = options.cwd || path.resolve(pkgFile, '..')
@@ -183,7 +183,7 @@ const install = async (
         // if there is nothing on stderr, reject with stdout
         throw new Error(err?.message || err || stdout)
       }
-    })
+    }
   }
   // show the install hint unless auto-install occurred
   else if (!isInteractive) {


### PR DESCRIPTION
When using ncu within a script (top level function with `"type": "module"`) with always install option, it doesn't actually run the install command after upgrading `package.json`

```
const upgraded = await ncu.run({
    upgrade: true,
    install: "always",
});
console.log("upgraded", upgraded); // { "mypackage": "^2.0.0", ... }
process.exit(0);
```

I debugged through `node_modules/npm-check-updates/build/index.js`, I can see the function within `forEach` (https://github.com/raineorshine/npm-check-updates/blob/b7c3106c9b1ba96608165f808dcd726ba76286bc/src/index.ts#L148) is getting called. So I suspect the whole `install` function is not properly getting awaited. 

The part I don't quite understand is why running directly through `npx` works fine, maybe due to the `cli` scripts are wrapped in iife and vite bundled it in a smarter way?


MacOS, node - v20.13.1