### PR TITLE
fix: support singular 'catalog' field in pnpm-workspace.yaml

### DIFF
--- a/src/lib/getAllPackages.ts
+++ b/src/lib/getAllPackages.ts
@@ -12,7 +12,9 @@ import findPackage from './findPackage'
 import loadPackageInfoFromFile from './loadPackageInfoFromFile'
 import programError from './programError'
 
-type PnpmWorkspaces = string[] | { packages: string[]; catalog?: Index<VersionSpec>; catalogs?: Index<Index<VersionSpec>> }
+type PnpmWorkspaces =
+  | string[]
+  | { packages: string[]; catalog?: Index<VersionSpec>; catalogs?: Index<Index<VersionSpec>> }
 
 const globOptions: GlobOptions = {
   ignore: ['**/node_modules/**'],


### PR DESCRIPTION
## Summary

Fixes two bugs in pnpm catalog support:

1. **Singular 'catalog' field not supported**: Previously only \`catalogs\` (plural, for named catalogs) was supported. This adds support for \`catalog\` (singular, default catalog), which is the standard format for a single catalog in pnpm workspaces.
<img width="719" height="171" alt="image" src="https://github.com/user-attachments/assets/4ca12834-b49b-4420-8ca6-ab9c72a28587" />

3. **Catalogs not checked with --workspace flag**: Catalog checking only occurred with \`--workspaces\` flag, not with \`--workspace <name>\`. Changed condition to ensure catalogs are checked whenever working in workspace 

## Fixes

Potentially "closes" #1543, but I'm not entirely sure what the issue is.

## Changes

- Add support for singular \`catalog\` field in \`pnpm-workspace.yaml\`
- Fix catalog checking to work with both \`--workspaces\` and \`--workspace\` flags
- Add 3 new test cases covering both fixes

## Testing

Added 3 new test 
- Test for singular \`catalog\` field in pnpm-workspace.
- Test for named \`catalogs\` (existing test renamed for 
- Test for catalog checking with \`--workspace\` 

Also verified manually on a real project using singular catalog format.