### PR TITLE
Enhance `--format time`: consistent caching, interactive support, and human-readable timestamps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "sinon": "^21.1.2",
         "source-map-support": "^0.5.21",
         "spawn-please": "^3.0.0",
-        "timeago.js": "4.0.2",
+        "timeago.js": "^4.0.2",
         "ts-json-schema-generator": "^2.9.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "sinon": "^21.1.2",
         "source-map-support": "^0.5.21",
         "spawn-please": "^3.0.0",
+        "timeago.js": "4.0.2",
         "ts-json-schema-generator": "^2.9.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
@@ -13728,6 +13729,13 @@
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
+    },
+    "node_modules/timeago.js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
+      "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "sinon": "^21.1.2",
     "source-map-support": "^0.5.21",
     "spawn-please": "^3.0.0",
-    "timeago.js": "4.0.2",
+    "timeago.js": "^4.0.2",
     "ts-json-schema-generator": "^2.9.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "sinon": "^21.1.2",
     "source-map-support": "^0.5.21",
     "spawn-please": "^3.0.0",
+    "timeago.js": "4.0.2",
     "ts-json-schema-generator": "^2.9.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { type CacheData, type Cacher } from '../types/Cacher'
+import { CURRENT_CACHE_SCHEMA, type CacheData, type Cacher } from '../types/Cacher'
 import { type Index } from '../types/IndexType'
 import { type Options } from '../types/Options'
 import { type Version } from '../types/Version'
@@ -17,6 +17,10 @@ export const CACHE_DELIMITER = '___'
  * @returns
  */
 function checkCacheExpiration(cacheData: CacheData, cacheExpiration = 10) {
+  if (cacheData.schema !== CURRENT_CACHE_SCHEMA) {
+    return true
+  }
+
   if (typeof cacheData.timestamp !== 'number') {
     return false
   }
@@ -72,6 +76,9 @@ export default async function cacher(options: Omit<Options, 'cacher'>): Promise<
     // ignore file read/parse/remove errors
   }
 
+  if (typeof cacheData.schema !== 'number') {
+    cacheData.schema = CURRENT_CACHE_SCHEMA
+  }
   if (typeof cacheData.timestamp !== 'number') {
     cacheData.timestamp = Date.now()
   }
@@ -90,15 +97,7 @@ export default async function cacher(options: Omit<Options, 'cacher'>): Promise<
       if (cached) {
         cacheHits.add(name)
       }
-
-      if (cached?.version) {
-        return cached
-      }
-
-      // fallback to old format cached until cache cleared
-      return {
-        version: cached as unknown as string,
-      }
+      return cached
     },
     set: (name: string, target: string, version: string, time?: string) => {
       if (!cacheData.packages) return

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -87,15 +87,23 @@ export default async function cacher(options: Omit<Options, 'cacher'>): Promise<
       if (!cacheData.packages) return
       const key = `${name}${CACHE_DELIMITER}${target}`
       const cached = cacheData.packages[key]
-      if (cached && !key.includes(cached)) {
+      if (cached) {
         cacheHits.add(name)
       }
-      return cached
+
+      if (cached?.version) {
+        return cached
+      }
+
+      // fallback to old format cached until cache cleared
+      return {
+        version: cached as unknown as string,
+      }
     },
-    set: (name: string, target: string, version: string) => {
+    set: (name: string, target: string, version: string, time?: string) => {
       if (!cacheData.packages) return
       const key = `${name}${CACHE_DELIMITER}${target}`
-      cacheData.packages[key] = version
+      cacheData.packages[key] = { version, ...(time ? { time } : null) }
     },
     getPeers: (name: string, version: Version) => {
       if (!cacheData.peers) return

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -60,38 +60,33 @@ export default async function cacher(options: Omit<Options, 'cacher'>): Promise<
   }
 
   const cacheFile = resolveCacheFile(options.cacheFile)
-  let cacheData: CacheData = {}
   const cacheHits = new Set<string>()
 
-  try {
-    cacheData = JSON.parse(await fs.promises.readFile(cacheFile, 'utf-8'))
+  let cacheData: CacheData = {
+    schema: CURRENT_CACHE_SCHEMA,
+    timestamp: Date.now(),
+    packages: {},
+    peers: {},
+  }
 
-    const expired = checkCacheExpiration(cacheData, options.cacheExpiration)
-    if (expired) {
+  try {
+    const raw = await fs.promises.readFile(cacheFile, 'utf-8')
+    const parsed = JSON.parse(raw)
+
+    // Validate schema before assigning
+    if (!checkCacheExpiration(parsed, options.cacheExpiration)) {
+      const { schema, timestamp, packages = {}, peers = {} } = parsed
+      cacheData = { schema, timestamp, packages, peers }
+    } else {
       // reset cache
-      fs.promises.rm(cacheFile, { force: true })
-      cacheData = {}
+      await fs.promises.rm(cacheFile, { force: true })
     }
   } catch (error) {
     // ignore file read/parse/remove errors
   }
 
-  if (typeof cacheData.schema !== 'number') {
-    cacheData.schema = CURRENT_CACHE_SCHEMA
-  }
-  if (typeof cacheData.timestamp !== 'number') {
-    cacheData.timestamp = Date.now()
-  }
-  if (!cacheData.packages) {
-    cacheData.packages = {}
-  }
-  if (!cacheData.peers) {
-    cacheData.peers = {}
-  }
-
   return {
     get: (name: string, target: string) => {
-      if (!cacheData.packages) return
       const key = `${name}${CACHE_DELIMITER}${target}`
       const cached = cacheData.packages[key]
       if (cached) {
@@ -100,9 +95,8 @@ export default async function cacher(options: Omit<Options, 'cacher'>): Promise<
       return cached
     },
     set: (name: string, target: string, version: string, time?: string) => {
-      if (!cacheData.packages) return
       const key = `${name}${CACHE_DELIMITER}${target}`
-      cacheData.packages[key] = { version, ...(time ? { time } : null) }
+      cacheData.packages[key] = { version, time }
     },
     getPeers: (name: string, version: Version) => {
       if (!cacheData.peers) return

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -3,6 +3,7 @@
  */
 import Table from 'cli-table3'
 import fs from 'fs/promises'
+import { format as timeAgoFormat } from 'timeago.js'
 import { type IgnoredUpgradeDueToEnginesNode } from '../types/IgnoredUpgradeDueToEnginesNode'
 import { type IgnoredUpgradeDueToPeerDeps } from '../types/IgnoredUpgradeDueToPeerDeps'
 import { type Index } from '../types/IndexType'
@@ -202,7 +203,8 @@ export async function toDependencyTable({
           const diffUrl = format?.includes('diff')
             ? `${process.env.NCU_DIFF || 'https://npmdiff.dev'}/${encodeURIComponent(dep)}/${from.replace(/^\W+/, '')}/${to.replace(/^\W+/, '')}`
             : ''
-          const publishTime = format?.includes('time') && time?.[dep] ? time[dep] : ''
+          const timestamp = format?.includes('time') && time?.[dep] ? time[dep] : null
+          const publishTime = timestamp ? timeAgoFormat(timestamp, 'en_US') : ''
           return [
             dep,
             ...(format?.includes('dep') ? [depType ? chalk.gray(depType) : ''] : []),

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -49,7 +49,10 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
       : [targetString, 'latest']
 
     const cached = options.cacher?.get(name, target)
-    if (cached?.version) {
+    // Skip the cache if cooldown is active since current cache does not store
+    // timestamp constraints; otherwise, validate based on version and time presence.
+    const isValidCache = !options.cooldown && cached?.version && (cached?.time || !options.format?.includes('time'))
+    if (isValidCache) {
       bar?.tick()
 
       return cached

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -49,12 +49,10 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
       : [targetString, 'latest']
 
     const cached = options.cacher?.get(name, target)
-    if (cached) {
+    if (cached?.version) {
       bar?.tick()
 
-      return {
-        version: cached,
-      }
+      return cached
     }
 
     let versionResult: VersionResult
@@ -130,7 +128,7 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
     bar?.tick()
 
     if (versionResult.version) {
-      options.cacher?.set(name, target, versionResult.version)
+      options.cacher?.set(name, target, versionResult.version, versionResult.time)
     }
 
     return versionResult

--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -78,6 +78,7 @@ export async function getOwnerPerDependency(fromVersion: Index<Version>, toVersi
 const chooseUpgrades = async (
   oldDependencies: Index<string>,
   newDependencies: Index<string>,
+  time: Index<string>,
   pkgFile: Maybe<string>,
   options: Options,
 ): Promise<Index<string>> => {
@@ -92,6 +93,7 @@ const chooseUpgrades = async (
     to: newDependencies,
     format: options.format,
     pkgFile: pkgFile || undefined,
+    time,
   })
 
   const formattedLines = keyValueBy(table.toString().split('\n'), line => {
@@ -255,7 +257,7 @@ export default async function runLocal(
     : undefined
 
   const chosenUpgraded = options.interactive
-    ? await chooseUpgrades(current, filteredUpgraded, pkgFile, options)
+    ? await chooseUpgrades(current, filteredUpgraded, time, pkgFile, options)
     : filteredUpgraded
 
   if (!options.json || options.deep) {

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -943,7 +943,7 @@ export const newest: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const result = await npmApi.fetchUpgradedPackumentMemo(
+  const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
     ['time', 'versions'],
     currentVersion,
@@ -957,7 +957,7 @@ export const newest: GetVersion = async (
   // result.versions is an object but is parsed as an array, so manually convert it to an object.
   // Otherwise keyValueBy will pass the predicate arguments in the wrong order.
   const versionsSatisfyingNodeEngine = keyValueBy(
-    result?.versions || {},
+    packument?.versions || {},
     (version: Version, packument: Packument['versions'][string]) =>
       satisfiesNodeEngine(packument, options.nodeEngineVersion) ? { [packument.version]: true } : null,
   )
@@ -965,7 +965,7 @@ export const newest: GetVersion = async (
   // filter out times that do not satisfy the node engine
   // filter out prereleases if pre:false (same as allowPreOrIsNotPre)
   const timesSatisfyingNodeEngine = filterObject(
-    (result?.time || {}) as Index<string>,
+    (packument?.time || {}) as Index<string>,
     version => versionsSatisfyingNodeEngine[version] && (options.pre !== false || !versionUtil.isPre(version)),
   )
 
@@ -975,15 +975,23 @@ export const newest: GetVersion = async (
   if (options.cooldown) {
     const versionsSatisfyingCooldownPeriod = versionsSortedByTime.filter(version =>
       satisfiesCooldownPeriod(
-        decorateTagPackumentWithTimeAndName((result as Packument).versions[version], result as Packument),
+        decorateTagPackumentWithTimeAndName((packument as Packument).versions[version], packument as Packument),
         options.cooldown as number | CooldownFunction,
       ),
     )
 
-    return { version: versionsSatisfyingCooldownPeriod.at(-1) }
+    const version = versionsSatisfyingCooldownPeriod.at(-1)
+    return {
+      version,
+      ...(packument?.time?.[version!] ? { time: packument.time[version!] } : null),
+    }
   }
 
-  return { version: versionsSortedByTime.at(-1) }
+  const newestVersion = versionsSortedByTime.at(-1)
+  return {
+    version: newestVersion,
+    ...(packument?.time?.[newestVersion!] ? { time: packument.time[newestVersion!] } : null),
+  }
 }
 
 /**

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -711,11 +711,7 @@ export const greatest: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const fields: (keyof Packument)[] = ['versions']
-
-  if (options.cooldown) {
-    fields.push('time')
-  }
+  const fields: (keyof Packument)[] = ['time', 'versions']
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -730,15 +726,18 @@ export const greatest: GetVersion = async (
   // known type based on 'versions'
   const versions = packument?.versions
 
+  const version =
+    Object.values(versions || {})
+      .filter(tagPackument =>
+        filterPredicate(options)(decorateTagPackumentWithTimeAndName(tagPackument, packument as Partial<Packument>)),
+      )
+      .map(o => o.version)
+      .sort(versionUtil.compareVersions)
+      .at(-1) || null
+
   return {
-    version:
-      Object.values(versions || {})
-        .filter(tagPackument =>
-          filterPredicate(options)(decorateTagPackumentWithTimeAndName(tagPackument, packument as Partial<Packument>)),
-        )
-        .map(o => o.version)
-        .sort(versionUtil.compareVersions)
-        .at(-1) || null,
+    version,
+    ...(packument?.time?.[version!] ? { time: packument.time[version!] } : null),
   }
 }
 
@@ -837,11 +836,7 @@ export const distTag: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ) => {
-  const fields: (keyof Packument)[] = ['dist-tags']
-
-  if (options.cooldown) {
-    fields.push('time')
-  }
+  const fields: (keyof Packument)[] = ['time', 'dist-tags']
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -1006,11 +1001,7 @@ export const minor: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const fields: (keyof Packument)[] = ['versions']
-
-  if (options.cooldown) {
-    fields.push('time')
-  }
+  const fields: (keyof Packument)[] = ['time', 'versions']
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -1032,7 +1023,11 @@ export const minor: GetVersion = async (
     currentVersion,
     'minor',
   )
-  return { version }
+
+  return {
+    version,
+    ...(packument?.time?.[version!] ? { time: packument.time[version!] } : null),
+  }
 }
 
 /**
@@ -1050,11 +1045,7 @@ export const patch: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const fields: (keyof Packument)[] = ['versions']
-
-  if (options.cooldown) {
-    fields.push('time')
-  }
+  const fields: (keyof Packument)[] = ['time', 'versions']
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -1076,7 +1067,10 @@ export const patch: GetVersion = async (
     currentVersion,
     'patch',
   )
-  return { version }
+  return {
+    version,
+    ...(packument?.time?.[version!] ? { time: packument.time[version!] } : null),
+  }
 }
 
 /**
@@ -1094,11 +1088,7 @@ export const semver: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const fields: (keyof Packument)[] = ['versions']
-
-  if (options.cooldown) {
-    fields.push('time')
-  }
+  const fields: (keyof Packument)[] = ['time', 'versions']
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -1122,7 +1112,10 @@ export const semver: GetVersion = async (
   // TODO: Upgrading within a prerelease does not seem to work.
   // { includePrerelease: true } does not help.
   const version = nodeSemver.maxSatisfying(versionsFiltered, currentVersion)
-  return { version }
+  return {
+    version,
+    ...(packument?.time?.[version!] ? { time: packument.time[version!] } : null),
+  }
 }
 
 export default spawnNpm

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -711,7 +711,11 @@ export const greatest: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const fields: (keyof Packument)[] = ['time', 'versions']
+  const fields: (keyof Packument)[] = ['versions']
+
+  if (options.cooldown) {
+    fields.push('time')
+  }
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -836,7 +840,11 @@ export const distTag: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ) => {
-  const fields: (keyof Packument)[] = ['time', 'dist-tags']
+  const fields: (keyof Packument)[] = ['dist-tags']
+
+  if (options.cooldown) {
+    fields.push('time')
+  }
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -1009,7 +1017,11 @@ export const minor: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const fields: (keyof Packument)[] = ['time', 'versions']
+  const fields: (keyof Packument)[] = ['versions']
+
+  if (options.cooldown) {
+    fields.push('time')
+  }
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -1053,7 +1065,11 @@ export const patch: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const fields: (keyof Packument)[] = ['time', 'versions']
+  const fields: (keyof Packument)[] = ['versions']
+
+  if (options.cooldown) {
+    fields.push('time')
+  }
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
@@ -1096,7 +1112,11 @@ export const semver: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  const fields: (keyof Packument)[] = ['time', 'versions']
+  const fields: (keyof Packument)[] = ['versions']
+
+  if (options.cooldown) {
+    fields.push('time')
+  }
 
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,

--- a/src/types/Cacher.ts
+++ b/src/types/Cacher.ts
@@ -1,7 +1,7 @@
 import { type Index } from './IndexType'
 import { type Version } from './Version'
 
-interface PackageInfo {
+export interface PackageInfo {
   version: string
   time?: string
 }
@@ -9,10 +9,10 @@ interface PackageInfo {
 export const CURRENT_CACHE_SCHEMA = 1
 
 export interface CacheData {
-  schema?: number
-  timestamp?: number
-  packages?: Record<string, PackageInfo | undefined>
-  peers?: Record<string, Index<string> | undefined>
+  schema: number
+  timestamp: number
+  packages: Record<string, PackageInfo>
+  peers: Record<string, Index<string>>
 }
 
 export type Cacher = {

--- a/src/types/Cacher.ts
+++ b/src/types/Cacher.ts
@@ -6,7 +6,10 @@ interface PackageInfo {
   time?: string
 }
 
+export const CURRENT_CACHE_SCHEMA = 1
+
 export interface CacheData {
+  schema?: number
   timestamp?: number
   packages?: Record<string, PackageInfo | undefined>
   peers?: Record<string, Index<string> | undefined>

--- a/src/types/Cacher.ts
+++ b/src/types/Cacher.ts
@@ -1,15 +1,20 @@
 import { type Index } from './IndexType'
 import { type Version } from './Version'
 
+interface PackageInfo {
+  version: string
+  time?: string
+}
+
 export interface CacheData {
   timestamp?: number
-  packages?: Record<string, string | undefined>
+  packages?: Record<string, PackageInfo | undefined>
   peers?: Record<string, Index<string> | undefined>
 }
 
 export type Cacher = {
-  get(name: string, target: string): string | undefined
-  set(name: string, target: string, version: string): void
+  get(name: string, target: string): PackageInfo | undefined
+  set(name: string, target: string, version: string, time?: string): void
   getPeers(name: string, version: Version): Index<string> | undefined
   setPeers(name: string, version: Version, peers: Index<string>): void
   save(): Promise<void>

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -2,18 +2,26 @@ import { expect } from 'chai'
 import fs from 'fs/promises'
 import ncu from '../src/'
 import { CACHE_DELIMITER, resolvedDefaultCacheFile } from '../src/lib/cache'
-import { type CacheData } from '../src/types/Cacher'
+import { CURRENT_CACHE_SCHEMA, type CacheData } from '../src/types/Cacher'
 import chaiSetup from './helpers/chaiSetup'
 import stubVersions from './helpers/stubVersions'
 
 chaiSetup()
 
+const DAY = 24 * 60 * 60 * 1000
+const NOW = Date.now()
+
+/**
+ * mock times
+ */
+const getTime = (daysAgo: number) => new Date(NOW - daysAgo * DAY).toISOString()
+
 describe('cache', () => {
   it('cache latest versions', async () => {
     const stub = stubVersions({
-      'ncu-test-v2': '2.0.0',
-      'ncu-test-tag': '1.1.0',
-      'ncu-test-alpha': '1.0.0',
+      'ncu-test-v2': { version: '2.0.0', time: { '2.0.0': getTime(10) } },
+      'ncu-test-tag': { version: '1.1.0', time: { '1.1.0': getTime(20) } },
+      'ncu-test-alpha': { version: '1.0.0', time: { '1.0.0': getTime(30) } },
     })
     try {
       const packageData = {
@@ -30,9 +38,9 @@ describe('cache', () => {
 
       expect(cacheData.timestamp).lessThanOrEqual(Date.now())
       expect(cacheData.packages).deep.eq({
-        [`ncu-test-v2${CACHE_DELIMITER}latest`]: '2.0.0',
-        [`ncu-test-tag${CACHE_DELIMITER}latest`]: '1.1.0',
-        [`ncu-test-alpha${CACHE_DELIMITER}latest`]: '1.0.0',
+        [`ncu-test-v2${CACHE_DELIMITER}latest`]: { version: '2.0.0', time: getTime(10) },
+        [`ncu-test-tag${CACHE_DELIMITER}latest`]: { version: '1.1.0', time: getTime(20) },
+        [`ncu-test-alpha${CACHE_DELIMITER}latest`]: { version: '1.0.0', time: getTime(30) },
       })
       expect(cacheData.peers).deep.eq({
         [`ncu-test-alpha${CACHE_DELIMITER}1.0.0`]: {},
@@ -48,21 +56,23 @@ describe('cache', () => {
   })
 
   it('use different cache key for different target', async () => {
-    const stub = stubVersions(options =>
-      options.target === 'latest'
-        ? {
-            'ncu-test-v2': '2.0.0',
-            'ncu-test-tag': '1.1.0',
-            'ncu-test-alpha': '1.0.0',
-          }
-        : options.target === 'greatest'
-          ? {
-              'ncu-test-v2': '2.0.0',
-              'ncu-test-tag': '1.2.0-dev.0',
-              'ncu-test-alpha': '2.0.0-alpha.2',
-            }
-          : null,
-    )
+    const latest = {
+      'ncu-test-v2': { version: '2.0.0', time: { '2.0.0': getTime(10) } },
+      'ncu-test-tag': { version: '1.1.0', time: { '1.1.0': getTime(20) } },
+      'ncu-test-alpha': { version: '1.0.0', time: { '1.0.0': getTime(30) } },
+    }
+
+    const greatest = {
+      'ncu-test-v2': { version: '2.0.0', time: { '2.0.0': getTime(10) } },
+      'ncu-test-tag': { version: '1.2.0-dev.0', time: { '1.2.0-dev.0': getTime(5) } },
+      'ncu-test-alpha': { version: '2.0.0-alpha.2', time: { '2.0.0-alpha.2': getTime(15) } },
+    }
+
+    const stub = stubVersions(options => {
+      if (options.target === 'latest') return latest
+      if (options.target === 'greatest') return greatest
+      return null
+    })
     try {
       const packageData = {
         dependencies: {
@@ -78,9 +88,9 @@ describe('cache', () => {
       const cacheData1: CacheData = await fs.readFile(resolvedDefaultCacheFile, 'utf-8').then(JSON.parse)
 
       expect(cacheData1.packages).deep.eq({
-        [`ncu-test-v2${CACHE_DELIMITER}latest`]: '2.0.0',
-        [`ncu-test-tag${CACHE_DELIMITER}latest`]: '1.1.0',
-        [`ncu-test-alpha${CACHE_DELIMITER}latest`]: '1.0.0',
+        [`ncu-test-v2${CACHE_DELIMITER}latest`]: { version: '2.0.0', time: getTime(10) },
+        [`ncu-test-tag${CACHE_DELIMITER}latest`]: { version: '1.1.0', time: getTime(20) },
+        [`ncu-test-alpha${CACHE_DELIMITER}latest`]: { version: '1.0.0', time: getTime(30) },
       })
       expect(cacheData1.peers).deep.eq({})
 
@@ -95,12 +105,12 @@ describe('cache', () => {
       const cacheData2: CacheData = await fs.readFile(resolvedDefaultCacheFile, 'utf-8').then(JSON.parse)
 
       expect(cacheData2.packages).deep.eq({
-        [`ncu-test-v2${CACHE_DELIMITER}latest`]: '2.0.0',
-        [`ncu-test-tag${CACHE_DELIMITER}latest`]: '1.1.0',
-        [`ncu-test-alpha${CACHE_DELIMITER}latest`]: '1.0.0',
-        [`ncu-test-v2${CACHE_DELIMITER}greatest`]: '2.0.0',
-        [`ncu-test-tag${CACHE_DELIMITER}greatest`]: '1.2.0-dev.0',
-        [`ncu-test-alpha${CACHE_DELIMITER}greatest`]: '2.0.0-alpha.2',
+        [`ncu-test-v2${CACHE_DELIMITER}latest`]: { version: '2.0.0', time: getTime(10) },
+        [`ncu-test-tag${CACHE_DELIMITER}latest`]: { version: '1.1.0', time: getTime(20) },
+        [`ncu-test-alpha${CACHE_DELIMITER}latest`]: { version: '1.0.0', time: getTime(30) },
+        [`ncu-test-v2${CACHE_DELIMITER}greatest`]: { version: '2.0.0', time: getTime(10) },
+        [`ncu-test-tag${CACHE_DELIMITER}greatest`]: { version: '1.2.0-dev.0', time: getTime(5) },
+        [`ncu-test-alpha${CACHE_DELIMITER}greatest`]: { version: '2.0.0-alpha.2', time: getTime(15) },
       })
     } finally {
       await fs.rm(resolvedDefaultCacheFile, { recursive: true, force: true })
@@ -129,5 +139,59 @@ describe('cache', () => {
     }
     expect(noCacheFile).eq(true)
     stub.restore()
+  })
+
+  it('expires cache when schema version does not match', async () => {
+    const stub = stubVersions('2.0.0')
+    const packageData = { dependencies: { 'ncu-test-v2': '^1.0.0' } }
+
+    // 1. Manually write an "old" schema (e.g., schema: 0)
+    const oldCache = {
+      schema: 0,
+      timestamp: Date.now(),
+      packages: { [`ncu-test-v2${CACHE_DELIMITER}latest`]: { version: '1.0.0' } },
+      peers: {},
+    }
+
+    try {
+      await fs.writeFile(resolvedDefaultCacheFile, JSON.stringify(oldCache))
+
+      // 2. Run ncu - it should detect mismatch and refresh (calling the stub)
+      await ncu({ packageData, cache: true })
+
+      // 3. Verify the cache was overwritten with the new schema (v1)
+      const newCache = await fs.readFile(resolvedDefaultCacheFile, 'utf-8').then(JSON.parse)
+      expect(newCache.schema).eq(CURRENT_CACHE_SCHEMA)
+      expect(newCache.packages[`ncu-test-v2${CACHE_DELIMITER}latest`].version).eq('2.0.0')
+    } finally {
+      await fs.rm(resolvedDefaultCacheFile, { recursive: true, force: true })
+      stub.restore()
+    }
+  })
+
+  it('expires cache when timestamp is older than 10 minutes', async () => {
+    const stub = stubVersions('2.0.0')
+    const packageData = { dependencies: { 'ncu-test-v2': '^1.0.0' } }
+
+    // 1. Create a cache file with a valid schema but expired timestamp (11 mins ago)
+    const expiredCache = {
+      schema: CURRENT_CACHE_SCHEMA,
+      timestamp: Date.now() - 11 * 60 * 1000,
+      packages: { [`ncu-test-v2${CACHE_DELIMITER}latest`]: { version: '1.0.0' } },
+      peers: {},
+    }
+    try {
+      await fs.writeFile(resolvedDefaultCacheFile, JSON.stringify(expiredCache))
+
+      // 2. Run ncu - should force refresh
+      await ncu({ packageData, cache: true })
+
+      // 3. Verify it refreshed
+      const cacheData = await fs.readFile(resolvedDefaultCacheFile, 'utf-8').then(JSON.parse)
+      expect(cacheData.packages[`ncu-test-v2${CACHE_DELIMITER}latest`].version).eq('2.0.0')
+    } finally {
+      await fs.rm(resolvedDefaultCacheFile, { recursive: true, force: true })
+      stub.restore()
+    }
   })
 })

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises'
 import os from 'os'
 import path, { dirname } from 'path'
 import spawn from 'spawn-please'
+import { format as timeAgoFormat } from 'timeago.js'
 import { fileURLToPath } from 'url'
 import chaiSetup from './helpers/chaiSetup'
 import removeDir from './helpers/removeDir'
@@ -106,7 +107,7 @@ describe('format', () => {
     })
   })
 
-  // do not stubVersions here, because we need to test if if time is parsed correctly from npm-registry-fetch
+  // do not stubVersions here, because we need to test if time is parsed correctly from npm-registry-fetch
   it('--format time', async () => {
     const timestamp = '2020-04-27T21:48:11.660Z'
     const packageData = {
@@ -115,7 +116,8 @@ describe('format', () => {
       },
     }
     const { stdout } = await spawn('node', [bin, '--format', 'time', '--stdin'], { stdin: JSON.stringify(packageData) })
-    expect(stdout).contains(timestamp)
+    const expectedString = timeAgoFormat(timestamp, 'en_US')
+    expect(stdout).contains(expectedString)
   })
 
   it('--format repo', async () => {

--- a/test/queryVersions.test.ts
+++ b/test/queryVersions.test.ts
@@ -78,6 +78,7 @@ describe('queryVersions', function () {
     result.should.deep.equal({
       request: {
         version: 'npm:ncu-test-v2@2.0.0',
+        time: '2020-04-27T21:48:11.660Z',
       },
     })
   })
@@ -196,6 +197,7 @@ describe('queryVersions', function () {
       upgrades.should.deep.equal({
         'ncu-test-v2': {
           version: '2.0.0',
+          time: '2020-04-27T21:48:11.660Z',
         },
       })
     })

--- a/test/queryVersions.test.ts
+++ b/test/queryVersions.test.ts
@@ -78,7 +78,6 @@ describe('queryVersions', function () {
     result.should.deep.equal({
       request: {
         version: 'npm:ncu-test-v2@2.0.0',
-        time: '2020-04-27T21:48:11.660Z',
       },
     })
   })
@@ -197,7 +196,6 @@ describe('queryVersions', function () {
       upgrades.should.deep.equal({
         'ncu-test-v2': {
           version: '2.0.0',
-          time: '2020-04-27T21:48:11.660Z',
         },
       })
     })


### PR DESCRIPTION
### Description

This PR resolves several issues related to the display and persistence of package release timestamps in `npm-check-updates`.

Previously, when using `--format time --cache`, timestamps were only available during the initial network request. Because the existing cache implementation only stored the version string and omitted the release timestamp, subsequent runs using cached data resulted in missing time information. This PR also addresses the omission of timestamps in interactive mode and replaces raw ISO timestamps with a more readable format.

### Key Changes

#### 1. Cache Schema Update & Invalidation (`cache.ts`)

Updated the caching logic to store an object `{ version, time }` and introduced a schema versioning system.

- **The Fix:** Added a `schema` version (v1) to the cache file.
- **Invalidation Mechanism:** Updated `checkCacheExpiration` to compare the cache's stored `schema` version with `CURRENT_CACHE_SCHEMA`. If they do not match, the function returns `true` (expired), forcing a clean refresh. This eliminates the need for legacy fallback logic.

#### 2. Consistent Metadata Retrieval (`npm.ts`)

Updated `npm.ts` functions to ensure that package release times are always bundled with version information. This provides a single source of truth, ensuring that downstream functions—including `filterResults`—always have access to timestamp metadata.

#### 3. Human-Readable Formatting

Integrated `timeago.js` to replace raw ISO strings with a human-readable format via `timeAgoFormat(timestamp, 'en_US')`, allowing developers to quickly identify how recently a dependency was published.

#### 4. Interactive Mode Support

Updated `chooseUpgrades` to include the `time` argument, ensuring it is correctly passed to `toDependencyTable` so that timestamps are displayed during the interactive selection process.