### PR TITLE
Reproduce ESM config loading issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,7 +942,7 @@ export default defineConfig({
 
 #### CommonJS
 
-Use the `.ncurc.cjs` extension or a standard `.ncurc.js` file (if useing `"type": "commonjs"`).
+Use the `.ncurc.cjs` extension or a standard `.ncurc.js` file (if using `"type": "commonjs"`).
 
 ```js
 const { defineConfig } = require('npm-check-updates')

--- a/test/rc-config.test.ts
+++ b/test/rc-config.test.ts
@@ -203,6 +203,30 @@ describe('rc-config', () => {
     }
   })
 
+  it('auto detect ESM .ncurc.js in a type module package', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+    const configFile = path.join(tempDir, '.ncurc.js')
+    const pkgFile = path.join(tempDir, 'package.json')
+    await fs.writeFile(configFile, 'export default { filter: "ncu-test-v2" }', 'utf-8')
+    await fs.writeFile(
+      pkgFile,
+      JSON.stringify({
+        type: 'module',
+        dependencies: { 'ncu-test-v2': '1.0.0', 'ncu-test-tag': '0.1.0' },
+      }),
+      'utf-8',
+    )
+    try {
+      // awkwardly, we have to set mergeConfig to enable autodetecting the rcconfig because otherwise it is explicitly disabled for tests
+      const { stdout } = await spawn('node', [bin, '--mergeConfig', '--jsonUpgraded'], {}, { cwd: tempDir })
+      const pkgData = JSON.parse(stdout)
+      pkgData.should.have.property('ncu-test-v2')
+      pkgData.should.not.have.property('ncu-test-tag')
+    } finally {
+      await removeDir(tempDir)
+    }
+  })
+
   it('should not crash if because of $schema property', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
     const configFile = path.join(tempDir, '.ncurc.json')


### PR DESCRIPTION
Reproduces #1674

My recommendation would be to either:

1. Update the instructions in the README to properly guide users to use `.ncurc.cjs` for packages with `type: module`.
2. Migrate to https://github.com/cosmiconfig/cosmiconfig

Please let me know if you want me to update the README documentation.