### PR TITLE
Gracefully handle inaccessible packages

### DIFF
--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -86,6 +86,9 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
         // allow downgrading when explicit tag is used
         pre: options.pre != null ? options.pre : targetString.startsWith('@') || isPre(version),
         retry: options.retry ?? 2,
+      }).catch(reason => {
+        // This might happen if a (private) package cannot be accessed due to a missing or invalid token.
+        return { error: reason?.body?.error || reason.toString() }
       })
 
       versionResult.version =

--- a/test/queryVersions.test.ts
+++ b/test/queryVersions.test.ts
@@ -25,6 +25,22 @@ describe('queryVersions', function () {
     result.should.deep.equal({})
   })
 
+  it('error while querying version should be handled', async () => {
+    const stub = stubVersions(() => {
+      throw new Error(`Package inaccessible`)
+    })
+
+    const result = await queryVersions({ async: '1.5.1' }, { loglevel: 'silent' })
+    result.should.deep.equal({
+      async: {
+        error: 'Error: Package inaccessible',
+        version: null,
+      },
+    })
+
+    stub.restore()
+  })
+
   it('local file urls should be ignored', async () => {
     const result = await queryVersions(
       { 'eslint-plugin-internal': 'file:devtools/eslint-rules' },


### PR DESCRIPTION
This PR solves #1527

In case a package is not accessible, an error is thrown that was not handled so far.
This PR adds a `.catch` that transforms the rejection to a handled error.

## Reproduce:

This is a tutorial on how to reproduce this error without having to set up a private registry.

1. **Start a registry server that declines every request**

    We can use a very simple [Hono](https://hono.dev/docs/) server.
    Simply run

    ```sh
    npm create hono@latest
    ```
  
    Then open `src/index.ts` and replace the existing `app.get("...` declaration with this:

    ```ts
    app.get("/*", (c) => {
      throw new HTTPException(401, {
        message: "Unauthorized access",
      })
    })
    ```

    Start the app by running

    ```sh
    npm run dev
    ```

2. **Create a new npm project to run `ncu` inside**

    Create a new npm project
    ```sh
    npm init -y
    ```

    Add this `devDependencies` section:

    ```json
      "devDependencies": {
        "@my-scope/package": "^1.0.0",
        "typescript": "^5.0.0"
      }
    ```

    Add a `.npmrc` file with this content:

    ```ini
    @my-scope:registry=http://localhost:3000/
    ```

3. **Run `ncu`**

    **Output using this branch**

    ```log
    Checking /Users/USERNAME/Desktop/example-client/package.json
    [====================] 2/2 100%

     typescript  ^5.0.0  →  ^5.8.3

     @my-scope/package  HttpErrorGeneral: 401 Unauthorized - GET http://localhost:3000/%40my-scope%2Fpackage 

    Run npx npm-check-updates -u to upgrade package.json
    ```

    **Actual output from the current main branch**

    ```log
    Checking /Users/USERNAME/Desktop/example-client/package.json
    [--------------------] 0/2 0%HttpErrorGeneral: 401 Unauthorized - GET http://localhost:3000/%40my-scope%2Fpackage
        at /Users/USERNAME/npm-check-updates/node_modules/npm-registry-fetch/lib/check-response.js:103:15
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
      headers: [Object: null prototype] {
        'content-type': [ 'text/plain;charset=UTF-8' ],
        date: [ 'Tue, 22 Jul 2025 23:01:37 GMT' ],
        connection: [ 'keep-alive' ],
        'keep-alive': [ 'timeout=5' ],
        'transfer-encoding': [ 'chunked' ],
        'x-fetch-attempts': [ '1' ]
      },
      statusCode: 401,
      code: 'E401',
      method: 'GET',
      uri: 'http://localhost:3000/%40my-scope%2Fpackage',
      body: <Buffer 55 6e 61 75 74 68 6f 72 69 7a 65 64 20 61 63 63 65 73 73>,
      pkgid: '@my-scope/package'
    }
    [==========----------] 1/2 50%Unhandled Rejection! This is a bug and should be reported: https://github.com/raineorshine/npm-check-updates/issues
    ```