### PR TITLE
test: cover Windows spawn command fallback

### DIFF
--- a/src/lib/spawnCommand.ts
+++ b/src/lib/spawnCommand.ts
@@ -2,6 +2,10 @@ import { type SpawnOptions } from 'child_process'
 import spawn from 'spawn-please'
 import { type SpawnPleaseOptions } from '../types/SpawnPleaseOptions'
 
+/** Returns the command names to try for a spawned executable. */
+export const getSpawnCommands = (command: string, platform: NodeJS.Platform = process.platform) =>
+  platform === 'win32' && command !== 'bun' ? [`${command}.cmd`, command] : [command]
+
 /**
  * Spawn a command. On Windows, prefer `<command>.cmd` but fall back to `<command>` when the
  * `.cmd` shim is not available (e.g. mise, scoop).
@@ -12,19 +16,19 @@ async function spawnCommand(
   spawnPleaseOptions?: SpawnPleaseOptions,
   spawnOptions?: SpawnOptions,
 ) {
-  if (process.platform !== 'win32' || command === 'bun') {
-    return spawn(command, args, spawnPleaseOptions, spawnOptions)
-  }
+  const commands = getSpawnCommands(command)
 
-  try {
-    return spawn(`${command}.cmd`, args, spawnPleaseOptions, spawnOptions)
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
-      return spawn(command, args, spawnPleaseOptions, spawnOptions)
+  for (const [index, command] of commands.entries()) {
+    try {
+      return await spawn(command, args, spawnPleaseOptions, spawnOptions)
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT' || index === commands.length - 1) {
+        throw e
+      }
     }
-
-    throw e
   }
+
+  throw new Error(`No spawn commands available for ${command}`)
 }
 
 export default spawnCommand

--- a/test/spawnCommand.test.ts
+++ b/test/spawnCommand.test.ts
@@ -1,0 +1,18 @@
+import { getSpawnCommands } from '../src/lib/spawnCommand'
+import chaiSetup from './helpers/chaiSetup'
+
+chaiSetup()
+
+describe('spawnCommand', () => {
+  it('prefers cmd shims on Windows and falls back to extensionless commands', () => {
+    getSpawnCommands('pnpm', 'win32').should.deep.equal(['pnpm.cmd', 'pnpm'])
+  })
+
+  it('does not use cmd shims on non-Windows platforms', () => {
+    getSpawnCommands('pnpm', 'linux').should.deep.equal(['pnpm'])
+  })
+
+  it('does not use cmd shims for bun on Windows', () => {
+    getSpawnCommands('bun', 'win32').should.deep.equal(['bun'])
+  })
+})


### PR DESCRIPTION
## Summary
- Refactor the Windows spawn command order into a small testable helper.
- Add regression coverage for trying `pnpm.cmd` before falling back to extensionless `pnpm` on Windows.
- Keep `bun` unchanged because it should not use a `.cmd` shim.

Fixes #1595.

## Testing
- `.\node_modules\.bin\mocha.CMD test\spawnCommand.test.ts`
- `.\node_modules\.bin\tsc.CMD --noEmit`
- `.\node_modules\.bin\eslint.CMD --cache --cache-location node_modules/.cache/.eslintcache --report-unused-disable-directives src/lib/spawnCommand.ts test/spawnCommand.test.ts`
