### PR TITLE
test: use node util to strip ansi in deep test

### DIFF
--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -4,6 +4,7 @@ import fs from 'fs/promises'
 import os from 'os'
 import path, { dirname } from 'path'
 import spawn from 'spawn-please'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
 import { fileURLToPath } from 'url'
 import ncu from '../src/'
 import mergeOptions from '../src/lib/mergeOptions'
@@ -184,7 +185,6 @@ describe('--deep', function () {
 
   it('formats package status output without extra blank lines in deep mode', async () => {
     const tempDir = await setupDeepStatusTest()
-    const { default: stripAnsi } = await import('strip-ansi')
 
     try {
       const cli = getCliInvocation('-u', '--deep')


### PR DESCRIPTION
﻿## Summary
- Replace the dynamic `strip-ansi` import in `test/deep.test.ts` with Node's built-in `stripVTControlCharacters`.
- Addresses the follow-up from https://github.com/raineorshine/npm-check-updates/commit/3352f61ccafd0b95945dd003e49758454dfcca9c#r186881125.

## Testing
- `npm run lint:types`
- `npm run lint:src -- test/deep.test.ts`
- `.\node_modules\.bin\mocha.CMD test\deep.test.ts --grep "formats package status output without extra blank lines in deep mode"`

Note: I ran the npm commands with `npm_config_script_shell=powershell` locally because this Windows environment has npm configured to use bash, but WSL bash is unavailable.
