### PR TITLE
test: remove unused temp directory creation

### DIFF
--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -36,7 +36,6 @@ const getCliInvocation = (...args: string[]) =>
  */
 const setupDeepTest = async () => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
-  await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
   const pkgData = JSON.stringify({
     dependencies: {
       express: '1',
@@ -157,7 +156,6 @@ describe('--deep', function () {
 
   it('--deep --errorLevel 2 should exit with code 0 when there are no upgrades', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
-    await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
     const pkgData = JSON.stringify({
       dependencies: {
         'ncu-test-v2': '99.9.9',

--- a/test/workspaces.test.ts
+++ b/test/workspaces.test.ts
@@ -83,7 +83,6 @@ const setupSymlinkedPackages = async (
   customName?: string,
 ) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
-  await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
 
   const pkgDataRoot = JSON.stringify({ workspaces })
 


### PR DESCRIPTION
﻿## Summary
- Remove three unused `fs.mkdtemp` calls that created extra temp directories without using or cleaning them up.
- Fixes #1745.

## Testing
- `.\node_modules\.bin\mocha.CMD test\deep.test.ts test\workspaces.test.ts`
- `.\node_modules\.bin\tsc.CMD --noEmit`
- `.\node_modules\.bin\eslint.CMD --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives test/deep.test.ts test/workspaces.test.ts`
