### PR TITLE
fix: do not call semver.minVersion on non-semver package protocols

### DIFF
--- a/src/lib/isFetchable.ts
+++ b/src/lib/isFetchable.ts
@@ -1,0 +1,13 @@
+import { type VersionSpec } from '../types/VersionSpec'
+import isPackageManagerProtocol from './isPackageManagerProtocol'
+
+/** Returns true if the dependency spec is not fetchable from the registry and is ignored. */
+function isFetchable(spec: VersionSpec): boolean {
+  return (
+    !isPackageManagerProtocol(spec) &&
+    // short github urls that are ignored, e.g. raineorshine/foo
+    !/^[^/:@]+\/\w+/.test(spec)
+  )
+}
+
+export default isFetchable

--- a/src/lib/isPackageManagerProtocol.ts
+++ b/src/lib/isPackageManagerProtocol.ts
@@ -1,0 +1,17 @@
+import { type VersionSpec } from '../types/VersionSpec'
+
+/**
+ * Returns true if the spec uses a package manager protocol that references something
+ * other than a registry version (e.g. `file:` or pnpm's `catalog:`).
+ */
+function isPackageManagerProtocol(spec: VersionSpec): boolean {
+  return (
+    spec.startsWith('file:') ||
+    spec.startsWith('link:') ||
+    spec.startsWith('workspace:') ||
+    spec.startsWith('catalog:') ||
+    spec.startsWith('portal:')
+  )
+}
+
+export default isPackageManagerProtocol

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -17,6 +17,7 @@ import filterObject from './filterObject'
 import getPackageJson from './getPackageJson'
 import getPackageVersion from './getPackageVersion'
 import getRepoUrl from './getRepoUrl'
+import isFetchable from './isFetchable'
 import {
   WILDCARDS,
   colorizeDiff,
@@ -40,15 +41,6 @@ const logLevels = {
   verbose: 5,
   silly: 6,
 }
-
-/** Returns true if the dependency spec is not fetchable from the registry and is ignored. */
-const isFetchable = (spec: VersionSpec) =>
-  !spec.startsWith('file:') &&
-  !spec.startsWith('link:') &&
-  !spec.startsWith('workspace:') &&
-  !spec.startsWith('catalog:') &&
-  // short github urls that are ignored, e.g. raineorshine/foo
-  !/^[^/:@]+\/\w+/.test(spec)
 
 /**
  * Prints a message if it is included within options.loglevel.

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -14,6 +14,16 @@ import keyValueBy from './keyValueBy'
 import programError from './programError'
 import { createNpmAlias, isGitHubUrl, isPre, parseNpmAlias } from './version-util'
 
+const PKG_MANAGER_PROTOCOLS = ['catalog:', 'workspace:', 'link:', 'file:', 'portal:'] as const
+
+/**
+ * Returns true if the spec uses a package manager protocol that references something
+ * other than a registry version (e.g. pnpm's `catalog:` / `workspace:`, or `link:` / `file:`).
+ */
+function isPackageManagerProtocol(spec: VersionSpec): boolean {
+  return PKG_MANAGER_PROTOCOLS.some(protocol => spec.startsWith(protocol))
+}
+
 /**
  * Get the latest or greatest versions from the NPM repository based on the version target.
  *
@@ -42,6 +52,13 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
   async function getPackageVersionProtected(dep: VersionSpec): Promise<VersionResult> {
     const npmAlias = parseNpmAlias(packageMap[dep])
     const [name, version] = npmAlias || [dep, packageMap[dep]]
+
+    // Skip valid specs that are not registry versions, such as different package manager protocols.
+    if (isPackageManagerProtocol(version)) {
+      bar?.tick()
+      return { version: null }
+    }
+
     const targetOption = options.target || 'latest'
     const targetString = typeof targetOption === 'string' ? targetOption : targetOption(name, parseRange(version))
     const [target, distTag] = targetString.startsWith('@')

--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -10,19 +10,10 @@ import { type VersionResult } from '../types/VersionResult'
 import { type VersionSpec } from '../types/VersionSpec'
 import { getChalk } from './chalk'
 import getPackageManager from './getPackageManager'
+import isPackageManagerProtocol from './isPackageManagerProtocol'
 import keyValueBy from './keyValueBy'
 import programError from './programError'
 import { createNpmAlias, isGitHubUrl, isPre, parseNpmAlias } from './version-util'
-
-const PKG_MANAGER_PROTOCOLS = ['catalog:', 'workspace:', 'link:', 'file:', 'portal:'] as const
-
-/**
- * Returns true if the spec uses a package manager protocol that references something
- * other than a registry version (e.g. pnpm's `catalog:` / `workspace:`, or `link:` / `file:`).
- */
-function isPackageManagerProtocol(spec: VersionSpec): boolean {
-  return PKG_MANAGER_PROTOCOLS.some(protocol => spec.startsWith(protocol))
-}
 
 /**
  * Get the latest or greatest versions from the NPM repository based on the version target.

--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -332,6 +332,12 @@ export function findGreatestByLevel(versions: string[], current: string, level: 
 
 /** Returns a filter function that can be used to filter versions by a level. */
 export function filterByLevel(current: string, level: VersionLevel): (v: string) => boolean | null {
+  // semver.minVersion throws on non-semver specs (e.g. pnpm's `catalog:` / `workspace:`
+  // protocols, `link:`, `file:`). Guard with validRange to keep this safe.
+  if (!semver.validRange(current)) {
+    return () => false
+  }
+
   const cur = semver.minVersion(current)
   return (v: string) => {
     const parsed = semver.parse(v)

--- a/test/version-util.test.ts
+++ b/test/version-util.test.ts
@@ -427,6 +427,33 @@ describe('version-util', () => {
     })
   })
 
+  describe('filterByLevel', () => {
+    it('only return true for versions at the given semantic versioning level', () => {
+      const minor = versionUtil.filterByLevel('1.0.0', 'minor')
+      minor('1.0.0')!.should.equal(true)
+      minor('1.5.0')!.should.equal(true)
+      minor('2.0.0')!.should.equal(false)
+
+      const patch = versionUtil.filterByLevel('1.0.0', 'patch')
+      patch('1.0.5')!.should.equal(true)
+      patch('1.1.0')!.should.equal(false)
+    })
+
+    it('return false for every version when current is not a valid semver range', () => {
+      const catalog = versionUtil.filterByLevel('catalog:', 'minor')
+      catalog('1.0.0')!.should.equal(false)
+
+      const workspace = versionUtil.filterByLevel('workspace:^1.0.0', 'patch')
+      workspace('1.0.0')!.should.equal(false)
+
+      const link = versionUtil.filterByLevel('link:../local-pkg', 'minor')
+      link('1.0.0')!.should.equal(false)
+
+      const file = versionUtil.filterByLevel('file:./local.tgz', 'patch')
+      file('1.0.0')!.should.equal(false)
+    })
+  })
+
   describe('findGreatestByLevel', () => {
     it('find the greatest version at the given semantic versioning level', () => {
       const versions = ['0.1.0', '1.0.0', '1.0.1', '1.1.0', '2.0.1']

--- a/test/workspaces.test.ts
+++ b/test/workspaces.test.ts
@@ -623,6 +623,55 @@ catalog:
         }
       })
 
+      it('do not throw on valid package protocols when target is not "latest"', async () => {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+        try {
+          await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify({}), 'utf-8')
+          await fs.writeFile(
+            path.join(tempDir, 'pnpm-workspace.yaml'),
+            `packages:\n  - 'packages/**'\n\ncatalog:\n  ncu-test-tag: '1.0.0'\n`,
+            'utf-8',
+          )
+          await fs.writeFile(path.join(tempDir, 'pnpm-lock.yaml'), '', 'utf-8')
+
+          await fs.mkdir(path.join(tempDir, 'packages/a'), { recursive: true })
+          await fs.writeFile(
+            path.join(tempDir, 'packages/a/package.json'),
+            JSON.stringify({
+              dependencies: {
+                'ncu-test-tag': 'catalog:',
+                'ncu-test-v2': 'workspace:^',
+                'some-link': 'link:../local-pkg',
+                'some-file': 'file:./local.tgz',
+              },
+            }),
+            'utf-8',
+          )
+
+          const { stdout, stderr } = await spawn(
+            'node',
+            [bin, '--jsonAll', '--workspaces', '--target', 'minor'],
+            { rejectOnError: false },
+            { cwd: tempDir },
+          )
+
+          stderr.should.not.match(/Invalid comparator/)
+          stdout.should.not.match(/Invalid comparator/)
+
+          // Workspace package.json should be left untouched because its dependencies
+          // are all package-manager protocol refs.
+          const output = JSON.parse(stdout)
+          output['packages/a/package.json'].dependencies.should.deep.equal({
+            'ncu-test-tag': 'catalog:',
+            'ncu-test-v2': 'workspace:^',
+            'some-link': 'link:../local-pkg',
+            'some-file': 'file:./local.tgz',
+          })
+        } finally {
+          await removeDir(tempDir)
+        }
+      })
+
       it('update pnpm catalog dependencies from pnpm-workspace.yaml', async () => {
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
         try {


### PR DESCRIPTION
Fixes #1765.

AI assisted but tested and reviewed manually.

## Context

When a workspace uses a non-semver package protocol (like `catalog:`, `workspace:`, `link:` etc.), running `ncu` with a `--target` that isn't `latest` throws a `TypeError: Invalid comparator: catalog:` error for each of those deps.

Related: #1710 fixed the same error on the `--peer` path.

<img width="677" height="228" alt="image" src="https://github.com/user-attachments/assets/b0bead5b-aa5b-4d2c-b0b1-a87910c1df7a" />

## Changes

- `src/lib/queryVersions.ts`: detect the non-registry protocols up front and skip them, the same way the `latest` path already does.
- `src/lib/version-util.ts`: in `filterByLevel`, return a filter that returns false when the input is not a valid version range, instead of trying to parse it.

## Tests

- `test/version-util.test.ts`: `filterByLevel` returns `false` for `catalog:`, `workspace:`, `link:`, and `file:` inputs.
- `test/workspaces.test.ts`: a workspace with all four protocol types in its dependencies runs cleanly under `--target minor`, and the catalog entry still upgrades as expected.
