### PR TITLE
fix: tests on windows

### DIFF
--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -6,17 +6,15 @@ import spawn from 'spawn-please'
 import chaiSetup from './helpers/chaiSetup'
 import stubVersions from './helpers/stubVersions'
 
-/** @returns Whether the tests are being run on the Windows operating system. */
-function onWindows(): boolean {
-  return process.platform === 'win32'
-}
-
 /**
  * It is necessary to sleep on Windows to get around errors like:
  * Error: EBUSY: resource busy or locked, rmdir 'C:\Users\alice\AppData\Local\Temp\npm-check-updates-yc1wT3'
  */
-async function sleep(milliseconds: number) {
-  await new Promise(resolve => setTimeout(resolve, milliseconds))
+async function sleepOnWindows() {
+  if (process.platform === 'win32') {
+    // 100 milliseconds is arbitrarily chosen, but it seems to successfully resolve the issue.
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
 }
 
 chaiSetup()
@@ -81,9 +79,7 @@ describe('format', () => {
       const { stdout } = await spawn('node', [bin, '--format', 'lines'], {}, { cwd: tempDir })
       stdout.should.equals('ncu-test-v2@^2.0.0\nncu-test-tag@^1.1.0\n')
     } finally {
-      if (onWindows()) {
-        await sleep(100)
-      }
+      await sleepOnWindows()
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -119,9 +115,7 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot specify both --format lines and --jsonUpgraded.')
     } finally {
-      if (onWindows()) {
-        await sleep(100)
-      }
+      await sleepOnWindows()
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -157,9 +151,7 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot specify both --format lines and --jsonAll.')
     } finally {
-      if (onWindows()) {
-        await sleep(100)
-      }
+      await sleepOnWindows()
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -195,9 +187,7 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot use --format lines with other formatting options.')
     } finally {
-      if (onWindows()) {
-        await sleep(100)
-      }
+      await sleepOnWindows()
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -68,6 +68,7 @@ describe('format', () => {
       const { stdout } = await spawn('node', [bin, '--format', 'lines'], {}, { cwd: tempDir })
       stdout.should.equals('ncu-test-v2@^2.0.0\nncu-test-tag@^1.1.0\n')
     } finally {
+      await new Promise(resolve => setTimeout(resolve, 100))
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -103,6 +104,7 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot specify both --format lines and --jsonUpgraded.')
     } finally {
+      await new Promise(resolve => setTimeout(resolve, 100))
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -138,6 +140,7 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot specify both --format lines and --jsonAll.')
     } finally {
+      await new Promise(resolve => setTimeout(resolve, 100))
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -173,6 +176,7 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot use --format lines with other formatting options.')
     } finally {
+      await new Promise(resolve => setTimeout(resolve, 100))
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -6,6 +6,19 @@ import spawn from 'spawn-please'
 import chaiSetup from './helpers/chaiSetup'
 import stubVersions from './helpers/stubVersions'
 
+/** @returns Whether the tests are being run on the Windows operating system. */
+function onWindows(): boolean {
+  return process.platform === 'win32'
+}
+
+/**
+ * It is necessary to sleep on Windows to get around errors like:
+ * Error: EBUSY: resource busy or locked, rmdir 'C:\Users\alice\AppData\Local\Temp\npm-check-updates-yc1wT3'
+ */
+async function sleep(milliseconds: number) {
+  await new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
 chaiSetup()
 
 const bin = path.join(__dirname, '../build/cli.js')
@@ -68,6 +81,9 @@ describe('format', () => {
       const { stdout } = await spawn('node', [bin, '--format', 'lines'], {}, { cwd: tempDir })
       stdout.should.equals('ncu-test-v2@^2.0.0\nncu-test-tag@^1.1.0\n')
     } finally {
+      if (onWindows()) {
+        await sleep(100)
+      }
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -103,6 +119,9 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot specify both --format lines and --jsonUpgraded.')
     } finally {
+      if (onWindows()) {
+        await sleep(100)
+      }
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -138,6 +157,9 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot specify both --format lines and --jsonAll.')
     } finally {
+      if (onWindows()) {
+        await sleep(100)
+      }
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -173,6 +195,9 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot use --format lines with other formatting options.')
     } finally {
+      if (onWindows()) {
+        await sleep(100)
+      }
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -68,7 +68,6 @@ describe('format', () => {
       const { stdout } = await spawn('node', [bin, '--format', 'lines'], {}, { cwd: tempDir })
       stdout.should.equals('ncu-test-v2@^2.0.0\nncu-test-tag@^1.1.0\n')
     } finally {
-      await new Promise(resolve => setTimeout(resolve, 100))
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -104,7 +103,6 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot specify both --format lines and --jsonUpgraded.')
     } finally {
-      await new Promise(resolve => setTimeout(resolve, 100))
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -140,7 +138,6 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot specify both --format lines and --jsonAll.')
     } finally {
-      await new Promise(resolve => setTimeout(resolve, 100))
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }
@@ -176,7 +173,6 @@ describe('format', () => {
         },
       ).should.eventually.be.rejectedWith('Cannot use --format lines with other formatting options.')
     } finally {
-      await new Promise(resolve => setTimeout(resolve, 100))
       await fs.rm(tempDir, { recursive: true, force: true })
       stub.restore()
     }

--- a/test/getIgnoredUpgradesDueToPeerDeps.test.ts
+++ b/test/getIgnoredUpgradesDueToPeerDeps.test.ts
@@ -7,6 +7,10 @@ chaiSetup()
 
 describe('getIgnoredUpgradesDueToPeerDeps', function () {
   it('ncu-test-peer-update', async () => {
+    const stub = stubVersions({
+      'ncu-test-return-version': '2.0.0',
+      'ncu-test-peer': '1.1.0',
+    })
     const data = await getIgnoredUpgradesDueToPeerDeps(
       {
         'ncu-test-return-version': '1.0.0',
@@ -32,6 +36,7 @@ describe('getIgnoredUpgradesDueToPeerDeps', function () {
         },
       },
     })
+    stub.restore()
   })
   it('ignored peer after upgrade', async () => {
     const stub = stubVersions({

--- a/test/getIgnoredUpgradesDueToPeerDeps.test.ts
+++ b/test/getIgnoredUpgradesDueToPeerDeps.test.ts
@@ -7,10 +7,6 @@ chaiSetup()
 
 describe('getIgnoredUpgradesDueToPeerDeps', function () {
   it('ncu-test-peer-update', async () => {
-    const stub = stubVersions({
-      'ncu-test-return-version': '2.0.0',
-      'ncu-test-peer': '1.1.0',
-    })
     const data = await getIgnoredUpgradesDueToPeerDeps(
       {
         'ncu-test-return-version': '1.0.0',
@@ -36,7 +32,6 @@ describe('getIgnoredUpgradesDueToPeerDeps', function () {
         },
       },
     })
-    stub.restore()
   })
   it('ignored peer after upgrade', async () => {
     const stub = stubVersions({

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -30,7 +30,7 @@ describe('install', () => {
 
       try {
         const { stdout } = await spawn('node', [bin, '-u', '--packageFile', pkgFile])
-        stripAnsi(stdout).should.include('Run npm install to install new versions')
+        stripAnsi(stdout).should.match(/Run (npm install|yarn install) to install new versions/)
         expect(await exists(path.join(tempDir, 'package-lock.json'))).to.be.false
         expect(await exists(path.join(tempDir, 'node_modules'))).to.be.false
       } finally {
@@ -54,8 +54,13 @@ describe('install', () => {
 
       try {
         const { stdout } = await spawn('node', [bin, '-u', '--packageFile', pkgFile, '--install', 'always'])
+        const lockFile = (await exists(path.join(tempDir, 'yarn.lock')))
+          ? 'yarn.lock'
+          : (await exists(path.join(tempDir, 'bun.lockb')))
+            ? 'bun.lockb'
+            : 'package-lock.json'
         stripAnsi(stdout).should.not.include('Run npm install to install new versions')
-        expect(await exists(path.join(tempDir, 'package-lock.json'))).to.be.true
+        expect(await exists(path.join(tempDir, lockFile))).to.be.true
         expect(await exists(path.join(tempDir, 'node_modules'))).to.be.true
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true })
@@ -113,7 +118,12 @@ describe('install', () => {
             },
           },
         )
-        expect(await exists(path.join(tempDir, 'package-lock.json'))).to.be.true
+        const lockFile = (await exists(path.join(tempDir, 'yarn.lock')))
+          ? 'yarn.lock'
+          : (await exists(path.join(tempDir, 'bun.lockb')))
+            ? 'bun.lockb'
+            : 'package-lock.json'
+        expect(await exists(path.join(tempDir, lockFile))).to.be.true
         expect(await exists(path.join(tempDir, 'node_modules'))).to.be.true
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true })
@@ -179,7 +189,12 @@ describe('install', () => {
             },
           },
         )
-        expect(await exists(path.join(tempDir, 'package-lock.json'))).to.be.true
+        const lockFile = (await exists(path.join(tempDir, 'yarn.lock')))
+          ? 'yarn.lock'
+          : (await exists(path.join(tempDir, 'bun.lockb')))
+            ? 'bun.lockb'
+            : 'package-lock.json'
+        expect(await exists(path.join(tempDir, lockFile))).to.be.true
         expect(await exists(path.join(tempDir, 'node_modules'))).to.be.true
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true })

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -102,6 +102,7 @@ describe('install', () => {
         const { stdout } = await spawn('node', [bin, '-u', '--packageFile', pkgFile, '--install', 'never'])
         stripAnsi(stdout).should.not.match(/Run (npm|yarn) install to install new versions/)
         expect(await exists(path.join(tempDir, 'package-lock.json'))).to.be.false
+        expect(await exists(path.join(tempDir, 'yarn.lock'))).to.be.false
         expect(await exists(path.join(tempDir, 'node_modules'))).to.be.false
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true })


### PR DESCRIPTION
Fixes #1530 

This PR was (partially) created with the Gemini CLI tool. (I did some refactoring of my own to make it more sane.)
"npm test" now passes on Windows.

However, Gemini insisted on "fixing a critical performance issue with peer dependencies", which is why there are changes to the "getPeerDependenciesFromRegistry.ts" file. I decided to leave that in the PR for your review. If you think it is bogus, then I can take it out.