### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete string escaping or encoding

### DIFF
--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -1,4 +1,5 @@
 import propertyOf from 'lodash/propertyOf'
+import escapeRegExp from 'lodash/escapeRegExp'
 import parseGitHubUrl from 'parse-github-url'
 import semver from 'semver'
 import semverutils, { SemVer, parse, parseRange } from 'semver-utils'
@@ -28,7 +29,7 @@ const VERSION_PART_DELIM: SemVer = {
 export const DEFAULT_WILDCARD = '^'
 export const WILDCARDS = ['^', '~', '.*', '.x']
 const WILDCARDS_PURE = ['^', '~', '^*', '*', 'x', 'x.x', 'x.x.x']
-const WILDCARD_PURE_REGEX = new RegExp(`^(${WILDCARDS_PURE.join('|').replace(/\^/g, '\\^').replace(/\*/g, '\\*')})$`)
+const WILDCARD_PURE_REGEX = new RegExp(`^(${WILDCARDS_PURE.map(escapeRegExp).join('|')})$`)
 
 /** Matches an npm alias version declaration. */
 const NPM_ALIAS_REGEX = /^npm:(.*)@(.*)/


### PR DESCRIPTION
Potential fix for [https://github.com/raineorshine/npm-check-updates/security/code-scanning/13](https://github.com/raineorshine/npm-check-updates/security/code-scanning/13)

In general, when dynamically constructing a regular expression from data, all regex meta-characters (including backslash) should be escaped, or a robust, well-tested escaping function should be used. Manually escaping just a couple of characters with `string.replace` is fragile and prone to omissions like not handling backslashes.

The best fix here is to use a standard library function that escapes *all* special regex characters in each element of `WILDCARDS_PURE` before joining them into the alternation pattern. Since the project already uses Lodash (`propertyOf`), we can safely add another Lodash import and use `_.escapeRegExp`. This avoids writing our own escaping logic and automatically handles backslashes and all other regex metacharacters. Concretely, in `src/lib/version-util.ts`, we should:

1. Add an import of `escapeRegExp` from `lodash/escapeRegExp`.
2. Change the construction of `WILDCARD_PURE_REGEX` so that it maps `WILDCARDS_PURE` through `escapeRegExp` and then joins with `'|'`, instead of manually calling `.replace(/\^/g, '\\^').replace(/\*/g, '\\*')`.

This preserves the existing behavior for current values and adds correct escaping for any future values, including backslashes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
