### PR TITLE
fix: make --dep and --format robust to PowerShell arg rewriting (comma-or-space-delimited)

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -721,7 +721,7 @@ const cliOptions: CLIOption[] = [
     description:
       'Check one or more sections of dependencies only: dev, optional, peer, prod, or packageManager (comma-delimited).',
     default: ['prod', 'dev', 'optional', 'packageManager'],
-    parse: value => (value && typeof value === 'string' ? value.split(',') : value),
+    parse: value => (typeof value === 'string' ? value.split(/,|\s/) : value),
     type: 'string | readonly string[]',
   },
   {
@@ -797,7 +797,7 @@ const cliOptions: CLIOption[] = [
     arg: 'value',
     description:
       'Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion.',
-    parse: value => (typeof value === 'string' ? value.split(',') : value),
+    parse: value => (typeof value === 'string' ? value.split(/,|\s/) : value),
     default: [],
     type: 'readonly string[]',
     choices: ['dep', 'group', 'homepage', 'ownerChanged', 'repo', 'diff', 'time', 'lines', 'installedVersion'],


### PR DESCRIPTION
### **Summary**

PowerShell rewrites comma‑separated arguments when expanding `$args` inside package‑manager–generated `.ps1` shims (such as those created by pnpm).
This causes a user‑supplied value like:

```
--format time,group
```

to be transformed into:

```
--format time group
```

As a result, strict comma‑only parsing breaks for users invoking `ncu` through the shim, even though direct `node build/cli.js` execution works correctly.

```
Invalid option value: --format time group. Valid values are: dep, group, homepage, ownerChanged, repo, diff, time, lines, installedVersion.
```

### **Change**

To make the CLI resilient to this shell behavior, the parsing logic for `--format` and `--dep` has been updated:

```ts
// old
parse: value => (typeof value === 'string' ? value.split(',') : value),

// new
parse: value => (typeof value === 'string' ? value.split(/,|\s/) : value),
```

This allows both comma‑delimited and space‑delimited values to be interpreted consistently.

### **Notes**

This effectively standardizes both options as **comma‑or‑space‑delimited**, which:

- avoids PowerShell shim rewriting issues
- maintains backward compatibility
- improves UX by accepting intuitive input formats
- avoids the need for brittle, environment‑dependent tests

No additional tests are required for this change.