### PR TITLE
Show auto-detected cooldown source at normal log level; fix test isolation

### DIFF
--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -226,7 +226,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
             : null
       if (days != null && !isNaN(days)) {
         options.cooldown = days
-        print(options, `Using npm config min-release-age: ${days} days`, 'verbose')
+        print(options, `Using min-release-age from .npmrc: ${days} day${days !== 1 ? 's' : ''}`)
       }
     } else if (packageManager === 'pnpm') {
       // Automatically apply pnpm's minimumReleaseAge from pnpm-workspace.yaml as cooldown if cooldown is not explicitly set.
@@ -241,16 +241,11 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
           options.cooldown = (packageName: string) => (matchers.some(m => m(packageName)) ? null : days)
           print(
             options,
-            `Using pnpm workspace minimumReleaseAge: ${minimumReleaseAge} minutes (${days} days) with ${minimumReleaseAgeExclude.length} excluded pattern(s)`,
-            'verbose',
+            `Using minimumReleaseAge from pnpm-workspace.yaml: ${days} day${days !== 1 ? 's' : ''} (${minimumReleaseAgeExclude.length} excluded pattern${minimumReleaseAgeExclude.length !== 1 ? 's' : ''})`,
           )
         } else {
           options.cooldown = days
-          print(
-            options,
-            `Using pnpm workspace minimumReleaseAge: ${minimumReleaseAge} minutes (${days} days)`,
-            'verbose',
-          )
+          print(options, `Using minimumReleaseAge from pnpm-workspace.yaml: ${days} day${days !== 1 ? 's' : ''}`)
         }
       }
     } else if (packageManager === 'yarn') {
@@ -267,12 +262,11 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
           options.cooldown = (packageName: string) => (matchers.some(m => m(packageName)) ? null : days)
           print(
             options,
-            `Using yarn config npmMinimalAgeGate: ${npmMinimalAgeGate} seconds (${days} days) with ${npmPreapprovedPackages.length} pre-approved package(s)`,
-            'verbose',
+            `Using npmMinimalAgeGate from .yarnrc.yml: ${days} day${days !== 1 ? 's' : ''} (${npmPreapprovedPackages.length} pre-approved package${npmPreapprovedPackages.length !== 1 ? 's' : ''})`,
           )
         } else {
           options.cooldown = days
-          print(options, `Using yarn config npmMinimalAgeGate: ${npmMinimalAgeGate} seconds (${days} days)`, 'verbose')
+          print(options, `Using npmMinimalAgeGate from .yarnrc.yml: ${days} day${days !== 1 ? 's' : ''}`)
         }
       }
     }

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -265,6 +265,9 @@ describe('cooldown', () => {
       }),
     )
 
+    // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
+    const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
+
     // When: running ncu without cooldown
     const result = await ncu({ packageData })
 
@@ -272,6 +275,7 @@ describe('cooldown', () => {
     expect(result).to.have.property('test-package', '1.2.0')
 
     stub.restore()
+    findNpmConfigStub.restore()
   })
 
   it('upgrades package when cooldown is set to 0 (no cooldown)', async () => {
@@ -993,6 +997,9 @@ describe('cooldown', () => {
         }),
       )
 
+      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
+      const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
+
       // Stub getPnpmWorkspaceMinimumReleaseAge to return a config with minimumReleaseAge: 1440 minutes
       const pnpmWorkspaceStub = Sinon.stub(pnpmModule, 'getPnpmWorkspaceMinimumReleaseAge').resolves({
         minimumReleaseAge: 1440,
@@ -1006,6 +1013,7 @@ describe('cooldown', () => {
       expect(result).to.not.have.property('test-package')
 
       stub.restore()
+      findNpmConfigStub.restore()
       pnpmWorkspaceStub.restore()
     })
 
@@ -1031,6 +1039,9 @@ describe('cooldown', () => {
         }),
       })
 
+      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
+      const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
+
       // Stub getPnpmWorkspaceMinimumReleaseAge to return a config with 7 days cooldown and @myorg/* excluded
       const pnpmWorkspaceStub = Sinon.stub(pnpmModule, 'getPnpmWorkspaceMinimumReleaseAge').resolves({
         minimumReleaseAge: 10080, // 7 days in minutes
@@ -1045,6 +1056,7 @@ describe('cooldown', () => {
       expect(result).to.have.property('@myorg/pkg', '2.0.0')
 
       stub.restore()
+      findNpmConfigStub.restore()
       pnpmWorkspaceStub.restore()
     })
 
@@ -1144,6 +1156,9 @@ describe('cooldown', () => {
         }),
       )
 
+      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
+      const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
+
       // Stub getYarnMinimalAgeGate to return a config with npmMinimalAgeGate: 86400 seconds (1 day)
       const yarnAgeGateStub = Sinon.stub(yarnModule, 'getYarnMinimalAgeGate').resolves({
         npmMinimalAgeGate: 86400,
@@ -1157,6 +1172,7 @@ describe('cooldown', () => {
       expect(result).to.not.have.property('test-package')
 
       stub.restore()
+      findNpmConfigStub.restore()
       yarnAgeGateStub.restore()
     })
 
@@ -1180,6 +1196,9 @@ describe('cooldown', () => {
         }),
       )
 
+      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
+      const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
+
       const yarnAgeGateStub = Sinon.stub(yarnModule, 'getYarnMinimalAgeGate').resolves({
         npmMinimalAgeGate: 86400,
         npmPreapprovedPackages: [],
@@ -1192,6 +1211,7 @@ describe('cooldown', () => {
       expect(result).to.have.property('test-package', '1.1.0')
 
       stub.restore()
+      findNpmConfigStub.restore()
       yarnAgeGateStub.restore()
     })
 
@@ -1217,6 +1237,9 @@ describe('cooldown', () => {
         }),
       })
 
+      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
+      const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
+
       // Stub getYarnMinimalAgeGate to return a 7-day cooldown with @myorg/pkg pre-approved
       const yarnAgeGateStub = Sinon.stub(yarnModule, 'getYarnMinimalAgeGate').resolves({
         npmMinimalAgeGate: 604800,
@@ -1231,6 +1254,7 @@ describe('cooldown', () => {
       expect(result).to.have.property('@myorg/pkg', '2.0.0')
 
       stub.restore()
+      findNpmConfigStub.restore()
       yarnAgeGateStub.restore()
     })
 

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -265,7 +265,6 @@ describe('cooldown', () => {
       }),
     )
 
-    // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
     const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
 
     // When: running ncu without cooldown
@@ -997,7 +996,7 @@ describe('cooldown', () => {
         }),
       )
 
-      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
+      // Prevent user's .npmrc min-release-age from taking precedence over pnpm/yarn config in tests
       const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
 
       // Stub getPnpmWorkspaceMinimumReleaseAge to return a config with minimumReleaseAge: 1440 minutes
@@ -1039,7 +1038,6 @@ describe('cooldown', () => {
         }),
       })
 
-      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
       const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
 
       // Stub getPnpmWorkspaceMinimumReleaseAge to return a config with 7 days cooldown and @myorg/* excluded
@@ -1156,7 +1154,6 @@ describe('cooldown', () => {
         }),
       )
 
-      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
       const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
 
       // Stub getYarnMinimalAgeGate to return a config with npmMinimalAgeGate: 86400 seconds (1 day)
@@ -1196,7 +1193,6 @@ describe('cooldown', () => {
         }),
       )
 
-      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
       const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
 
       const yarnAgeGateStub = Sinon.stub(yarnModule, 'getYarnMinimalAgeGate').resolves({
@@ -1237,7 +1233,6 @@ describe('cooldown', () => {
         }),
       })
 
-      // Stub findNpmConfig to return null so user's .npmrc min-release-age does not interfere
       const findNpmConfigStub = Sinon.stub(npmModule, 'findNpmConfig').returns(null)
 
       // Stub getYarnMinimalAgeGate to return a 7-day cooldown with @myorg/pkg pre-approved


### PR DESCRIPTION
## Summary

- Show auto-detected cooldown source (`.npmrc` min-release-age, `pnpm-workspace.yaml` minimumReleaseAge, `.yarnrc.yml` npmMinimalAgeGate) at **normal log level** instead of verbose-only. This is consistent with existing messages like `Using config file ...` and `Using yarn/pnpm`.
- Fix test isolation: pnpm/yarn cooldown tests did not stub `findNpmConfig`, causing 4 test failures when the user running tests has `min-release-age` set in their `~/.npmrc`.

**Before:** No output at normal level when cooldown is auto-detected — packages silently skipped.

**After:**
```
Using min-release-age from .npmrc: 7 days
Checking /path/to/package.json
[====================] 36/36 100%
```

Fixes #1661

## Test plan

- [x] All 41 cooldown tests pass (was 37 passing / 4 failing before fix)
- [x] Lint and prettier clean
- [x] Manual verification: run `ncu` with `min-release-age` in `.npmrc` and confirm the message appears without `--verbose`