### PR TITLE
fix: skip intersects() for non-semver specs like catalog: in peer dep checks

### DIFF
--- a/src/lib/getIgnoredUpgradesDueToPeerDeps.ts
+++ b/src/lib/getIgnoredUpgradesDueToPeerDeps.ts
@@ -62,6 +62,8 @@ export async function getIgnoredUpgradesDueToPeerDeps(
           .filter(
             ([peer, peerSpec]) =>
               upgradedPackagesWithPeerRestriction[peer] &&
+              // Non-semver specs like catalog: references cannot be compared; treat as compatible
+              !!validRange(upgradedPackagesWithPeerRestriction[peer]) &&
               !(!validRange(peerSpec) || intersects(upgradedPackagesWithPeerRestriction[peer], peerSpec)),
           )
           .reduce(

--- a/src/lib/upgradePackageDefinitions.ts
+++ b/src/lib/upgradePackageDefinitions.ts
@@ -38,6 +38,8 @@ const checkIfInPeerViolation = (
       ([peer, peerSpec]) =>
         upgradedDependencies[peer] === undefined ||
         !validRange(peerSpec) ||
+        // Non-semver specs like catalog: references cannot be compared; treat as compatible
+        !validRange(upgradedDependencies[peer]) ||
         intersects(upgradedDependencies[peer], peerSpec),
     )
   })

--- a/test/peer.test.ts
+++ b/test/peer.test.ts
@@ -191,4 +191,26 @@ describe('peer dependencies', function () {
     upgrades!.should.deep.equal({})
     stub.restore()
   })
+
+  // https://github.com/raineorshine/npm-check-updates/issues/1604
+  it('does not throw when pnpm catalog: references appear as dependency versions with --peer', async () => {
+    // In a pnpm workspace, packages can reference catalog entries like "catalog:"
+    // instead of a semver version. NCU should not crash when encountering these
+    // non-semver specs during peer dependency constraint checking.
+    const upgrades = await ncu({
+      peer: true,
+      packageData: {
+        dependencies: {
+          // ncu-test-peer@1.0.0 declares: peerDependencies: { 'ncu-test-return-version': '1.0.x' }
+          // Checking the peer constraint calls intersects(currentVersion, '1.0.x').
+          // If currentVersion is 'catalog:' (non-semver), intersects() throws without the fix.
+          'ncu-test-peer': '1.0.0',
+          'ncu-test-return-version': 'catalog:',
+        },
+      },
+    })
+    // Should complete without throwing; ncu-test-return-version at 'catalog:' is treated as
+    // compatible (non-semver) so peer constraint is not considered violated.
+    upgrades!.should.be.an('object')
+  })
 })


### PR DESCRIPTION
## Problem

When a pnpm workspace lists a dependency using the [catalog protocol](https://pnpm.io/catalogs) (e.g. `"catalog:"` or `"catalog:default"`), that string is not a valid semver range.

The peer dependency constraint checking code called `intersects(upgradedDependencies[peer], peerSpec)` without first verifying that `upgradedDependencies[peer]` is a valid semver range. Since `semver.intersects()` internally calls `semver.parse()` which throws on invalid input, running `ncu --peer -w` on a workspace containing `catalog:` references in `peerDependencies` crashes with:

```
TypeError: Invalid comparator: catalog:
```

The same guard (`!validRange(peerSpec)`) already exists for the _right-hand_ operand — it was just missing for the _left-hand_ one.

Fixes #1604.

## Fix

Add a `!validRange(upgradedDependencies[peer])` guard in both places that call `intersects()` with a value sourced from the current/upgraded dependency map (`getIgnoredUpgradesDueToPeerDeps.ts` and `upgradePackageDefinitions.ts`).

When the installed/upgraded version spec is not a valid semver range (`catalog:`, `file:`, `git+https://…`, etc.) the constraint check is skipped and treated as compatible — matching the existing convention already applied to the peer spec side.

A regression test covering the `catalog:` case is included in `test/peer.test.ts`.
