### PR TITLE
fix(cooldown): handle `CooldownFunction` in config file

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -985,7 +985,7 @@ const cliOptions: CLIOption[] = [
       'Sets a minimum age (in days) for package versions to be considered for upgrade, reducing the risk of installing newly published, potentially compromised packages.',
     type: `number | CooldownFunction`,
     help: extendedHelpCooldown,
-    parse: s => (typeof s === 'function' ? s : parseInt(s, 10))
+    parse: s => (typeof s === 'function' ? s : parseInt(s, 10)),
   },
 ]
 


### PR DESCRIPTION
## Description
This PR resolves an issue (#1564) in which providing cooldown as a predicate function in config file causes NCU to raise a validation error: `Cooldown must be a non-negative integer representing days since published or a function` (see example config below)

### Example config
```js
const { defineConfig } = require('npm-check-updates');

module.exports = defineConfig({
  cooldown: packageName => (packageName.startsWith('@my-company') ? 0 : 3)
})
```

Resolves #1564 

