### PR TITLE
fix: prevent incorrect warnings when no upgrade is found for target

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -171,6 +171,14 @@ const findTargetAndFallback = ({
     }
   }
 
+  if (versions.length === 0) {
+    return {
+      targetVersion: null,
+      fallbackVersion: null,
+      targetBlockedByCooldown: false,
+    }
+  }
+
   const result = versions.reduce(
     (acc, versionData) => {
       const version = versionData.version
@@ -212,7 +220,7 @@ const findTargetAndFallback = ({
     },
   )
 
-  let targetVersion: string | null = result.targetVersion
+  const targetVersion: string = result.targetVersion
   let fallbackVersion: string | null = result.fallbackVersion
 
   if (fallbackVersion === result.targetVersion) {
@@ -221,10 +229,6 @@ const findTargetAndFallback = ({
 
   if (fallbackVersion && !nodeSemver.gt(fallbackVersion, cur)) {
     fallbackVersion = null
-  }
-
-  if (!nodeSemver.gt(targetVersion, cur)) {
-    targetVersion = null
   }
 
   return {

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -237,6 +237,17 @@ describe('bin', async function () {
     stub.restore()
   })
 
+  it('do not warn about empty results when every dep is already at the highest version for non-latest --target', async () => {
+    const stub = stubVersions({ 'ncu-test-v2': '1.0.0' }, { spawn: true })
+    const { stdout } = await spawn('node', [bin, '--stdin', '--target', 'minor'], {
+      stdin: JSON.stringify({ dependencies: { 'ncu-test-v2': '1.0.0' } }),
+    })
+    const out = stripAnsi(stdout)!
+    out.should.not.include('No package versions were returned.')
+    out.should.include('All dependencies match the minor package versions')
+    stub.restore()
+  })
+
   it('combine boolean flags with arguments', async () => {
     const stub = stubVersions('99.9.9', { spawn: true })
     const { stdout } = await spawn('node', [bin, '--stdin', '--jsonUpgraded', 'ncu-test-v2'], {

--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -20,9 +20,7 @@ const tsNodeBin = path.join(__dirname, `../node_modules/.bin/ts-node${process.pl
 
 /** Returns the CLI invocation command and arguments, using the built binary if available, otherwise using ts-node. */
 const getCliInvocation = (...args: string[]) =>
-  fsSync.existsSync(bin)
-    ? { command: 'node', args: [bin, ...args] }
-    : { command: tsNodeBin, args: [srcBin, ...args] }
+  fsSync.existsSync(bin) ? { command: 'node', args: [bin, ...args] } : { command: tsNodeBin, args: [srcBin, ...args] }
 
 /** Creates a temp directory with nested package files for --deep testing. Returns the temp directory name (should be removed by caller).
  *
@@ -128,12 +126,7 @@ describe('--deep', function () {
     const tempDir = await setupDeepTest()
     try {
       const cli = getCliInvocation('-u', '--jsonUpgraded', '--packageFile', path.join(tempDir, '**/package.json'))
-      const { stdout } = await spawn(
-        cli.command,
-        cli.args,
-        { stdin: '{ "dependencies": {}}' },
-        { cwd: tempDir },
-      )
+      const { stdout } = await spawn(cli.command, cli.args, { stdin: '{ "dependencies": {}}' }, { cwd: tempDir })
 
       const upgradedPkg1 = JSON.parse(await fs.readFile(path.join(tempDir, 'packages/sub1/package.json'), 'utf-8'))
       upgradedPkg1.should.have.property('dependencies')


### PR DESCRIPTION
Fixes #1764.

AI assisted but tested and reviewed manually.

## Context

When you run `ncu` with `--target` set to anything other than `latest` and there is no upgrade available, ncu prints a "No package versions were returned" warning that sounds like the registry or network is broken. In reality the registry was reached and the packages were checked, there just is no upgrade at the requested level.

Seems to have been introduced in 22.2.0 (#1711).

## Changes

Two small changes to `findTargetAndFallback`:

1. If `versions` comes back empty, return early to ensure "No package versions were returned" is still printed for real registry failures.

2. When ncu finishes checking a package and `targetVersion` is the same as the current, keep that version as the result instead of setting it to `null`. The existing upgrade check still filters it, but ncu can now tell it actually checked the package, so it prints `All dependencies match the <target> package versions :)` as expected.

## Tests

`test/bin.test.ts`: running `ncu --target minor` on a project that is already on the latest minor version now prints "All dependencies match the minor package versions" instead of the warning.