### PR TITLE
build workflow: add npm pack --dry-run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      - run: npm pack --dry-run
+
       - name: Check for uncommitted changes
         run: |
           changed=$(git diff --name-only)


### PR DESCRIPTION
We could/should switch later to using something like https://github.com/ai/size-limit so that size bumps are caught.
