### PR TITLE
fix: vite build warning

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -27,5 +27,10 @@ export default defineConfig(({ mode }) => ({
     outDir: 'build',
     sourcemap: true,
     minify: mode === 'production' && 'esbuild',
+    rollupOptions: {
+      output: {
+        exports: 'named',
+      },
+    },
   },
 }))


### PR DESCRIPTION
When we run "npm run build", it displays the following warning:

> Entry module "src/index.ts" is using named and default exports together. Consumers of your bundle will have to use `chunk.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.

This pull request fixes it.