### PR TITLE
fix: handle registries missing 'time' metadata during version resolution

### DIFF
--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -242,8 +242,17 @@ export async function toDependencyTable({
           const diffUrl = format?.includes('diff')
             ? `${process.env.NCU_DIFF || 'https://npmdiff.dev'}/${encodeURIComponent(dep)}/${from.replace(/^\W+/, '')}/${to.replace(/^\W+/, '')}`
             : ''
-          const timestamp = format?.includes('time') && time?.[dep] ? time[dep] : null
-          const publishTime = timestamp ? timeAgoFormat(timestamp, 'en_US') : ''
+
+          const showCoolDown = format?.includes('cooldown')
+          const showTime = format?.includes('time')
+          // show '[missing time]' in publishTime column or cooldown column
+          const missingTime = time?.[dep] ? '' : '[missing time]'
+          const timestamp = showTime && time?.[dep] ? time[dep] : null
+          const publishTime = timestamp
+            ? timeAgoFormat(timestamp, 'en_US')
+            : showTime || !showCooldownCol
+              ? missingTime
+              : ''
 
           const cooldownVersion = skippedByCooldown?.[dep]?.version
           let cooldown = ''
@@ -256,6 +265,8 @@ export async function toDependencyTable({
               coerced && !cooldownVersion.endsWith(coerced.version) ? `${coerced.version}-+` : cooldownVersion
             const skippedColorized = colorizeDiff(to, wildcard + getVersion(shortended))
             cooldown = `[cooldown] ${skippedColorized.replace(wildcard, '')}`
+          } else if (showCoolDown && !showTime) {
+            cooldown = missingTime
           }
 
           return [
@@ -302,7 +313,7 @@ async function printSkippedByCooldownTable({
 
   for (const params of Object.values(skippedByCooldown)) {
     const { name, version, currentVersion, fallbackVersion, time: versionTime } = params
-    if (!isFetchable(currentVersion)) continue
+    if (!isFetchable(currentVersion) || !version) continue
 
     const wildcard = WILDCARDS.includes(currentVersion[0]) ? currentVersion[0] : ''
     const caf = wildcard + stripRange(fallbackVersion ?? currentVersion)

--- a/src/package-managers/filters.ts
+++ b/src/package-managers/filters.ts
@@ -75,7 +75,8 @@ export const satisfiesCooldownPeriod = (
   if (!version) return false
 
   if (!cooldownDaysOrPredicateFn) return true
-  if (!versionTimeData) return false
+  // when there is no time to check wh can not check it for cooldown, always return true
+  if (!versionTimeData) return true
 
   const versionReleaseDate = new Date(versionTimeData)
   const DAY_AS_MS = 86400000 // milliseconds in a day

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -170,6 +170,7 @@ const findTargetAndFallback = ({
       targetBlockedByCooldown: false,
     }
   }
+  const currentInCooldown = !satisfiesCooldownPeriod(packageName, cur, time?.[cur], options.cooldown)
 
   const result = versions.reduce(
     (acc, versionData) => {
@@ -204,7 +205,7 @@ const findTargetAndFallback = ({
     {
       targetVersion: cur,
       fallbackVersion: cur,
-      targetBlockedByCooldown: false,
+      targetBlockedByCooldown: currentInCooldown,
     } as {
       targetVersion: string
       fallbackVersion: string
@@ -212,7 +213,7 @@ const findTargetAndFallback = ({
     },
   )
 
-  let targetVersion: string | null = result.targetVersion
+  const targetVersion: string | null = result.targetVersion
   let fallbackVersion: string | null = result.fallbackVersion
 
   if (fallbackVersion === result.targetVersion) {
@@ -223,8 +224,9 @@ const findTargetAndFallback = ({
     fallbackVersion = null
   }
 
-  if (!nodeSemver.gt(targetVersion, cur)) {
-    targetVersion = null
+  // don't "Block" current version
+  if (currentInCooldown && targetVersion === cur) {
+    result.targetBlockedByCooldown = false
   }
 
   return {
@@ -562,7 +564,10 @@ npmApi.mockFetchUpgradedPackument =
       )
     }
 
-    const time = (isPackument(partialPackument) && partialPackument.time?.[version]) || new Date().toISOString()
+    const time =
+      isPackument(partialPackument) && partialPackument.time
+        ? partialPackument.time?.[version]
+        : new Date().toISOString()
     const packument: Packument = {
       name,
       'dist-tags': {
@@ -1005,9 +1010,11 @@ export const distTag: GetVersion = async (
 
   const publishTime = packument?.time?.[version!]
   const maybeTime = publishTime ? { time: publishTime } : null
+  const current = nodeSemver.minVersion(currentVersion)?.version ?? '0.0.0'
 
   const isSatisfiesCooldown =
-    tagPackument && satisfiesCooldownPeriod(packageName, tagPackument.version, publishTime, options.cooldown)
+    tagPackument.version === current ||
+    (tagPackument && satisfiesCooldownPeriod(packageName, tagPackument.version, publishTime, options.cooldown))
 
   // latest should not be deprecated
   // if latest exists and latest is not a prerelease version, return it
@@ -1031,20 +1038,15 @@ export const distTag: GetVersion = async (
       )
     }
 
-    const current = nodeSemver.minVersion(currentVersion)?.version ?? '0.0.0'
-    if (nodeSemver.gt(tagPackument.version, current)) {
-      return {
-        cooldownInfo: {
-          name: packageName,
-          currentVersion,
-          currentVersionTime: packument?.time?.[current],
-          version: tagPackument.version,
-          ...maybeTime,
-        },
-      }
+    return {
+      cooldownInfo: {
+        name: packageName,
+        currentVersion,
+        currentVersionTime: packument?.time?.[current],
+        version: tagPackument.version,
+        ...maybeTime,
+      },
     }
-
-    return {}
   }
 
   // If we use a custom dist-tag, we do not want to get other 'pre' versions, just the ones from this dist-tag
@@ -1119,16 +1121,24 @@ export const newest: GetVersion = async (
   )
 
   const versions = Object.values(packument?.versions ?? {})
-  const packageInfo = { packageName, currentVersion, options, versions, time: packument?.time }
+  const time = packument?.time
+  const isTimeMissing = !time || Object.keys(time).length === 0
+  const packageInfo = { packageName, currentVersion, options, versions, time }
 
-  const versionResult = findTargetAndFallback({
-    ...packageInfo,
-    compare: (v1, v2) => {
-      const t1 = packument?.time?.[v1] || ''
-      const t2 = packument?.time?.[v2] || ''
-      return t1 > t2 ? 1 : t1 < t2 ? -1 : 0
-    },
-  })
+  const versionResult = isTimeMissing
+    ? {
+        targetVersion: currentVersion,
+        fallbackVersion: null,
+        targetBlockedByCooldown: false,
+      }
+    : findTargetAndFallback({
+        ...packageInfo,
+        compare: (v1, v2) => {
+          const t1 = packument?.time?.[v1] || ''
+          const t2 = packument?.time?.[v2] || ''
+          return t1 > t2 ? 1 : t1 < t2 ? -1 : 0
+        },
+      })
 
   return toVersionResult({ ...packageInfo, ...versionResult })
 }

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -162,7 +162,8 @@ const findTargetAndFallback = ({
   compare?: (v1: string, v2: string) => number
 }): GreatestWithFallbackResult => {
   const isValidVersion = filterPredicate(options)
-  const cur = nodeSemver.minVersion(currentVersion)?.version
+  // nodeSemver.minVersion throws on non-semver specs (e.g. catalog: or workspace:)
+  const cur = nodeSemver.validRange(currentVersion) ? nodeSemver.minVersion(currentVersion)?.version : null
   if (!cur) {
     return {
       targetVersion: null,
@@ -265,7 +266,7 @@ const toVersionResult = ({
 
   // only check fallback if target is in cooldown period.
   if (options.cooldown && targetVersion && targetBlockedByCooldown) {
-    const current = nodeSemver.minVersion(currentVersion)?.version
+    const current = nodeSemver.validRange(currentVersion) ? nodeSemver.minVersion(currentVersion)?.version : null
     const cooldownInfo: CooldownInfo = {
       name: packageName,
       currentVersion,
@@ -1010,7 +1011,7 @@ export const distTag: GetVersion = async (
 
   const publishTime = packument?.time?.[version!]
   const maybeTime = publishTime ? { time: publishTime } : null
-  const current = nodeSemver.minVersion(currentVersion)?.version ?? '0.0.0'
+  const current = (nodeSemver.validRange(currentVersion) && nodeSemver.minVersion(currentVersion)?.version) || '0.0.0'
 
   const isSatisfiesCooldown =
     tagPackument.version === current ||

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -287,7 +287,8 @@ describe('bin', async function () {
       const { stdout } = await spawn('node', [bin, '--stdin'], { stdin: JSON.stringify({ dependencies }) })
       stripAnsi(stdout)
         .trim()
-        .should.equal('ncu-test-v2  https://github.com/raineorshine/ncu-test-v2.git#v1.0.0  →  v2.0.0')
+        .replace(/\s+/g, ' ') // Replace all whitespace sequences with a single space
+        .should.equal('ncu-test-v2 https://github.com/raineorshine/ncu-test-v2.git#v1.0.0 → v2.0.0 [missing time]')
     })
 
     it('strip prefix from npm alias in "to" output', async () => {

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -237,6 +237,17 @@ describe('bin', async function () {
     stub.restore()
   })
 
+  it('do not warn about empty results when every dep is already at the highest version for non-latest --target', async () => {
+    const stub = stubVersions({ 'ncu-test-v2': '1.0.0' }, { spawn: true })
+    const { stdout } = await spawn('node', [bin, '--stdin', '--target', 'minor'], {
+      stdin: JSON.stringify({ dependencies: { 'ncu-test-v2': '1.0.0' } }),
+    })
+    const out = stripAnsi(stdout)!
+    out.should.not.include('No package versions were returned.')
+    out.should.include('All dependencies match the minor package versions')
+    stub.restore()
+  })
+
   it('combine boolean flags with arguments', async () => {
     const stub = stubVersions('99.9.9', { spawn: true })
     const { stdout } = await spawn('node', [bin, '--stdin', '--jsonUpgraded', 'ncu-test-v2'], {

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -52,11 +52,14 @@ const getNormalizedLogs = (logSpy: Sinon.SinonStub<any[], void>): string[] => {
   return logSpy.args
     .flat()
     .filter((arg): arg is string => typeof arg === 'string')
+    .join('\n')
+    .replace(/^\n+|\n+$/g, '') // Remove newlines at the start and end
+    .replace(/\n+/g, '\n') // Remove consecutive newlines
+    .split('\n')
     .map(
       l =>
         stripVTControlCharacters(l)
           .replace(/\s+/g, ' ') // Replace all whitespace sequences with a single space
-          .replace(/^\n+|\n+$/g, '') // Remove newlines at the start and end
           .trim(), // Ensure no stray spaces remain at the edges
     )
 }
@@ -505,6 +508,43 @@ describe('cooldown', () => {
     })
   })
 
+  it('prints "All dependencies match the latest package versions" instead of registry error when installed version is the latest and within cooldown', async () => {
+    // Given: cooldown set to 10, test-package@1.1.0 installed and it is latest version 1.1.0 released 5 days ago (within 10-day cooldown)
+    const cooldown = 10
+    const packageData: PackageFile = {
+      dependencies: {
+        'test-package': '1.1.0',
+      },
+    }
+    const stub = stubVersions(
+      createMockVersion({
+        name: 'test-package',
+        versions: {
+          '1.1.0': new Date(NOW - 5 * DAY).toISOString(),
+          '1.0.0': new Date(NOW - 11 * DAY).toISOString(),
+        },
+        distTags: {
+          latest: '1.1.0',
+        },
+      }),
+    )
+
+    const logSpy = Sinon.stub(console, 'log')
+    silenceProgressBar()
+
+    // When ncu is run with cooldown and jsonUpgraded disabled
+    // Note: loglevel must be set explicitly since the module default sets silent mode
+    await ncu({ packageData, cooldown, target: 'latest', jsonUpgraded: false, loglevel: 'warn' })
+
+    // Then: the output should say "All dependencies match the latest package versions", not "No package versions were returned"
+    const allMessages = logSpy.args.flat().filter(arg => typeof arg === 'string')
+    expect(allMessages.some(msg => msg.includes('All dependencies match the latest package versions'))).to.be.true
+    expect(allMessages.some(msg => msg.includes('No package versions were returned'))).to.be.false
+
+    logSpy.restore()
+    stub.restore()
+  })
+
   describe('when @TAG target', () => {
     it('upgrades package when @next version was released outside cooldown period', async () => {
       // Given: cooldown set to 10, test-package@1.0.0 installed, @next version 1.1.0-rc.1 released 15 days ago (outside 10-day cooldown boundary)
@@ -792,38 +832,6 @@ describe('cooldown', () => {
       expect(result).to.have.property('test-package', '^1.0.1')
       stub.restore()
     })
-  })
-
-  it('skips package upgrade if no time data and cooldown is set', async () => {
-    // Given: cooldown days is set to 10 days, test-package is installed in version 1.0.0, and the latest version - 1.1.0 was released 5 days ago (inside cooldown period). Another version 1.0.1 was released 10 days ago (outside cooldown period), but it is not the latest version, so it should not be upgraded either.
-    const cooldown = 10
-    const packageData: PackageFile = {
-      dependencies: {
-        'test-package': '1.0.0',
-      },
-    }
-    const stub = stubVersions(
-      createMockVersion({
-        name: 'test-package',
-        versions: {
-          // @ts-expect-error -- testing missing time data
-          '1.1.0': undefined,
-          // @ts-expect-error -- testing missing time data
-          '1.0.1': undefined,
-        },
-        distTags: {
-          latest: '1.1.0',
-        },
-      }),
-    )
-
-    // When ncu is run with a 1 day cooldown parameter
-    const result = await ncu({ packageData, cooldown })
-
-    // Then test-package should not be upgraded
-    expect(result).to.not.have.property('test-package')
-
-    stub.restore()
   })
 
   it('upgrades package when version was released exactly at the cooldown boundary', async () => {
@@ -1549,7 +1557,7 @@ describe('cooldown', () => {
 
     const targets = ['latest', 'newest', 'greatest', 'minor', 'patch', 'semver', '@latest'] as const
     targets.forEach(async target => {
-      it(`for "target: ${target}" when all versions are within cooldown (no fallback possible)`, async () => {
+      it(`handles "target: ${target}" when all versions are within cooldown (no fallback possible)`, async () => {
         // Given: cooldown set to 10, test-package@1.0.0 installed
         // latest dist-tag (1.0.2) released 5 days ago (within 10-day cooldown)
         // previous version (1.0.1) released 8 days ago — also within cooldown, so no fallback exists
@@ -1571,7 +1579,7 @@ describe('cooldown', () => {
         stub.restore()
       })
 
-      it(`for "target: ${target}" when target version are within cooldown and a fallback exist)`, async () => {
+      it(`handles "target: ${target}" when target version are within cooldown and a fallback exist)`, async () => {
         // Given: cooldown set to 6, test-package@1.0.0 installed
         // latest dist-tag (1.0.2) released 5 days ago (within 6-day cooldown)
         // previous version (1.0.1) released 8 days ago — is before cooldown and return as a fallback
@@ -1601,26 +1609,33 @@ describe('cooldown', () => {
         stub.restore()
       })
     })
+  })
 
-    const latestTarget = ['latest', '@latest'] as const
-    latestTarget.forEach(async target => {
-      it(`distTag cooldownInfo must contain new version`, async () => {
-        const mockedVersion = createMockVersion({
-          name: 'test-package',
-          versions: {
-            '2.0.0': new Date(NOW - 3 * DAY).toISOString(),
-            '1.0.0': new Date(NOW - 10 * DAY).toISOString(),
-          },
-          distTags: {
-            latest: '2.0.0',
-          },
-        })
-        const packageData: PackageFile = {
-          dependencies: {
-            'test-package': '^2.0.0',
-          },
-        }
-
+  describe('when installed version matches target version and is within cooldown', () => {
+    const mockedVersion = createMockVersion({
+      name: 'test-package',
+      versions: {
+        '2.0.0': new Date(NOW - 3 * DAY).toISOString(),
+        '1.0.0': new Date(NOW - 10 * DAY).toISOString(),
+      },
+      distTags: {
+        latest: '2.0.0',
+      },
+    })
+    const packageData: PackageFile = {
+      dependencies: {
+        'test-package': '^2.0.0',
+      },
+    }
+    const options = {
+      packageData,
+      jsonUpgraded: false,
+      loglevel: 'warn',
+      format: ['cooldown'],
+    }
+    const targets = ['latest', '@latest', 'newest', 'greatest'] as const
+    targets.forEach(async target => {
+      it(`handles "target: ${target}" correctly within cooldown`, async () => {
         const cooldown = 6
 
         const stub = stubVersions(mockedVersion)
@@ -1630,12 +1645,298 @@ describe('cooldown', () => {
         await ncu({ ...options, packageData, cooldown, target, format: ['cooldown', 'time'] })
 
         const allMessages = getNormalizedLogs(logSpy)
-        const [_name, from, , to] = allMessages[1].split(' ')
-        expect(from).not.to.equal(to)
+        const happyMsg = `All dependencies match the ${target} package versions :)`
+        expect(allMessages.some(msg => msg.includes(happyMsg))).to.be.true
+        expect(allMessages.some(msg => msg.includes('No package versions were returned'))).to.be.false
+        expect(allMessages.some(msg => msg.includes(`Skipped due to ${cooldown}-day cooldown`))).to.be.false
 
         logSpy.restore()
         stub.restore()
       })
+    })
+  })
+
+  describe(`Don't skip by cooldown when package metadata doesn't have "time"`, () => {
+    const mockedVersion = createMockVersion({
+      name: 'test-package',
+      versions: {
+        '1.0.3-pre.0': new Date(NOW - 3 * DAY).toISOString(),
+        '1.0.2': new Date(NOW - 3 * DAY).toISOString(),
+        '1.0.1': new Date(NOW - 6 * DAY).toISOString(),
+        '1.0.0': new Date(NOW - 9 * DAY).toISOString(),
+      },
+      distTags: {
+        latest: '1.0.2',
+      },
+    })
+    const mockedVersionWithNoTime = {
+      ...mockedVersion,
+      time: {
+        ...mockedVersion.time,
+      },
+      name: 'test-package-with-no-time',
+    }
+
+    // mock missing time
+    // mockedVersionWithNoTime.time = {}
+    delete mockedVersionWithNoTime.time!['1.0.3-pre.0']
+    delete mockedVersionWithNoTime.time!['1.0.2']
+
+    const packageData: PackageFile = {
+      dependencies: {
+        'test-package': '^1.0.0',
+        'test-package-with-no-time': '^1.0.0',
+      },
+    }
+
+    // When ncu is run with cooldown and jsonUpgraded disabled
+    // Note: loglevel must be set explicitly since the module default sets silent mode
+    const options = {
+      packageData,
+      jsonUpgraded: false,
+      loglevel: 'warn',
+      format: ['cooldown'],
+    }
+
+    let stub: { restore: () => void }
+    const versions = {
+      'test-package': mockedVersion,
+      'test-package-with-no-time': mockedVersionWithNoTime,
+    }
+    after(() => stub.restore())
+
+    const targets = ['latest', 'greatest', 'minor', 'patch', 'semver'] as const
+    targets.forEach(async target => {
+      it(`handles "target: ${target}" correctly within cooldown`, async () => {
+        // greatest version time was deleted, all teaget function should return
+        // test-package-with-no-time: 1.0.2 or 1.0.3-pre.0, for newest and greatest for the upgrade
+        // when newest function get a package with missing time it should return greatest instead
+        stub = stubVersions(versions)
+        const cooldown = 5
+
+        const logSpy = Sinon.stub(console, 'log')
+        silenceProgressBar()
+
+        await ncu({ ...options, cooldown, target })
+
+        const upgradeVersion = ['newest', 'greatest'].includes(target) ? '1.0.3-pre.0' : '1.0.2'
+        const truncateVersion = ['newest', 'greatest'].includes(target) ? '1.0.3-+' : '1.0.2'
+
+        const allMessages = getNormalizedLogs(logSpy)
+        expect(allMessages[0]).to.equal(`Skipped due to ${cooldown}-day cooldown`)
+        expect(allMessages[1]).to.equal(`test-package ^1.0.1 → ^${upgradeVersion} 3 days ago`)
+        expect(allMessages[3]).to.equal(`test-package ^1.0.0 → ^1.0.1 [cooldown] ${truncateVersion}`)
+        expect(allMessages[4]).to.equal(`test-package-with-no-time ^1.0.0 → ^${upgradeVersion} [missing time]`)
+
+        logSpy.restore()
+      })
+    })
+
+    it(`handles "target: '@latest'" correctly within cooldown`, async () => {
+      stub = stubVersions(versions)
+      const cooldown = 5
+
+      const logSpy = Sinon.stub(console, 'log')
+      silenceProgressBar()
+
+      await ncu({ ...options, cooldown, target: '@latest' })
+
+      const allMessages = getNormalizedLogs(logSpy)
+
+      expect(allMessages[0]).to.equal(`Skipped due to ${cooldown}-day cooldown`)
+      expect(allMessages[1]).to.equal(`test-package ^1.0.0 → ^1.0.2 3 days ago`)
+      expect(allMessages[3]).to.equal(`test-package-with-no-time ^1.0.0 → ^1.0.2 [missing time]`)
+
+      logSpy.restore()
+    })
+
+    it(`"target: newest" - ignore versions without time`, async () => {
+      // test-package-with-no-time versions 1.0.2 and 1.0.3-pre.0 don't have time
+      // test-package-with-no-time will upgrade to version 1.0.1
+      stub = stubVersions(versions)
+      const cooldown = 5
+
+      const logSpy = Sinon.stub(console, 'log')
+      silenceProgressBar()
+
+      await ncu({ ...options, cooldown, target: 'newest' })
+
+      const allMessages = getNormalizedLogs(logSpy)
+      expect(allMessages[0]).to.equal(`Skipped due to ${cooldown}-day cooldown`)
+      expect(allMessages[1]).to.equal(`test-package ^1.0.1 → ^1.0.3-pre.0 3 days ago`)
+      expect(allMessages[3]).to.equal(`test-package ^1.0.0 → ^1.0.1 [cooldown] 1.0.3-+`)
+      expect(allMessages[4]).to.equal(`test-package-with-no-time ^1.0.0 → ^1.0.1`)
+
+      logSpy.restore()
+    })
+
+    it(`"target: newest" - no upgrade is possible when all times are missing`, async () => {
+      // delete all times and update stub
+      stub = stubVersions({
+        'test-package': mockedVersion,
+        'test-package-with-no-time': { ...mockedVersionWithNoTime, time: {} },
+      })
+
+      const cooldown = 5
+
+      const logSpy = Sinon.stub(console, 'log')
+      silenceProgressBar()
+
+      await ncu({ ...options, cooldown, target: 'newest' })
+
+      const allMessages = getNormalizedLogs(logSpy)
+      expect(allMessages[0]).to.equal(`Skipped due to ${cooldown}-day cooldown`)
+      expect(allMessages[1]).to.equal(`test-package ^1.0.1 → ^1.0.3-pre.0 3 days ago`)
+      expect(allMessages[3]).to.equal(`test-package ^1.0.0 → ^1.0.1 [cooldown] 1.0.3-+`)
+      expect(allMessages.join('/n')).not.to.include(`test-package-with-no-time`)
+
+      logSpy.restore()
+    })
+    // prints "All dependencies match the latest package versions"
+    it(`handles "target: newest" when all packages are without time`, async () => {
+      // delete all times for all packages and update stub
+      stub = stubVersions({
+        'test-package': { ...mockedVersion, time: {} },
+        'test-package-with-no-time': { ...mockedVersionWithNoTime, time: {} },
+      })
+
+      const cooldown = 5
+
+      const logSpy = Sinon.stub(console, 'log')
+      silenceProgressBar()
+
+      await ncu({ ...options, cooldown, target: 'newest' })
+
+      const allMessages = getNormalizedLogs(logSpy)
+      expect(allMessages[0]).to.equal(`All dependencies match the newest package versions :)`)
+
+      logSpy.restore()
+    })
+  })
+
+  describe('downgrade from prerelease when target version is within cooldown', () => {
+    const cooldown = 10
+
+    // Common options for all tests in this describe block
+    const options = {
+      cooldown,
+      jsonUpgraded: false,
+      loglevel: 'warn',
+      format: ['cooldown'],
+    }
+
+    it('downgrades from prerelease to older stable version when target @latest is not within cooldown', async () => {
+      // Given: test-package@2.0.0-beta.1 (prerelease) installed
+      // @latest is 1.5.0 released 11 days ago (outside cooldown)
+      // older stable version 1.0.0 released 15 days ago (outside cooldown)
+      const packageData: PackageFile = {
+        dependencies: {
+          'test-package': '2.0.0-beta.1',
+        },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.5.0': new Date(NOW - 11 * DAY).toISOString(),
+            '1.0.0': new Date(NOW - 15 * DAY).toISOString(),
+            '2.0.0-beta.1': new Date(NOW - 20 * DAY).toISOString(),
+          },
+          distTags: {
+            latest: '1.5.0',
+          },
+        }),
+      )
+
+      const logSpy = Sinon.stub(console, 'log')
+      silenceProgressBar()
+
+      await ncu({ ...options, packageData, target: '@latest' })
+
+      const allMessages = getNormalizedLogs(logSpy)
+      expect(allMessages.length).to.equal(1)
+      expect(allMessages[0]).to.equal(`test-package 2.0.0-beta.1 → 1.5.0`)
+
+      logSpy.restore()
+      stub.restore()
+    })
+
+    it('skip by cooldown downgrades from prerelease to older stable version when target @latest is within cooldown', async () => {
+      // Given: test-package@2.0.0-beta.1 (prerelease) installed
+      // @latest is 1.5.0 released 5 days ago (within cooldown)
+      // older stable version 1.0.0 released 15 days ago (outside cooldown)
+      const packageData: PackageFile = {
+        dependencies: {
+          'test-package': '2.0.0-beta.1',
+        },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.5.0': new Date(NOW - 5 * DAY).toISOString(),
+            '1.0.0': new Date(NOW - 15 * DAY).toISOString(),
+            '2.0.0-beta.1': new Date(NOW - 20 * DAY).toISOString(),
+          },
+          distTags: {
+            latest: '1.5.0',
+          },
+        }),
+      )
+
+      const logSpy = Sinon.stub(console, 'log')
+      silenceProgressBar()
+
+      await ncu({ ...options, packageData, target: '@latest' })
+
+      const allMessages = getNormalizedLogs(logSpy)
+      expect(allMessages[0]).to.equal(`Skipped due to ${cooldown}-day cooldown`)
+      expect(allMessages[1]).to.equal(`test-package 2.0.0-beta.1 → 1.5.0 5 days ago`)
+      // if version from dist-tag does not meet cooldown requirement skip finding other versions
+      expect(allMessages.join('\n')).not.to.include(`test-package 2.0.0-beta.1 → 1.0.0`)
+      expect(allMessages[2]).to.equal(`All dependencies not in cooldown match the @latest package versions :)`)
+
+      logSpy.restore()
+      stub.restore()
+    })
+
+    it('skip by cooldown upgrades from prerelease to specific tag when target tag version is within cooldown', async () => {
+      // Given: test-package@1.0.0-dev.0 (prerelease) installed
+      // @next tag is 1.5.0-rc.1 released 3 days ago (within cooldown)
+      // older version on @next tag is 1.0.0-next.0 released 15 days ago (outside cooldown)
+      const packageData: PackageFile = {
+        dependencies: {
+          'test-package': '1.0.0-dev.0',
+        },
+      }
+      const stub = stubVersions(
+        createMockVersion({
+          name: 'test-package',
+          versions: {
+            '1.5.0-rc.1': new Date(NOW - 3 * DAY).toISOString(),
+            '1.1.0-dev.0': new Date(NOW - 15 * DAY).toISOString(),
+            '1.0.0-dev.0': new Date(NOW - 20 * DAY).toISOString(),
+          },
+          distTags: {
+            next: '1.5.0-rc.1',
+          },
+        }),
+      )
+
+      const logSpy = Sinon.stub(console, 'log')
+      silenceProgressBar()
+
+      await ncu({ ...options, packageData, target: '@next' })
+
+      const allMessages = getNormalizedLogs(logSpy)
+      expect(allMessages[0]).to.equal(`Skipped due to ${cooldown}-day cooldown`)
+      expect(allMessages[1]).to.equal(`test-package 1.0.0-dev.0 → 1.5.0-rc.1 3 days ago`)
+      // if version from dist-tag does not meet cooldown requirement skip finding other versions
+      expect(allMessages.join('\n')).not.to.include(`test-package 1.0.0-dev.0 → 1.1.0-dev.0`)
+      expect(allMessages[2]).to.equal(`All dependencies not in cooldown match the @next package versions :)`)
+
+      logSpy.restore()
+      stub.restore()
     })
   })
 })


### PR DESCRIPTION
close #1746

**Summary**
This PR addresses an issue where packages from registries lacking `time` metadata were incorrectly skipped during version resolution, even when the cooldown period was set to 0.

**Changes**

* **Version Resolution Logic for 'newest':** Updated the resolution strategy to default to the greatest available version when `time` metadata is unavailable for a package, ensuring that 'newest' targets are correctly identified.
* **Cooldown Bypass:** Modified the filtering logic to prevent packages from being skipped due to cooldown predicates when their publish time information is missing.
* **UI Feedback:** Enhanced logging to explicitly indicate when a version is being upgraded despite missing `time` metadata by appending `[missing time]` to the output.

**Motivation**
Previously, the absence of `time` metadata triggered a `skip by cooldown` even when the cooldown was set to zero.

**Testing**

* Verified that packages missing `time` metadata are now correctly included in resolution candidates.
* Confirmed that version selection defaults to the highest semantic version when timestamps are absent for 'newest' targets.
* Verified that log output correctly displays `[missing time]` during the upgrade process.

**Additional Fixes**
* Resolved an edge case where the CLI would incorrectly show a "No package versions were returned" warning when the currently installed version is within the cooldown period and matches the target version.

### Testing Improvements, WIP for future PR

* Currently working on a comprehensive migration from Mocha to Vitest. This transition is already yielding significant performance gains, reducing local test execution times from approximately 2 minutes to under 15 seconds.