### PR TITLE
fix(cooldown): support newest, minor, patch, and semver targets

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -926,8 +926,6 @@ export const newest: GetVersion = async (
       ),
     )
 
-    console.log({ versionsSatisfiesfyingCooldownPeriod, result })
-
     return { version: versionsSatisfiesfyingCooldownPeriod.at(-1) }
   }
 

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -27,7 +27,7 @@ import { SpawnPleaseOptions } from '../types/SpawnPleaseOptions'
 import { Version } from '../types/Version'
 import { VersionResult } from '../types/VersionResult'
 import { VersionSpec } from '../types/VersionSpec'
-import { filterPredicate, satisfiesNodeEngine, satisfiesCooldownPeriod } from './filters'
+import { filterPredicate, satisfiesCooldownPeriod, satisfiesNodeEngine } from './filters'
 
 const EXPLICIT_RANGE_OPS = new Set(['-', '||', '&&', '<', '<=', '>', '>='])
 
@@ -918,10 +918,12 @@ export const newest: GetVersion = async (
   // sort by timestamp (entry[1]) and map versions
   const versionsSortedByTime = sortBy(Object.entries(timesSatisfyingNodeEngine), v => v[1]).map(([version]) => version)
 
-  
   if (options.cooldown) {
     const versionsSatisfiesfyingCooldownPeriod = versionsSortedByTime.filter(version =>
-      satisfiesCooldownPeriod(decorateTagPackumentWithTime((result as Packument).versions[version], result as Packument), options.cooldown),
+      satisfiesCooldownPeriod(
+        decorateTagPackumentWithTime((result as Packument).versions[version], result as Packument),
+        options.cooldown,
+      ),
     )
 
     console.log({ versionsSatisfiesfyingCooldownPeriod, result })
@@ -953,7 +955,15 @@ export const minor: GetVersion = async (
     fields.push('time')
   }
 
-  const packument = await fetchUpgradedPackumentMemo(packageName, fields, currentVersion, options, 0, npmConfig, npmConfigProject);
+  const packument = await fetchUpgradedPackumentMemo(
+    packageName,
+    fields,
+    currentVersion,
+    options,
+    0,
+    npmConfig,
+    npmConfigProject,
+  )
 
   const versions = packument?.versions as Index<Packument>
   const version = versionUtil.findGreatestByLevel(
@@ -989,14 +999,22 @@ export const patch: GetVersion = async (
     fields.push('time')
   }
 
-  const packument = await fetchUpgradedPackumentMemo(packageName, fields, currentVersion, options, 0, npmConfig, npmConfigProject);
+  const packument = await fetchUpgradedPackumentMemo(
+    packageName,
+    fields,
+    currentVersion,
+    options,
+    0,
+    npmConfig,
+    npmConfigProject,
+  )
 
   const versions = packument?.versions as Index<Packument>
   const version = versionUtil.findGreatestByLevel(
     Object.values(versions || {})
-        .filter(tagPackument =>
-          filterPredicate(options)(decorateTagPackumentWithTime(tagPackument, packument as Partial<Packument>)),
-        )
+      .filter(tagPackument =>
+        filterPredicate(options)(decorateTagPackumentWithTime(tagPackument, packument as Partial<Packument>)),
+      )
       .map(o => o.version),
     currentVersion,
     'patch',
@@ -1025,7 +1043,15 @@ export const semver: GetVersion = async (
     fields.push('time')
   }
 
-  const packument = await fetchUpgradedPackumentMemo(packageName, fields, currentVersion, options, 0, npmConfig, npmConfigProject);
+  const packument = await fetchUpgradedPackumentMemo(
+    packageName,
+    fields,
+    currentVersion,
+    options,
+    0,
+    npmConfig,
+    npmConfigProject,
+  )
 
   const versions = packument?.versions as Index<Packument>
   // ignore explicit version ranges
@@ -1033,8 +1059,8 @@ export const semver: GetVersion = async (
 
   const versionsFiltered = Object.values(versions || {})
     .filter(tagPackument =>
-          filterPredicate(options)(decorateTagPackumentWithTime(tagPackument, packument as Partial<Packument>)),
-        )
+      filterPredicate(options)(decorateTagPackumentWithTime(tagPackument, packument as Partial<Packument>)),
+    )
     .map(o => o.version)
   // TODO: Upgrading within a prerelease does not seem to work.
   // { includePrerelease: true } does not help.

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -304,6 +304,121 @@ describe('cooldown', () => {
     })
   })
 
+  describe('when newest target', () => {
+    it('upgrades package to newest version older than cooldown period', async () => {
+      // Given: test-package@1.0.0 installed, version 1.2.0 released 5 days ago (within cooldown), version 1.1.0 released 15 days ago (outside 10-day cooldown)
+      const cooldown = 10
+      const packageData: PackageFile = {
+        dependencies: {
+          'test-package': '1.0.0',
+        },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.2.0': new Date(NOW - 5 * DAY).toISOString(),
+            '1.1.0': new Date(NOW - 15 * DAY).toISOString(),
+          },
+        }),
+      )
+
+      // When ncu is run with the cooldown parameter and target is 'newest'
+      const result = await ncu({ packageData, cooldown, target: 'newest' })
+
+      // Then: package is upgraded to version 1.1.0 (newest version outside cooldown)
+      expect(result).to.have.property('test-package', '1.1.0')
+
+      stub.restore()
+    })
+  });
+
+  describe('when minor target', () => {
+    it('upgrades package to newest minor version older than cooldown period', async () => {
+      // Given: test-package@1.0.0 installed, version 1.2.0 released 5 days ago (within cooldown), version 1.1.0 released 15 days ago (outside 10-day cooldown)
+      const cooldown = 10
+      const packageData: PackageFile = {
+        dependencies: {
+          'test-package': '1.0.0',
+        },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.2.0': new Date(NOW - 5 * DAY).toISOString(),
+            '1.1.0': new Date(NOW - 15 * DAY).toISOString(),
+          },
+        }),
+      )
+
+      // When ncu is run with the cooldown parameter and target is 'minor'
+      const result = await ncu({ packageData, cooldown, target: 'minor' })
+
+      // Then: package is upgraded to version 1.1.0 (newest minor version outside cooldown)
+      expect(result).to.have.property('test-package', '1.1.0')
+
+      stub.restore()
+    })
+  })
+
+  describe('when patch target', () => {
+    it('upgrades package to newest patch version older than cooldown period', async () => {
+      // Given: test-package@1.0.0 installed, version 1.0.2 released 5 days ago (within cooldown), version 1.0.1 released 15 days ago (outside 10-day cooldown)
+      const cooldown = 10
+      const packageData: PackageFile = {
+        dependencies: {
+          'test-package': '1.0.0',
+        },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.0.2': new Date(NOW - 5 * DAY).toISOString(),
+            '1.0.1': new Date(NOW - 15 * DAY).toISOString(),
+          },
+        }),
+      )
+
+      // When ncu is run with the cooldown parameter and target is 'patch'
+      const result = await ncu({ packageData, cooldown, target: 'patch' })
+
+      // Then: package is upgraded to version 1.0.1 (newest patch version outside cooldown)
+      expect(result).to.have.property('test-package', '1.0.1')
+
+      stub.restore()
+    })
+  })
+
+  describe('when semver target', () => {
+    it('upgrades package to newest semver version older than cooldown period', async () => {
+      // Given: test-package@1.0.0 installed, version 1.1.0 released 5 days ago (within cooldown), version 1.0.1 released 15 days ago (outside 10-day cooldown)
+      const cooldown = 10
+      const packageData: PackageFile = {
+        dependencies: {
+          'test-package': '^1.0.0',
+        },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.1.0': new Date(NOW - 5 * DAY).toISOString(),
+            '1.0.1': new Date(NOW - 15 * DAY).toISOString(),
+          },
+        }),
+      )
+
+      // When ncu is run with the cooldown parameter and target is 'semver'
+      const result = await ncu({ packageData, cooldown, target: 'semver' })
+      
+      // Then: package is upgraded to version ^1.0.1 (newest semver version outside cooldown)
+      expect(result).to.have.property('test-package', '^1.0.1')
+      stub.restore()
+    })
+  })
+
   it('skips package upgrade if no time data and cooldown is set', async () => {
     // Given: cooldown days is set to 10 days, test-package is installed in version 1.0.0, and the latest version - 1.1.0 was released 5 days ago (inside cooldown period). Another version 1.0.1 was released 10 days ago (outside cooldown period), but it is not the latest version, so it should not be upgraded either.
     const cooldown = 10

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -331,7 +331,7 @@ describe('cooldown', () => {
 
       stub.restore()
     })
-  });
+  })
 
   describe('when minor target', () => {
     it('upgrades package to newest minor version older than cooldown period', async () => {
@@ -412,7 +412,7 @@ describe('cooldown', () => {
 
       // When ncu is run with the cooldown parameter and target is 'semver'
       const result = await ncu({ packageData, cooldown, target: 'semver' })
-      
+
       // Then: package is upgraded to version ^1.0.1 (newest semver version outside cooldown)
       expect(result).to.have.property('test-package', '^1.0.1')
       stub.restore()


### PR DESCRIPTION
## Issue
In the current implementation, the cooldown parameter functions only with the latest and greatest targets. For other targets (`newest`, `minor`, `patch`, or `semver`), it is broken - when used together, no updates are ever applied - despite being listed as supported in the documentation:

```
With other targets:

$ ncu --cooldown 5 --target greatest|newest|minor|patch|semver

Each target will select the best version that is at least 5 days old:

    greatest → 1.2.0        (highest version number outside cooldown)
    newest   → 2.0.0-beta.1 (most recently published version outside cooldown)
    minor    → 1.2.0        (highest minor version outside cooldown)
    patch    → 1.1.1        (highest patch version outside cooldown)
```
> [source](https://github.com/raineorshine/npm-check-updates#cooldown)

This PR is a fix for supporting rest of the targets