### PR TITLE
npm: decorateTagPackumentWithTimeAndName accepts undefined tagPackument

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -143,9 +143,10 @@ const fetchPartialPackument = async (
  * @returns A new packument object that includes the `time` property if available for the tag's version and package name.
  */
 const decorateTagPackumentWithTimeAndName = (
-  tagPackument: Partial<Packument>,
+  tagPackument: Partial<Packument> | undefined,
   packument: Partial<Packument>,
 ): Partial<Packument> => {
+  if (!tagPackument) return { name: packument.name }
   const version = tagPackument.version
 
   return {


### PR DESCRIPTION
Closes #1696. `--target '@next'` looks up a tag that doesn't exist on every package; `tagPackument.version` crashes the per-package update probe.