### PR TITLE
fix: chmod build/cli.js executable after vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { chmodSync } from 'fs'
 import { type Plugin, defineConfig } from 'vite'
 import { analyzer } from 'vite-bundle-analyzer'
 import dts from 'vite-plugin-dts'
@@ -13,6 +14,16 @@ function buildOptionsPlugin(): Plugin {
     name: 'build-options',
     async configResolved() {
       await buildOptions()
+    },
+  }
+}
+
+/** Makes the CLI entry point executable after build (cross-platform fs.chmodSync). */
+function chmodBinPlugin(): Plugin {
+  return {
+    name: 'chmod-bin',
+    closeBundle() {
+      chmodSync('build/cli.js', 0o755)
     },
   }
 }
@@ -50,6 +61,7 @@ export default defineConfig(({ mode }) => ({
       insertTypesEntry: true,
       outDir: 'build',
     }),
+    chmodBinPlugin(),
     ...(process.env.ANALYZER ? [analyzerOnce()] : []),
   ],
   ssr: {


### PR DESCRIPTION
Adds a chmodBinPlugin to vite.config.ts that runs closeBundle to set the executable bit on build/cli.js after every build. Uses Node's built-in fs.chmodSync for cross-platform compatibility.