### PR TITLE
add support for skipping pinned vesrions

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,10 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
     <td>Don't output anything. Alias for <code>--loglevel</code> silent.</td>
   </tr>
   <tr>
+    <td>--skipPinned</td>
+    <td>Skip upgrading pinned versions (exact versions without range indicators like ^, ~, >=, etc.).</td>
+  </tr>
+  <tr>
     <td>--stdin</td>
     <td>Read package.json from stdin.</td>
   </tr>

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -920,6 +920,11 @@ const cliOptions: CLIOption[] = [
     type: 'boolean',
   },
   {
+    long: 'skipPinned',
+    description: 'Skip upgrading pinned versions (exact versions without range indicators like ^, ~, >=, etc.).',
+    type: 'boolean',
+  },
+  {
     long: 'stdin',
     description: 'Read package.json from stdin.',
     type: 'string',

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -81,7 +81,7 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
 
     try {
       if (options.skipPinned && isPinned(version)) {
-        print(options, `Skipping package ${name} with pinned version ${version}`, 'verbose')
+        print(options, `Skipping package ${name} with pinned version ${version}`, 'warn')
         versionResult = {}
       } else {
         versionResult = await getPackageVersion(name, version, {

--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -9,6 +9,7 @@ import { Maybe } from '../types/Maybe'
 import { Options } from '../types/Options'
 import { UpgradeGroup } from '../types/UpgradeGroup'
 import { VersionLevel } from '../types/VersionLevel'
+import { VersionSpec } from '../types/VersionSpec'
 import chalk from './chalk'
 import { keyValueBy } from './keyValueBy'
 import { sortBy } from './sortBy'
@@ -544,4 +545,17 @@ export const upgradeGithubUrl = (declaration: string, upgraded: string) => {
   if (!parsedUrl) return declaration
   const tag = decodeURIComponent(parsedUrl.branch).replace(/^semver:/, '')
   return declaration.replace(tag, upgradeDependencyDeclaration(tag, revertPseudoVersion(tag, upgradedNormalized)))
+}
+
+/**
+ * Determines if a version is pinned (exact version without range indicators like ^, ~, >=, etc.).
+ *
+ * @param version The version string to check
+ * @returns True if the version is pinned, false otherwise
+ */
+export const isPinned = (version: VersionSpec): boolean => {
+  // Handle npm aliases by extracting the version part
+  const npmAliasMatch = version.match(NPM_ALIAS_REGEX)
+  const versionToCheck = npmAliasMatch ? npmAliasMatch[2] : version
+  return Boolean(semver.valid(versionToCheck))
 }

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -455,6 +455,10 @@
       "description": "Don't output anything. Alias for `--loglevel` silent.",
       "type": "boolean"
     },
+    "skipPinned": {
+      "description": "Skip upgrading pinned versions (exact versions without range indicators like ^, ~, >=, etc.).",
+      "type": "boolean"
+    },
     "stdin": {
       "description": "Read package.json from stdin.",
       "type": "string"

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -175,6 +175,9 @@ export interface RunOptions {
   /** Don't output anything. Alias for `--loglevel` silent. */
   silent?: boolean
 
+  /** Skip upgrading pinned versions (exact versions without range indicators like ^, ~, >=, etc.). */
+  skipPinned?: boolean
+
   /** Read package.json from stdin. */
   stdin?: string
 

--- a/test/queryVersions.test.ts
+++ b/test/queryVersions.test.ts
@@ -20,6 +20,17 @@ describe('queryVersions', function () {
     stub.restore()
   })
 
+  it('piined version should be ignored when asked packages', async () => {
+    const stub = stubVersions('99.9.9')
+    const latestVersions = await queryVersions(
+      { async: '1.5.1', npm: '^3.10.3' },
+      { loglevel: 'silent', skipPinned: true },
+    )
+    latestVersions.should.not.have.property('async')
+    latestVersions.should.have.property('npm')
+    stub.restore()
+  })
+
   it('unavailable packages should be ignored', async () => {
     const result = await queryVersions({ abchdefntofknacuifnt: '1.2.3' }, { loglevel: 'silent' })
     result.should.deep.equal({})

--- a/test/version-util.test.ts
+++ b/test/version-util.test.ts
@@ -544,4 +544,114 @@ describe('version-util', () => {
       })
     })
   })
+
+  describe('isPinned', () => {
+    it('should return true for exact versions (pinned)', () => {
+      versionUtil.isPinned('1.0.0').should.equal(true)
+      versionUtil.isPinned('2.5.10').should.equal(true)
+      versionUtil.isPinned('0.1.0').should.equal(true)
+      versionUtil.isPinned('10.20.30').should.equal(true)
+    })
+
+    it('should return false for versions with caret (^)', () => {
+      versionUtil.isPinned('^1.0.0').should.equal(false)
+      versionUtil.isPinned('^1.0').should.equal(false)
+      versionUtil.isPinned('^1').should.equal(false)
+    })
+
+    it('should return false for versions with tilde (~)', () => {
+      versionUtil.isPinned('~1.0.0').should.equal(false)
+      versionUtil.isPinned('~1.0').should.equal(false)
+      versionUtil.isPinned('~1').should.equal(false)
+    })
+
+    it('should return false for versions with greater than or equal (>=)', () => {
+      versionUtil.isPinned('>=1.0.0').should.equal(false)
+      versionUtil.isPinned('>=1.0').should.equal(false)
+      versionUtil.isPinned('>=1').should.equal(false)
+    })
+
+    it('should return false for versions with greater than (>)', () => {
+      versionUtil.isPinned('>1.0.0').should.equal(false)
+      versionUtil.isPinned('>1.0').should.equal(false)
+      versionUtil.isPinned('>1').should.equal(false)
+    })
+
+    it('should return false for versions with less than or equal (<=)', () => {
+      versionUtil.isPinned('<=1.0.0').should.equal(false)
+      versionUtil.isPinned('<=1.0').should.equal(false)
+      versionUtil.isPinned('<=1').should.equal(false)
+    })
+
+    it('should return false for versions with less than (<)', () => {
+      versionUtil.isPinned('<1.0.0').should.equal(false)
+      versionUtil.isPinned('<1.0').should.equal(false)
+      versionUtil.isPinned('<1').should.equal(false)
+    })
+
+    it('should return false for wildcard versions', () => {
+      versionUtil.isPinned('*').should.equal(false)
+      versionUtil.isPinned('1.*').should.equal(false)
+      versionUtil.isPinned('1.0.*').should.equal(false)
+      versionUtil.isPinned('x').should.equal(false)
+      versionUtil.isPinned('x.x').should.equal(false)
+      versionUtil.isPinned('x.x.x').should.equal(false)
+      versionUtil.isPinned('1.x').should.equal(false)
+      versionUtil.isPinned('1.0.x').should.equal(false)
+      versionUtil.isPinned('1.x.x').should.equal(false)
+      versionUtil.isPinned('^*').should.equal(false)
+    })
+
+    it('should return false for range versions', () => {
+      versionUtil.isPinned('1.0.0 - 2.0.0').should.equal(false)
+      versionUtil.isPinned('1.0 - 2.0').should.equal(false)
+      versionUtil.isPinned('1 - 2').should.equal(false)
+    })
+
+    it('should return false for OR conditions', () => {
+      versionUtil.isPinned('1.0.0 || 2.0.0').should.equal(false)
+      versionUtil.isPinned('^1.0.0 || ^2.0.0').should.equal(false)
+      versionUtil.isPinned('~1.0.0 || ~2.0.0').should.equal(false)
+    })
+
+    it('should return true for npm aliases with pinned versions', () => {
+      versionUtil.isPinned('npm:chalk@1.0.0').should.equal(true)
+      versionUtil.isPinned('npm:lodash@4.17.21').should.equal(true)
+      versionUtil.isPinned('npm:react@16.8.0').should.equal(true)
+    })
+
+    it('should return false for npm aliases with unpinned versions', () => {
+      versionUtil.isPinned('npm:chalk@^1.0.0').should.equal(false)
+      versionUtil.isPinned('npm:lodash@~4.17.21').should.equal(false)
+      versionUtil.isPinned('npm:react@>=16.8.0').should.equal(false)
+      versionUtil.isPinned('npm:vue@*').should.equal(false)
+    })
+
+    it('should return true for prerelease versions that are pinned', () => {
+      versionUtil.isPinned('1.0.0-alpha.1').should.equal(true)
+      versionUtil.isPinned('2.0.0-beta.3').should.equal(true)
+      versionUtil.isPinned('1.0.0-rc.1').should.equal(true)
+      versionUtil.isPinned('1.0.0-next.1').should.equal(true)
+    })
+
+    it('should return false for prerelease versions with range operators', () => {
+      versionUtil.isPinned('^1.0.0-alpha.1').should.equal(false)
+      versionUtil.isPinned('~2.0.0-beta.3').should.equal(false)
+      versionUtil.isPinned('>=1.0.0-rc.1').should.equal(false)
+    })
+
+    it('should return false for invalid or empty versions', () => {
+      versionUtil.isPinned('').should.equal(false)
+      versionUtil.isPinned('invalid-version').should.equal(false)
+      versionUtil.isPinned('not.a.version').should.equal(false)
+    })
+
+    it('should handle edge cases', () => {
+      versionUtil.isPinned('0.0.0').should.equal(true)
+      versionUtil.isPinned('0.0.1').should.equal(true)
+      versionUtil.isPinned('0.1.0').should.equal(true)
+      versionUtil.isPinned('1.0.0-0').should.equal(true)
+      versionUtil.isPinned('1.0.0+build.1').should.equal(true)
+    })
+  })
 })


### PR DESCRIPTION
If someone pinned a version, they might not want to update it. In that case, if using a new flag, it will be skipped