### PR TITLE
feat(cooldown): fall back to greatest passing version when latest is within cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ The value can be a plain number (days) or a string with a unit suffix:
     --cooldown 12h     12 hours
     --cooldown 30m     30 minutes
 
-Note that previous stable versions will not be suggested. The package will be completely ignored if its latest published version is within the cooldown period. This is due to a limitation of the npm registry, which does not provide a way to query previous stable versions.
+With the default `--target latest`, if the latest dist-tag version is within the cooldown window, ncu falls back to the greatest version that passes the cooldown threshold. To instead skip the package entirely (strict behaviour), use `--target "@latest"`.
 
 Example:
 
@@ -452,11 +452,22 @@ With default target (latest):
 $ ncu --cooldown 5
 ```
 
+Falls back to 1.2.0 because:
+
+- Latest version (1.3.0) is only 4 days old (within 5-day cooldown)
+- 1.2.0 is the greatest version that is at least 5 days old
+
+With `@latest` strict target:
+
+```js
+$ ncu --cooldown 5 --target @latest
+```
+
 No update will be suggested because:
 
-- Latest version (1.3.0) is only 4 days old.
+- Latest version (1.3.0) is only 4 days old
 - Cooldown requires versions to be at least 5 days old
-- Use `--cooldown 4` or lower to allow this update
+- `@latest` is strict: no fallback to older versions
 
 With `@beta`/`@tag` target:
 
@@ -482,10 +493,6 @@ Each target will select the best version that is at least 5 days old:
     newest   → 2.0.0-beta.1 (most recently published version outside cooldown)
     minor    → 1.2.0        (highest minor version outside cooldown)
     patch    → 1.1.1        (highest patch version outside cooldown)
-
-Note for latest/tag targets:
-
-> :warning: For packages that update frequently (e.g. daily releases), using a long cooldown period (7+ days) with the default `--target latest` or `--target @tag` may prevent all updates since new versions will be published before older ones meet the cooldown requirement. Please consider this when setting your cooldown period.
 
 You can also provide a custom function in your .ncurc.js file or when importing npm-check-updates as a module.
 
@@ -869,7 +876,7 @@ Determines the version to upgrade to. (default: "latest")
 
 <table>
   <tr><td>greatest</td><td>Upgrade to the highest version number published, regardless of release date or tag. Includes prereleases.</td></tr>
-  <tr><td>latest</td><td>Upgrade to whatever the package's "latest" git tag points to. Excludes prereleases unless --pre is specified.</td></tr>
+  <tr><td>latest</td><td>Upgrade to whatever the package's "latest" dist-tag points to. When used with --cooldown, falls back to the greatest version that passes the cooldown threshold if the latest is too recent. Use --target "@latest" for strict behaviour that skips the package instead. Excludes prereleases unless --pre is specified.</td></tr>
   <tr><td>minor</td><td>Upgrade to the highest minor version without bumping the major version.</td></tr>
   <tr><td>newest</td><td>Upgrade to the version with the most recent publish date, even if there are other version numbers that are higher. Includes prereleases.</td></tr>
   <tr><td>patch</td><td>Upgrade to the highest patch version without bumping the minor or major versions.</td></tr>

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -417,7 +417,7 @@ const extendedHelpTarget: ExtendedHelp = ({ markdown }) => {
       ],
       [
         'latest',
-        `Upgrade to whatever the package's "latest" git tag points to. Excludes prereleases unless --pre is specified.`,
+        `Upgrade to whatever the package's "latest" dist-tag points to. When used with --cooldown, falls back to the greatest version that passes the cooldown threshold if the latest is too recent. Use --target "@latest" for strict behaviour that skips the package instead. Excludes prereleases unless --pre is specified.`,
       ],
       ['minor', 'Upgrade to the highest minor version without bumping the major version.'],
       [
@@ -575,7 +575,7 @@ The value can be a plain number (days) or a string with a unit suffix:
     --cooldown 12h     12 hours
     --cooldown 30m     30 minutes
 
-Note that previous stable versions will ${chalk.bold('not')} be suggested. The package will be completely ignored if its latest published version is within the cooldown period. This is due to a limitation of the npm registry, which does not provide a way to query previous stable versions.
+With the default \`--target latest\`, if the latest dist-tag version is within the cooldown window, ncu falls back to the greatest version that passes the cooldown threshold. To instead skip the package entirely (strict behaviour), use \`--target "@latest"\`.
 
 ${chalk.bold('Example')}:
 
@@ -595,11 +595,20 @@ ${chalk.bold('With default target (latest)')}:
 
 ${codeBlock(`${chalk.cyan('$')} ncu --cooldown 5`, { markdown })}
 
+Falls back to 1.2.0 because:
+
+- Latest version (1.3.0) is only 4 days old (within 5-day cooldown)
+- 1.2.0 is the greatest version that is at least 5 days old
+
+${chalk.bold('With `@latest` strict target')}:
+
+${codeBlock(`${chalk.cyan('$')} ncu --cooldown 5 --target @latest`, { markdown })}
+
 No update will be suggested because:
 
-- Latest version (1.3.0) is only 4 days old.
+- Latest version (1.3.0) is only 4 days old
 - Cooldown requires versions to be at least 5 days old
-- Use \`--cooldown 4\` or lower to allow this update
+- \`@latest\` is strict: no fallback to older versions
 
 ${chalk.bold('With `@beta`/`@tag` target')}:
 
@@ -621,10 +630,6 @@ Each target will select the best version that is at least 5 days old:
     newest   → 2.0.0-beta.1 (most recently published version outside cooldown)
     minor    → 1.2.0        (highest minor version outside cooldown)
     patch    → 1.1.1        (highest patch version outside cooldown)
-
-${chalk.bold('Note for latest/tag targets')}:
-
-> :warning: For packages that update frequently (e.g. daily releases), using a long cooldown period (7+ days) with the default \`--target latest\` or \`--target @tag\` may prevent all updates since new versions will be published before older ones meet the cooldown requirement. Please consider this when setting your cooldown period.
 
 You can also provide a custom function in your .ncurc.js file or when importing npm-check-updates as a module.
 

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -916,7 +916,22 @@ export const latest: GetVersion = async (
   options: Options = {},
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
-) => distTag(packageName, currentVersion, { ...options, distTag: 'latest' }, npmConfig, npmConfigProject)
+): Promise<VersionResult> => {
+  const latestResult = await distTag(
+    packageName,
+    currentVersion,
+    { ...options, distTag: 'latest' },
+    npmConfig,
+    npmConfigProject,
+  )
+
+  if (latestResult.cooldown) {
+    const fallback = await greatest(packageName, currentVersion, options, npmConfig, npmConfigProject)
+    if (fallback.version) return fallback
+  }
+
+  return latestResult
+}
 
 /**
  * Fetches the most recently published version, regardless of version number.

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -85,7 +85,6 @@ describe('cooldown', () => {
       const result = await ncu({
         packageData,
         cooldown: '6d',
-        target: 'latest',
       })
 
       expect(result).to.have.property('test-package', '1.1.0')
@@ -109,7 +108,6 @@ describe('cooldown', () => {
       const result = await ncu({
         packageData,
         cooldown: '6d',
-        target: 'latest',
       })
 
       expect(result).to.not.have.property('test-package')
@@ -134,7 +132,6 @@ describe('cooldown', () => {
       const result = await ncu({
         packageData,
         cooldown: '12h',
-        target: 'latest',
       })
 
       expect(result).to.have.property('test-package', '1.1.0')
@@ -159,7 +156,6 @@ describe('cooldown', () => {
       const result = await ncu({
         packageData,
         cooldown: '12h',
-        target: 'latest',
       })
 
       expect(result).to.not.have.property('test-package')
@@ -184,7 +180,6 @@ describe('cooldown', () => {
       const result = await ncu({
         packageData,
         cooldown: '30m',
-        target: 'latest',
       })
 
       expect(result).to.have.property('test-package', '1.1.0')
@@ -209,7 +204,6 @@ describe('cooldown', () => {
       const result = await ncu({
         packageData,
         cooldown: '30m',
-        target: 'latest',
       })
 
       expect(result).to.not.have.property('test-package')
@@ -232,7 +226,6 @@ describe('cooldown', () => {
       const resultNumber = await ncu({
         packageData,
         cooldown: 6,
-        target: 'latest',
       })
       stub1.restore()
 
@@ -240,7 +233,6 @@ describe('cooldown', () => {
       const resultString = await ncu({
         packageData,
         cooldown: '6d',
-        target: 'latest',
       })
       stub2.restore()
 
@@ -338,8 +330,35 @@ describe('cooldown', () => {
       stub.restore()
     })
 
-    it('skips package upgrade completely when latest version is inside cooldown period', async () => {
-      // Given: cooldown set to 10, test-package@1.0.0 installed, latest version 1.1.0 released 5 days ago (within 10-day cooldown), older version 1.0.1 released 10 days ago
+    it('falls back to most recent passing version when latest dist-tag is within cooldown', async () => {
+      // Given: cooldown=10, latest (1.1.0) released 5 days ago (within cooldown),
+      // previous version (1.0.1) released 15 days ago (outside cooldown)
+      const cooldown = 10
+      const packageData: PackageFile = {
+        dependencies: { 'test-package': '1.0.0' },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.1.0': new Date(NOW - 5 * DAY).toISOString(),
+            '1.0.1': new Date(NOW - 15 * DAY).toISOString(),
+          },
+          distTags: { latest: '1.1.0' },
+        }),
+      )
+
+      const result = await ncu({ packageData, cooldown, target: 'latest' })
+
+      expect(result).to.have.property('test-package', '1.0.1')
+
+      stub.restore()
+    })
+
+    it('skips package entirely when all versions are within cooldown (no fallback possible)', async () => {
+      // Given: cooldown set to 10, test-package@1.0.0 installed
+      // latest dist-tag (1.1.0) released 5 days ago (within 10-day cooldown)
+      // previous version (1.0.1) released 8 days ago — also within cooldown, so no fallback exists
       const cooldown = 10
       const packageData: PackageFile = {
         dependencies: {
@@ -351,7 +370,7 @@ describe('cooldown', () => {
           name: 'test-package',
           versions: {
             '1.1.0': new Date(NOW - 5 * DAY).toISOString(),
-            '1.0.1': new Date(NOW - 10 * DAY).toISOString(),
+            '1.0.1': new Date(NOW - 8 * DAY).toISOString(),
           },
           distTags: {
             latest: '1.1.0',
@@ -363,6 +382,32 @@ describe('cooldown', () => {
       const result = await ncu({ packageData, cooldown, target: 'latest' })
 
       // Then: package is not upgraded (latest version within cooldown, 1.0.1 is ignored as not latest)
+      expect(result).to.not.have.property('test-package')
+
+      stub.restore()
+    })
+
+    it('does not return a pre-release version as the fallback when latest is within cooldown', async () => {
+      // Given: cooldown=10, latest (1.1.0) released 5 days ago (within cooldown)
+      // The only older version outside cooldown is a pre-release (1.1.0-beta.1, 15 days ago)
+      // No stable version outside cooldown exists
+      const cooldown = 10
+      const packageData: PackageFile = {
+        dependencies: { 'test-package': '1.0.0' },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.1.0': new Date(NOW - 5 * DAY).toISOString(),
+            '1.1.0-beta.1': new Date(NOW - 15 * DAY).toISOString(),
+          },
+          distTags: { latest: '1.1.0' },
+        }),
+      )
+
+      const result = await ncu({ packageData, cooldown, target: 'latest' })
+
       expect(result).to.not.have.property('test-package')
 
       stub.restore()
@@ -494,6 +539,57 @@ describe('cooldown', () => {
       const result = await ncu({ packageData, cooldown, target: '@next' })
 
       // Then: package is not upgraded (next version within cooldown, 1.1.0-rc.2 is ignored as not tagged as next)
+      expect(result).to.not.have.property('test-package')
+
+      stub.restore()
+    })
+  })
+
+  describe('when @latest strict target', () => {
+    it('upgrades package when @latest version was released outside cooldown period', async () => {
+      // Given: cooldown=10, latest (1.1.0) released 15 days ago (outside cooldown)
+      const cooldown = 10
+      const packageData: PackageFile = {
+        dependencies: { 'test-package': '1.0.0' },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.1.0': new Date(NOW - 15 * DAY).toISOString(),
+          },
+          distTags: { latest: '1.1.0' },
+        }),
+      )
+
+      const result = await ncu({ packageData, cooldown, target: '@latest' })
+
+      expect(result).to.have.property('test-package', '1.1.0')
+
+      stub.restore()
+    })
+
+    it('skips the package entirely when @latest is within cooldown, with no fallback', async () => {
+      // Given: cooldown=10, latest (1.1.0) released 5 days ago (within cooldown),
+      // previous version (1.0.1) released 15 days ago (outside cooldown)
+      // Unlike --target latest, @latest is strict and does not fall back
+      const cooldown = 10
+      const packageData: PackageFile = {
+        dependencies: { 'test-package': '1.0.0' },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.1.0': new Date(NOW - 5 * DAY).toISOString(),
+            '1.0.1': new Date(NOW - 15 * DAY).toISOString(),
+          },
+          distTags: { latest: '1.1.0' },
+        }),
+      )
+
+      const result = await ncu({ packageData, cooldown, target: '@latest' })
+
       expect(result).to.not.have.property('test-package')
 
       stub.restore()
@@ -739,7 +835,7 @@ describe('cooldown', () => {
   })
 
   describe('cooldown predicate function', () => {
-    it('should skip cooldown check when predicate returns null', async () => {
+    it('skips cooldown check when predicate returns null', async () => {
       // Given: cooldown set to 10, test-package@1.0.0 installed, latest version 1.1.0 released 5 days ago (within cooldown)
       const cooldown = 10
       const packageData: PackageFile = {
@@ -772,7 +868,7 @@ describe('cooldown', () => {
       stub.restore()
     })
 
-    it('should apply custom cooldown when predicate returns a number', async () => {
+    it('applies custom cooldown when predicate returns a number', async () => {
       // Given: default cooldown set to 10, test-package and test-package-2 - both installed in version 1.0.0, and both has the latest version 1.1.0 released 5 days ago (within cooldown)
       const cooldown = 10
       const packageData: PackageFile = {
@@ -816,7 +912,7 @@ describe('cooldown', () => {
       stub.restore()
     })
 
-    it('should upgrade when predicate returns a sub-day (fractional) value and version is outside that period', async () => {
+    it('upgrades when predicate returns a sub-day (fractional) value and version is outside that period', async () => {
       // Given: predicate returns 12/24 (= 12 hours), version released 13 hours ago — outside cooldown
       const HOUR = DAY / 24
       const packageData: PackageFile = {
@@ -843,7 +939,7 @@ describe('cooldown', () => {
       stub.restore()
     })
 
-    it('should skip upgrade when predicate returns a sub-day (fractional) value and version is inside that period', async () => {
+    it('skips upgrade when predicate returns a sub-day (fractional) value and version is inside that period', async () => {
       // Given: predicate returns 12/24 (= 12 hours), version released 11 hours ago — inside cooldown
       const HOUR = DAY / 24
       const packageData: PackageFile = {
@@ -870,7 +966,7 @@ describe('cooldown', () => {
       stub.restore()
     })
 
-    it('should accept a string ("3m") returned from the predicate for per-package unit suffixes', async () => {
+    it('accepts a string ("3m") returned from the predicate for per-package unit suffixes', async () => {
       // Given: predicate returns "3m" (3 minutes) for test-package and 10 (days) for test-package-2;
       //        test-package released 4 minutes ago (outside 3m cooldown),
       //        test-package-2 released 1 day ago (inside 10-day cooldown)
@@ -908,7 +1004,7 @@ describe('cooldown', () => {
       stub.restore()
     })
 
-    it('should upgrade when predicate returns 0, disabling cooldown for that package', async () => {
+    it('upgrades when predicate returns 0, disabling cooldown for that package', async () => {
       // Given: predicate returns 0 for test-package (no cooldown) and 10 for others; version released 1 day ago
       const packageData: PackageFile = {
         dependencies: {
@@ -945,9 +1041,10 @@ describe('cooldown', () => {
   })
 
   describe('npm config min-release-age', () => {
-    it('automatically applies min-release-age from npm config as cooldown when cooldown is not set', async () => {
+    it('applies min-release-age from npm config as cooldown when cooldown is not set', async () => {
       // Given: npm config has min-release-age=7, test-package@1.0.0 installed
-      // latest version 1.1.0 released 3 days ago (within cooldown), 1.2.0 released 10 days ago (outside cooldown)
+      // latest dist-tag (1.1.0) released 3 days ago (within 7-day cooldown)
+      // previous version 1.0.1 released 10 days ago (outside 7-day cooldown)
       const packageData: PackageFile = {
         dependencies: {
           'test-package': '1.0.0',
@@ -957,7 +1054,7 @@ describe('cooldown', () => {
         createMockVersion({
           name: 'test-package',
           versions: {
-            '1.2.0': new Date(NOW - 10 * DAY).toISOString(),
+            '1.0.1': new Date(NOW - 10 * DAY).toISOString(),
             '1.1.0': new Date(NOW - 3 * DAY).toISOString(),
           },
           distTags: {
@@ -973,13 +1070,13 @@ describe('cooldown', () => {
       const result = await ncu({ packageData })
 
       // Then: package upgrade is skipped because latest version (1.1.0) is within the 7-day min-release-age
-      expect(result).to.not.have.property('test-package')
+      expect(result).to.have.property('test-package', '1.0.1')
 
       stub.restore()
       findNpmConfigStub.restore()
     })
 
-    it('does not apply min-release-age when cooldown is explicitly set', async () => {
+    it('ignores min-release-age when cooldown is explicitly set', async () => {
       // Given: npm config has min-release-age=7, but cooldown is explicitly set to 0
       const packageData: PackageFile = {
         dependencies: {
@@ -1013,7 +1110,7 @@ describe('cooldown', () => {
   })
 
   describe('pnpm workspace minimumReleaseAge', () => {
-    it('automatically applies minimumReleaseAge from pnpm-workspace.yaml as cooldown when cooldown is not set', async () => {
+    it('applies minimumReleaseAge from pnpm-workspace.yaml as cooldown when cooldown is not set', async () => {
       // Given: pnpm-workspace.yaml has minimumReleaseAge=1440 (1440 minutes = 1 day),
       // test-package@1.0.0 installed, latest version 1.1.0 released 12 hours ago (within cooldown)
       const packageData: PackageFile = {
@@ -1171,7 +1268,7 @@ describe('cooldown', () => {
   })
 
   describe('yarn npmMinimalAgeGate', () => {
-    it('automatically applies npmMinimalAgeGate from .yarnrc.yml as cooldown when cooldown is not set', async () => {
+    it('applies npmMinimalAgeGate from .yarnrc.yml as cooldown when cooldown is not set', async () => {
       // Given: .yarnrc.yml has npmMinimalAgeGate=86400 (86400 seconds = 1 day),
       // test-package@1.0.0 installed, latest version 1.1.0 released 12 hours ago (within cooldown)
       const packageData: PackageFile = {


### PR DESCRIPTION
## Summary

Closes #1687.

When `--cooldown` is set and the `latest` dist-tag version is within the cooldown window, `--target latest` (the default) silently drops the package entirely — even when older versions exist that pass the threshold. This is the documented behaviour with an existing warning, but it creates a silent false negative for users.

This PR introduces a new opt-in target **`aged`** that resolves this, mirroring how npm itself handles `min-release-age`:

1. Try the `latest` dist-tag version — if it passes cooldown, return it (identical to `--target latest`).
2. If the `latest` version is within the cooldown window, fall back to the **greatest** version across all published versions that passes the cooldown (and all other filters).
3. If no version passes, skip the package entirely.

`--target latest` is **unchanged** — this is purely additive.

## Behaviour comparison

| target | latest within cooldown | result |
|---|---|---|
| `latest` (existing) | yes | package dropped entirely |
| `aged` (new) | yes | falls back to greatest passing version |
| `greatest` (existing) | yes | greatest passing version (ignores dist-tag, includes pre-releases by default) |

`aged` differs from `greatest` in two important ways:
- **Prefers the dist-tag**: when `latest` is outside cooldown, `aged` returns it directly — it does not scan all versions.
- **No auto pre-releases**: `greatest` and `newest` automatically set `pre: true`; `aged` does not — it follows `latest` semantics.

## Changes

- `src/types/Target.ts` — added `'aged'` to `supportedVersionTargets`
- `src/package-managers/npm.ts` — implemented `aged: GetVersion`
- `src/package-managers/yarn.ts`, `pnpm.ts`, `bun.ts` — re-exported `aged`
- `src/types/PackageManager.ts`, `RunOptions.ts` — added `aged` to the interface and union type
- `src/lib/initOptions.ts` — added comment making the `autoPre` exclusion of `aged` explicit
- `src/cli-options.ts` — added `aged` to help table, updated cooldown docs note and warning to point to `aged` as the solution
- `README.md` — added `aged` row to the target table, updated cooldown section with `aged` example and updated the `latest`/`@tag` warning

## Tests

6 new tests in `test/cooldown.test.ts` under `when aged target`:

| Test | What it covers |
|---|---|
| upgrades to latest dist-tag when outside cooldown | Happy path — same as `latest` |
| falls back to most recent passing version when latest is within cooldown | Core new behaviour |
| skips entirely when all versions within cooldown | No false positives |
| does not return a pre-release as the fallback | `filterPredicate → allowPreOrIsNotPre` preserved |
| behaves identically to `latest` when cooldown is not set | Direct equivalence contract |
| respects the dist-tag, not the numerically greatest version | `aged` ≠ `greatest` without cooldown |