### PR TITLE
Add catalog support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -226,17 +226,17 @@ async function runUpgrades(options: Options, timeout?: NodeJS.Timeout): Promise<
         }
         // For virtual catalog files (like package.json#catalog), use the PackageInfo data directly
         // since the virtual file doesn't exist on disk
-        let pkgData: string
+        let pkgData: string | null
         let pkgFile: string
 
         if (packageInfo.filepath.includes('#') || packageInfo.name === 'catalogs') {
           // Virtual catalog file or catalog package - use PackageInfo data
-          pkgData = packageInfo.pkgFile || ''
+          pkgData = packageInfo.pkgFile
           pkgFile = packageInfo.filepath
         } else {
           // Regular file - read from disk
           const result = await findPackage(pkgOptions)
-          pkgData = result.pkgData || ''
+          pkgData = result.pkgData
           pkgFile = result.pkgFile || packageInfo.filepath
         }
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,26 +228,32 @@ async function runUpgrades(options: Options, timeout?: NodeJS.Timeout): Promise<
         // since the virtual file doesn't exist on disk
         let pkgData: string | null
         let pkgFile: string
+        let indexKey: string
 
         if (packageInfo.filepath.includes('#') || packageInfo.name === 'catalogs') {
           // Virtual catalog file or catalog package - use PackageInfo data
           pkgData = packageInfo.pkgFile
           pkgFile = packageInfo.filepath
+          // For synthetic catalog files, use the actual underlying file path as the index key
+          indexKey = packageInfo.filepath.includes('#catalog') 
+            ? packageInfo.filepath.replace('#catalog', '')
+            : packageInfo.filepath
         } else {
           // Regular file - read from disk
           const result = await findPackage(pkgOptions)
           pkgData = result.pkgData
           pkgFile = result.pkgFile || packageInfo.filepath
+          indexKey = pkgFile
         }
         return {
           ...packages,
           // index by relative path if cwd was specified
           [pkgOptions.cwd
             ? path
-                .relative(path.resolve(pkgOptions.cwd), pkgFile!)
+                .relative(path.resolve(pkgOptions.cwd), indexKey)
                 // convert Windows path to *nix path for consistency
                 .replace(/\\/g, '/')
-            : pkgFile!]: await runLocal(pkgOptions, pkgData, pkgFile),
+            : indexKey]: await runLocal(pkgOptions, pkgData, pkgFile),
         }
       },
       Promise.resolve({} as Index<PackageFile> | PackageFile),

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,9 +235,13 @@ async function runUpgrades(options: Options, timeout?: NodeJS.Timeout): Promise<
           pkgData = packageInfo.pkgFile
           pkgFile = packageInfo.filepath
           // For synthetic catalog files, use the actual underlying file path as the index key
-          indexKey = packageInfo.filepath.includes('#catalog') 
+          indexKey = packageInfo.filepath.includes('#catalog')
             ? packageInfo.filepath.replace('#catalog', '')
             : packageInfo.filepath
+
+          // Print the same message as findPackage for consistency
+          const relPathToPackage = path.resolve(indexKey)
+          print(pkgOptions, `${pkgOptions.upgrade ? 'Upgrading' : 'Checking'} ${relPathToPackage} catalog dependencies`)
         } else {
           // Regular file - read from disk
           const result = await findPackage(pkgOptions)

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,7 +224,21 @@ async function runUpgrades(options: Options, timeout?: NodeJS.Timeout): Promise<
           packageFile: packageInfo.filepath,
           workspacePackages,
         }
-        const { pkgData, pkgFile } = await findPackage(pkgOptions)
+        // For virtual catalog files (like package.json#catalog), use the PackageInfo data directly
+        // since the virtual file doesn't exist on disk
+        let pkgData: string
+        let pkgFile: string
+
+        if (packageInfo.filepath.includes('#')) {
+          // Virtual catalog file - use PackageInfo data
+          pkgData = packageInfo.pkgFile || ''
+          pkgFile = packageInfo.filepath
+        } else {
+          // Regular file - read from disk
+          const result = await findPackage(pkgOptions)
+          pkgData = result.pkgData || ''
+          pkgFile = result.pkgFile || packageInfo.filepath
+        }
         return {
           ...packages,
           // index by relative path if cwd was specified

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,8 +229,8 @@ async function runUpgrades(options: Options, timeout?: NodeJS.Timeout): Promise<
         let pkgData: string
         let pkgFile: string
 
-        if (packageInfo.filepath.includes('#')) {
-          // Virtual catalog file - use PackageInfo data
+        if (packageInfo.filepath.includes('#') || packageInfo.name === 'catalogs') {
+          // Virtual catalog file or catalog package - use PackageInfo data
           pkgData = packageInfo.pkgFile || ''
           pkgFile = packageInfo.filepath
         } else {

--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -292,7 +292,7 @@ export default async function runLocal(
     }
   }
 
-  const newPkgData = await upgradePackageData(pkgData, current, chosenUpgraded, options)
+  const newPkgData = await upgradePackageData(pkgData, current, chosenUpgraded, options, pkgFile || undefined)
 
   const output: PackageFile | Index<VersionSpec> = options.jsonAll
     ? (parseJson(newPkgData) as PackageFile)

--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -313,7 +313,7 @@ export default async function runLocal(
     if (pkgFile) {
       if (options.upgrade) {
         // do not await until the end
-        writePromise = fs.writeFile(pkgFile, newPkgData)
+        writePromise = fs.writeFile(pkgFile.replace('#catalog', ''), newPkgData)
       } else {
         const ncuCmd = process.env.npm_lifecycle_event === 'npx' ? 'npx npm-check-updates' : 'ncu'
         // quote arguments with spaces

--- a/src/lib/upgradeCatalogData.ts
+++ b/src/lib/upgradeCatalogData.ts
@@ -1,0 +1,98 @@
+import fs from 'fs/promises'
+import path from 'path'
+import { Index } from '../types/IndexType'
+import { VersionSpec } from '../types/VersionSpec'
+
+/**
+ * @returns String safe for use in `new RegExp()`
+ */
+function escapeRegexp(s: string) {
+  return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+}
+
+/**
+ * Upgrade catalog dependencies in a YAML file (e.g., pnpm-workspace.yaml).
+ */
+async function upgradeYamlCatalogData(
+  filePath: string,
+  current: Index<VersionSpec>,
+  upgraded: Index<VersionSpec>,
+): Promise<string> {
+  const fileContent = await fs.readFile(filePath, 'utf-8')
+  let newContent = fileContent
+
+  // Use regex replacement to maintain original formatting
+  Object.keys(upgraded).forEach(dep => {
+    const currentVersion = current[dep]
+    const newVersion = upgraded[dep]
+
+    if (currentVersion && newVersion) {
+      // Match both quoted and unquoted versions
+      const quotedPattern = `(${escapeRegexp(dep)}\\s*:\\s*["'])(${escapeRegexp(currentVersion)})(["'])`
+      const unquotedPattern = `(${escapeRegexp(dep)}\\s*:\\s*)(${escapeRegexp(currentVersion)})(\\s*(?:\\n|$))`
+
+      const quotedRegex = new RegExp(quotedPattern, 'g')
+      const unquotedRegex = new RegExp(unquotedPattern, 'g')
+
+      newContent = newContent.replace(quotedRegex, `$1${newVersion}$3`)
+      newContent = newContent.replace(unquotedRegex, `$1${newVersion}$3`)
+    }
+  })
+
+  return newContent
+}
+
+/**
+ * Upgrade catalog dependencies in a JSON file (e.g., package.json for Bun).
+ */
+async function upgradeJsonCatalogData(
+  filePath: string,
+  current: Index<VersionSpec>,
+  upgraded: Index<VersionSpec>,
+): Promise<string> {
+  const fileContent = await fs.readFile(filePath, 'utf-8')
+  let newContent = fileContent
+
+  // Use regex replacement to maintain JSON formatting
+  Object.keys(upgraded).forEach(dep => {
+    const currentVersion = current[dep]
+    const newVersion = upgraded[dep]
+
+    if (currentVersion && newVersion) {
+      // Match catalog and catalogs sections in JSON (both top-level and within workspaces)
+      const catalogPattern = `("${escapeRegexp(dep)}"\\s*:\\s*")(${escapeRegexp(currentVersion)})(")`
+      const catalogRegex = new RegExp(catalogPattern, 'g')
+
+      newContent = newContent.replace(catalogRegex, `$1${newVersion}$3`)
+    }
+  })
+
+  return newContent
+}
+
+/**
+ * Upgrade catalog dependencies in either YAML or JSON catalog files.
+ * Supports pnpm-workspace.yaml (pnpm) and package.json (Bun) catalog formats.
+ *
+ * @param filePath The path to the catalog file (pnpm-workspace.yaml or package.json)
+ * @param current Current catalog dependencies {package: range}
+ * @param upgraded New catalog dependencies {package: range}
+ * @returns The updated file content as utf8 text
+ */
+export async function upgradeCatalogData(
+  filePath: string,
+  current: Index<VersionSpec>,
+  upgraded: Index<VersionSpec>,
+): Promise<string> {
+  const fileExtension = path.extname(filePath)
+
+  if (fileExtension === '.yaml' || fileExtension === '.yml') {
+    return upgradeYamlCatalogData(filePath, current, upgraded)
+  } else if (fileExtension === '.json') {
+    return upgradeJsonCatalogData(filePath, current, upgraded)
+  } else {
+    throw new Error(`Unsupported catalog file type: ${filePath}`)
+  }
+}
+
+export default upgradeCatalogData

--- a/src/lib/upgradePackageData.ts
+++ b/src/lib/upgradePackageData.ts
@@ -43,7 +43,7 @@ async function upgradePackageData(
       // This is a synthetic catalog file, we need to read and update the actual file
       const actualFilePath = pkgFile.replace('#catalog', '')
       const actualFileExtension = path.extname(actualFilePath)
-      
+
       if (actualFileExtension === '.json') {
         // Bun format: update package.json catalogs and return the updated content
         return upgradeCatalogData(actualFilePath, current, upgraded)

--- a/src/lib/upgradePackageData.ts
+++ b/src/lib/upgradePackageData.ts
@@ -1,3 +1,5 @@
+import fs from 'fs/promises'
+import yaml from 'js-yaml'
 import path from 'path'
 import { Index } from '../types/IndexType'
 import { Options } from '../types/Options'
@@ -41,6 +43,48 @@ async function upgradePackageData(
       fileName === 'pnpm-workspace.yaml' ||
       (fileName.includes('catalog') && (fileExtension === '.yaml' || fileExtension === '.yml'))
     ) {
+      // Check if we have synthetic catalog data (JSON with only dependencies and name/version)
+      // In this case, we should generate the proper catalog structure
+      try {
+        const parsed = JSON.parse(pkgData)
+        if (parsed.name === 'catalog-dependencies' && parsed.dependencies && Object.keys(parsed).length <= 3) {
+          // This is synthetic catalog data, we need to generate the proper catalog structure
+          // Read the original pnpm-workspace.yaml to get the catalog structure
+          const yamlContent = await fs.readFile(pkgFile, 'utf-8')
+          const yamlData = yaml.load(yamlContent) as any
+
+          // Update catalog dependencies with upgraded versions
+          if (yamlData.catalogs) {
+            Object.keys(yamlData.catalogs).forEach(catalogName => {
+              const catalog = yamlData.catalogs[catalogName]
+              Object.keys(catalog).forEach(dep => {
+                if (upgraded[dep]) {
+                  catalog[dep] = upgraded[dep]
+                }
+              })
+            })
+          }
+
+          // Also handle single catalog (if present)
+          if (yamlData.catalog) {
+            Object.keys(yamlData.catalog).forEach(dep => {
+              if (upgraded[dep]) {
+                yamlData.catalog[dep] = upgraded[dep]
+              }
+            })
+          }
+
+          // For pnpm, also expose the 'default' catalog as a top-level 'catalog' property
+          if (yamlData.catalogs && yamlData.catalogs.default) {
+            yamlData.catalog = yamlData.catalogs.default
+          }
+
+          return JSON.stringify(yamlData, null, 2)
+        }
+      } catch (e) {
+        // If it's not JSON, fall through to normal catalog handling
+      }
+
       return upgradeCatalogData(pkgFile, current, upgraded)
     }
 

--- a/test/workspaces.test.ts
+++ b/test/workspaces.test.ts
@@ -532,6 +532,7 @@ catalogs:
           // write root package file and pnpm-workspace.yaml
           await fs.writeFile(path.join(tempDir, 'package.json'), pkgDataRoot, 'utf-8')
           await fs.writeFile(path.join(tempDir, 'pnpm-workspace.yaml'), pnpmWorkspaceData, 'utf-8')
+          await fs.writeFile(path.join(tempDir, 'pnpm-lock.yaml'), '', 'utf-8')
 
           // create workspace package
           await fs.mkdir(path.join(tempDir, 'packages/a'), { recursive: true })

--- a/test/workspaces.test.ts
+++ b/test/workspaces.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+// eslint doesn't like .should.be.empty syntax
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
@@ -550,13 +552,9 @@ catalogs:
             { cwd: tempDir },
           )
 
-          // Debug output if there are errors
-          if (stderr) {
-            console.log('STDERR:', stderr)
-          }
-          if (!stdout || stdout.trim() === '') {
-            console.log('Empty stdout, stderr was:', stderr)
-          }
+          // Assert no errors and valid output
+          stderr.should.be.empty
+          stdout.should.not.be.empty
 
           const output = JSON.parse(stdout)
 
@@ -610,13 +608,9 @@ catalogs:
             { cwd: tempDir },
           )
 
-          // Debug output if there are errors
-          if (stderr) {
-            console.log('STDERR (top-level):', stderr)
-          }
-          if (!stdout || stdout.trim() === '') {
-            console.log('Empty stdout (top-level), stderr was:', stderr)
-          }
+          // Assert no errors and valid output
+          stderr.should.be.empty
+          stdout.should.not.be.empty
 
           const output = JSON.parse(stdout)
 
@@ -670,13 +664,9 @@ catalogs:
             { cwd: tempDir },
           )
 
-          // Debug output if there are errors
-          if (stderr) {
-            console.log('STDERR (top-level):', stderr)
-          }
-          if (!stdout || stdout.trim() === '') {
-            console.log('Empty stdout (top-level), stderr was:', stderr)
-          }
+          // Assert no errors and valid output
+          stderr.should.be.empty
+          stdout.should.not.be.empty
 
           const output = JSON.parse(stdout)
 

--- a/test/workspaces.test.ts
+++ b/test/workspaces.test.ts
@@ -570,7 +570,9 @@ catalogs:
           await fs.rm(tempDir, { recursive: true, force: true })
         }
       })
+    })
 
+    describe('bun', () => {
       it('update bun catalog dependencies from package.json (top-level)', async () => {
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
         try {


### PR DESCRIPTION
- Fixes #1451

I wanted to use catalogs for a monorepo I maintain that uses Bun for dependency management, and even though Bun now has an interactive update mode, I still like the way `ncu` handles it better.

There didn't seem to be any movement on #1451, and I didn't have a lot of bandwidth to tackle it myself, so I thought I would take Claude Code for a spin and see what it came up with.

This PR is basically 100% AI generated, with some gentle guidance here and there. But I've looked over it pretty thoroughly and of course tested it on my own project. (I only tested Bun, not pnpm, and there was a pnpm test failing that may have just been a local setup thing. Anyway we'll see how CI goes...)

> _NARRATOR: It wasn't just a local setup thing_