### PR TITLE
Display link to compare the changes between package versions (--format diff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ Modify the output formatting or show additional information. Specify one or more
   <tr><td>lines</td><td>Prints name@version on separate lines. Useful for piping to npm install.</td></tr>
   <tr><td>ownerChanged</td><td>Shows if the package owner has changed.</td></tr>
   <tr><td>repo</td><td>Infers and displays links to the package's source code repository. Requires packages to be installed.</td></tr>
+  <tr><td>diff</td><td>Display link to compare the changes between package versions.</td></tr>
   <tr><td>time</td><td>Shows the publish time of each upgrade.</td></tr>
 </table>
 

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -195,6 +195,7 @@ const extendedHelpFormat: ExtendedHelp = ({ markdown }) => {
       ['lines', 'Prints name@version on separate lines. Useful for piping to npm install.'],
       ['ownerChanged', `Shows if the package owner has changed.`],
       ['repo', `Infers and displays links to the package's source code repository. Requires packages to be installed.`],
+      ['diff', `Display link to compare the changes between package versions.`],
       ['time', 'Shows the publish time of each upgrade.'],
     ],
   })
@@ -794,7 +795,7 @@ const cliOptions: CLIOption[] = [
     parse: value => (typeof value === 'string' ? value.split(',') : value),
     default: [],
     type: 'readonly string[]',
-    choices: ['dep', 'group', 'homepage', 'ownerChanged', 'repo', 'time', 'lines', 'installedVersion'],
+    choices: ['dep', 'group', 'homepage', 'ownerChanged', 'repo', 'diff', 'time', 'lines', 'installedVersion'],
     help: extendedHelpFormat,
   },
   {

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -198,6 +198,9 @@ export async function toDependencyTable({
             ? (await getPackageJson(dep, { pkgFile }))?.homepage || ''
             : ''
           const repoUrl = format?.includes('repo') ? (await getRepoUrl(dep, undefined, { pkgFile })) || '' : ''
+          const diffUrl = format?.includes('diff')
+            ? `https://my.diffend.io/npm/${dep}/${from.replace(/^\W+/, '')}/${to.replace(/^\W+/, '')}`
+            : ''
           const publishTime = format?.includes('time') && time?.[dep] ? time[dep] : ''
           return [
             dep,
@@ -206,7 +209,7 @@ export async function toDependencyTable({
             '→',
             toColorized,
             ownerChanged,
-            ...[homepageUrl, repoUrl, publishTime].filter(x => x),
+            ...[homepageUrl, repoUrl, diffUrl, publishTime].filter(x => x),
           ]
         }),
     ),


### PR DESCRIPTION
Currently, by using the diffend.io website, which i am not affiliated with, fwiw -- actually, lately i found that site not catching in a timely manner with latest published versions, so if anybody knows of a better service we can swap it.