### PR TITLE
fix: readonly arrays on input options

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -615,7 +615,7 @@ const cliOptions: CLIOption[] = [
       'Check one or more sections of dependencies only: dev, optional, peer, prod, or packageManager (comma-delimited).',
     default: ['prod', 'dev', 'optional', 'packageManager'],
     parse: value => (value && typeof value === 'string' ? value.split(',') : value),
-    type: 'string | string[]',
+    type: 'string | readonly string[]',
   },
   {
     long: 'deprecated',
@@ -666,7 +666,7 @@ const cliOptions: CLIOption[] = [
     arg: 'p',
     description:
       'Include only package names matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | RegExp | (string | RegExp)[] | FilterFunction',
+    type: 'string | RegExp | readonly (string | RegExp)[] | FilterFunction',
     parse: (value, accum) => [...(accum || []), value],
     help: extendedHelpFilterFunction,
   },
@@ -682,7 +682,7 @@ const cliOptions: CLIOption[] = [
     long: 'filterVersion',
     arg: 'p',
     description: 'Filter on package version using comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | RegExp | (string | RegExp)[] | FilterFunction',
+    type: 'string | RegExp | readonly (string | RegExp)[] | FilterFunction',
     parse: (value, accum) => [...(accum || []), value],
     help: extendedHelpFilterVersionFunction,
   },
@@ -693,7 +693,7 @@ const cliOptions: CLIOption[] = [
       'Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, installedVersion.',
     parse: value => (typeof value === 'string' ? value.split(',') : value),
     default: [],
-    type: 'string[]',
+    type: 'readonly string[]',
     choices: ['group', 'ownerChanged', 'repo', 'time', 'lines', 'installedVersion'],
     help: extendedHelpFormat,
   },
@@ -824,7 +824,7 @@ const cliOptions: CLIOption[] = [
     arg: 'p',
     description:
       'Exclude packages matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | RegExp | (string | RegExp)[] | FilterFunction',
+    type: 'string | RegExp | readonly (string | RegExp)[] | FilterFunction',
     parse: (value, accum) => [...(accum || []), value],
     help: extendedHelpRejectFunction,
   },
@@ -901,7 +901,7 @@ const cliOptions: CLIOption[] = [
     parse: (value, accum) => [...accum, value],
     default: [],
     description: 'Run on one or more specified workspaces. Add `--root` to also upgrade the root project.',
-    type: 'string[]',
+    type: 'readonly string[]',
   },
   {
     long: 'workspaces',

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -832,7 +832,7 @@ const cliOptions: CLIOption[] = [
     long: 'rejectVersion',
     arg: 'p',
     description: 'Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | RegExp | (string | RegExp)[] | FilterFunction',
+    type: 'string | RegExp | readonly (string | RegExp)[] | FilterFunction',
     parse: (value, accum) => [...(accum || []), value],
     help: extendedHelpRejectVersionFunction,
   },

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -158,7 +158,7 @@ export async function toDependencyTable({
 }: {
   from: Index<VersionSpec>
   to: Index<VersionSpec>
-  format?: string[]
+  format?: readonly string[]
   ownersChangedDeps?: Index<boolean>
   /** See: logging/getPackageRepo pkgFile param. */
   pkgFile?: string

--- a/src/lib/resolveDepSections.ts
+++ b/src/lib/resolveDepSections.ts
@@ -11,7 +11,7 @@ const depAliases: Index<keyof PackageFile> = {
 }
 
 /** Gets a list of dependency sections based on options.dep. */
-const resolveDepSections = (dep?: string | string[]): (keyof PackageFile)[] => {
+const resolveDepSections = (dep?: string | readonly string[]): (keyof PackageFile)[] => {
   // parse dep string and set default
   const depOptions: string[] = dep ? (typeof dep === 'string' ? dep.split(',') : dep) : cliOptionsMap.dep.default
 

--- a/src/types/FilterPattern.ts
+++ b/src/types/FilterPattern.ts
@@ -1,4 +1,4 @@
 import { FilterFunction } from './FilterFunction'
 
 /** Supported patterns for the --filter and --reject options. */
-export type FilterPattern = string | RegExp | (string | RegExp)[] | FilterFunction
+export type FilterPattern = string | RegExp | readonly (string | RegExp)[] | FilterFunction

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -50,7 +50,7 @@ export interface RunOptions {
    *
    * @default ["prod","dev","optional","packageManager"]
    */
-  dep?: string | readonly string[]
+  dep?: string | string[]
 
   /** Include deprecated packages. Use `--no-deprecated` to exclude deprecated packages (uses more bandwidth).
    *
@@ -77,16 +77,16 @@ export interface RunOptions {
   errorLevel?: number
 
   /** Include only package names matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filter" for details. */
-  filter?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
+  filter?: string | RegExp | (string | RegExp)[] | FilterFunction
 
   /** Filters out upgrades based on a user provided function. Run "ncu --help --filterResults" for details. */
   filterResults?: FilterResultsFunction
 
   /** Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filterVersion" for details. */
-  filterVersion?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
+  filterVersion?: string | RegExp | (string | RegExp)[] | FilterFunction
 
   /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, installedVersion. Run "ncu --help --format" for details. */
-  format?: readonly string[]
+  format?: string[]
 
   /** Check global packages instead of in the current project. */
   global?: boolean
@@ -149,10 +149,10 @@ export interface RunOptions {
   registryType?: 'npm' | 'json'
 
   /** Exclude packages matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --reject" for details. */
-  reject?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
+  reject?: string | RegExp | (string | RegExp)[] | FilterFunction
 
   /** Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --rejectVersion" for details. */
-  rejectVersion?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
+  rejectVersion?: string | RegExp | (string | RegExp)[] | FilterFunction
 
   /** Remove version ranges from the final package version. */
   removeRange?: boolean
@@ -188,7 +188,7 @@ export interface RunOptions {
   verbose?: boolean
 
   /** Run on one or more specified workspaces. Add `--root` to also upgrade the root project. */
-  workspace?: readonly string[]
+  workspace?: string[]
 
   /** Run on all workspaces. Add `--root` to also upgrade the root project. */
   workspaces?: boolean

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -50,7 +50,7 @@ export interface RunOptions {
    *
    * @default ["prod","dev","optional","packageManager"]
    */
-  dep?: string | string[]
+  dep?: string | readonly string[]
 
   /** Include deprecated packages. Use `--no-deprecated` to exclude deprecated packages (uses more bandwidth).
    *
@@ -77,16 +77,16 @@ export interface RunOptions {
   errorLevel?: number
 
   /** Include only package names matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filter" for details. */
-  filter?: string | RegExp | (string | RegExp)[] | FilterFunction
+  filter?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
 
   /** Filters out upgrades based on a user provided function. Run "ncu --help --filterResults" for details. */
   filterResults?: FilterResultsFunction
 
   /** Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filterVersion" for details. */
-  filterVersion?: string | RegExp | (string | RegExp)[] | FilterFunction
+  filterVersion?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
 
   /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: group, ownerChanged, repo, time, lines, installedVersion. Run "ncu --help --format" for details. */
-  format?: string[]
+  format?: readonly string[]
 
   /** Check global packages instead of in the current project. */
   global?: boolean
@@ -149,10 +149,10 @@ export interface RunOptions {
   registryType?: 'npm' | 'json'
 
   /** Exclude packages matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --reject" for details. */
-  reject?: string | RegExp | (string | RegExp)[] | FilterFunction
+  reject?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
 
   /** Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --rejectVersion" for details. */
-  rejectVersion?: string | RegExp | (string | RegExp)[] | FilterFunction
+  rejectVersion?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
 
   /** Remove version ranges from the final package version. */
   removeRange?: boolean
@@ -188,7 +188,7 @@ export interface RunOptions {
   verbose?: boolean
 
   /** Run on one or more specified workspaces. Add `--root` to also upgrade the root project. */
-  workspace?: string[]
+  workspace?: readonly string[]
 
   /** Run on all workspaces. Add `--root` to also upgrade the root project. */
   workspaces?: boolean


### PR DESCRIPTION
Today I discovered that npm-check-updates would not take in my immutable filterVersion array. So, I fixed it in this PR, as well as the surrounding arrays that were also incorrectly marked as mutable.

More info: In TypeScript libraries it is idiomatic to take in read-only data structures. That way, end-users do not have to cast their immutable data structures to be mutable simply to satisfy the TypeScript compiler (which is both ugly and reduces safety in using the library).

In case it isn't obvious, this PR is backwards compatible in that end-users can now use either mutable OR immutable arrays.