### PR TITLE
fix(catalog): use the right yarn config name

### DIFF
--- a/src/lib/getAllPackages.ts
+++ b/src/lib/getAllPackages.ts
@@ -36,7 +36,7 @@ const readPnpmWorkspaces = async (pkgPath: string): Promise<PnpmWorkspaces | nul
 
 /** Reads, parses, and resolves catalog information from the yarn config file at the same path as the package file. */
 const readYarnConfig = async (pkgPath: string): Promise<YarnConfig | null> => {
-  const yarnConfigPath = path.join(path.dirname(pkgPath), 'yarnrc.yml')
+  const yarnConfigPath = path.join(path.dirname(pkgPath), '.yarnrc.yml')
   let yarnConfig: string
   try {
     yarnConfig = await fs.readFile(yarnConfigPath, 'utf-8')
@@ -206,7 +206,7 @@ async function getCatalogPackageInfo(options: Options, pkgPath: string): Promise
     options.packageManager === 'pnpm'
       ? path.join(path.dirname(pkgPath), 'pnpm-workspace.yaml')
       : options.packageManager === 'yarn'
-        ? path.join(path.dirname(pkgPath), 'yarnrc.yml')
+        ? path.join(path.dirname(pkgPath), '.yarnrc.yml')
         : `${pkgPath}#catalog`
 
   // Create synthetic file content that matches the synthetic PackageFile

--- a/src/lib/upgradePackageData.ts
+++ b/src/lib/upgradePackageData.ts
@@ -53,7 +53,7 @@ async function upgradePackageData(
     // Handle pnpm-workspace.yaml catalog files
     if (
       fileName === 'pnpm-workspace.yaml' ||
-      fileName === 'yarnrc.yml' ||
+      fileName === '.yarnrc.yml' ||
       (fileName.includes('catalog') && (fileExtension === '.yaml' || fileExtension === '.yml'))
     ) {
       // Check if we have synthetic catalog data (JSON with only dependencies and name/version)

--- a/test/workspaces.test.ts
+++ b/test/workspaces.test.ts
@@ -714,9 +714,9 @@ catalogs:
     ncu-test-tag: '1.0.0'
 `
 
-          // write root package file and yarnrc.yml
+          // write root package file and .yarnrc.yml
           await fs.writeFile(path.join(tempDir, 'package.json'), pkgDataRoot, 'utf-8')
-          await fs.writeFile(path.join(tempDir, 'yarnrc.yml'), yarnConfig, 'utf-8')
+          await fs.writeFile(path.join(tempDir, '.yarnrc.yml'), yarnConfig, 'utf-8')
           await fs.writeFile(path.join(tempDir, 'yarn.lock'), '', 'utf-8')
 
           // create workspace package
@@ -746,7 +746,7 @@ catalogs:
 
           // Should include catalog updates
           output.should.deep.equal({
-            'yarnrc.yml': {
+            '.yarnrc.yml': {
               catalogs: { default: { 'ncu-test-v2': '2.0.0' }, test: { 'ncu-test-tag': '1.1.0' } },
             },
             'package.json': { workspaces: ['packages/**'], dependencies: { 'ncu-test-v2': '2.0.0' } },
@@ -757,7 +757,7 @@ catalogs:
         }
       })
 
-      it('update yarn catalog dependencies from yarnrc.yml (singular catalog)', async () => {
+      it('update yarn catalog dependencies from .yarnrc.yml (singular catalog)', async () => {
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
         try {
           const pkgDataRoot = JSON.stringify({
@@ -775,7 +775,7 @@ catalog:
 
           // write root package file and pnpm-workspace.yaml
           await fs.writeFile(path.join(tempDir, 'package.json'), pkgDataRoot, 'utf-8')
-          await fs.writeFile(path.join(tempDir, 'yarnrc.yml'), yarnConfig, 'utf-8')
+          await fs.writeFile(path.join(tempDir, '.yarnrc.yml'), yarnConfig, 'utf-8')
           await fs.writeFile(path.join(tempDir, 'yarn.lock'), '', 'utf-8')
 
           // create workspace package
@@ -805,7 +805,7 @@ catalog:
 
           // Should include catalog updates
           output.should.deep.equal({
-            'yarnrc.yml': {
+            '.yarnrc.yml': {
               catalog: { 'ncu-test-v2': '2.0.0', 'ncu-test-tag': '1.1.0' },
             },
             'package.json': { workspaces: ['packages/**'], dependencies: { 'ncu-test-v2': '2.0.0' } },


### PR DESCRIPTION
forgot the `.` in `.yarnrc.yml`

Related to the last PR #1582 (Issue #1576)
