### PR TITLE
fix: skip intersects() for non-semver specs like catalog: in peer dep checks

### DIFF
--- a/src/lib/getIgnoredUpgradesDueToPeerDeps.ts
+++ b/src/lib/getIgnoredUpgradesDueToPeerDeps.ts
@@ -62,6 +62,8 @@ export async function getIgnoredUpgradesDueToPeerDeps(
           .filter(
             ([peer, peerSpec]) =>
               upgradedPackagesWithPeerRestriction[peer] &&
+              // Non-semver specs like catalog: references cannot be compared; treat as compatible
+              !!validRange(upgradedPackagesWithPeerRestriction[peer]) &&
               !(!validRange(peerSpec) || intersects(upgradedPackagesWithPeerRestriction[peer], peerSpec)),
           )
           .reduce(

--- a/src/lib/upgradePackageDefinitions.ts
+++ b/src/lib/upgradePackageDefinitions.ts
@@ -38,6 +38,8 @@ const checkIfInPeerViolation = (
       ([peer, peerSpec]) =>
         upgradedDependencies[peer] === undefined ||
         !validRange(peerSpec) ||
+        // Non-semver specs like catalog: references cannot be compared; treat as compatible
+        !validRange(upgradedDependencies[peer]) ||
         intersects(upgradedDependencies[peer], peerSpec),
     )
   })

--- a/test/peer.test.ts
+++ b/test/peer.test.ts
@@ -191,4 +191,26 @@ describe('peer dependencies', function () {
     upgrades!.should.deep.equal({})
     stub.restore()
   })
+
+  // https://github.com/raineorshine/npm-check-updates/issues/1604
+  it('does not throw when pnpm catalog: references appear as dependency versions with --peer', async () => {
+    // In a pnpm workspace, packages can reference catalog entries like "catalog:"
+    // instead of a semver version. NCU should not crash when encountering these
+    // non-semver specs during peer dependency constraint checking.
+    const upgrades = await ncu({
+      peer: true,
+      packageData: {
+        dependencies: {
+          // ncu-test-peer@1.0.0 declares: peerDependencies: { 'ncu-test-return-version': '1.0.x' }
+          // Checking the peer constraint calls intersects(currentVersion, '1.0.x').
+          // If currentVersion is 'catalog:' (non-semver), intersects() throws without the fix.
+          'ncu-test-peer': '1.0.0',
+          'ncu-test-return-version': 'catalog:',
+        },
+      },
+    })
+    // Should complete without throwing; ncu-test-return-version at 'catalog:' is treated as
+    // compatible (non-semver) so peer constraint is not considered violated.
+    upgrades!.should.be.an('object')
+  })
 })


### PR DESCRIPTION
﻿## Problem

Fixes #1604

When running ncu with --peer (-w for workspaces) on a pnpm workspace where packages use the catalog protocol in their dependencies (e.g. "catalog:" or "catalog:default"), ncu crashes with:

  TypeError: Invalid comparator: catalog:

This happens because the peer dependency constraint checking calls semver.intersects() with the catalog: string, which is not valid semver. semver.intersects() internally calls semver.parse() which throws on non-semver input.

## Root Cause

Two call sites in the peer dependency checking pipeline call intersects() with a value sourced from the current/upgraded dependency map (upgradedDependencies[peer] or upgradedPackagesWithPeerRestriction[peer]) without first checking if that value is a valid semver range:

upgradePackageDefinitions.ts (checkIfInPeerViolation):
  intersects(upgradedDependencies[peer], peerSpec)

getIgnoredUpgradesDueToPeerDeps.ts:
  intersects(upgradedPackagesWithPeerRestriction[peer], peerSpec)

When a dependency is pinned to a catalog reference (catalog:), the value is not valid semver and intersects() throws.

## Fix

Add a !validRange(upgradedDependencies[peer]) guard before each intersects() call, matching the existing !validRange(peerSpec) convention already in those same conditions. When the installed spec is not valid semver, we treat the constraint as compatible (cannot be verified), and skip the intersects() check.

This is consistent with how git URLs and other non-semver specs are already treated elsewhere in the codebase (ignored rather than crashing).

## Test

Added an integration test in test/peer.test.ts that uses ncu({ peer: true }) with a packageData containing 'ncu-test-return-version': 'catalog:' alongside 'ncu-test-peer': '1.0.0'. ncu-test-peer@1.0.0 declares a peer dependency on ncu-test-return-version: 1.0.x, so without the fix the intersects() call throws. With the fix it completes successfully.
