### PR TITLE
test/e2e.sh: fix shellcheck issues

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck enable=require-variable-braces
+
 # These can be set once the fnm permission errors are figured out
 # See: https://github.com/Schniz/fnm
 # set -e
@@ -9,34 +11,33 @@ cwd=$(pwd)
 e2e_dir=$(dirname "$(readlink -f "$0")")
 temp_dir=$(mktemp -d)
 registry_port=4873
-registry_local="http://localhost:$registry_port"
-registry_log=$temp_dir/verdaccio.log
-verdaccio_config=$temp_dir/verdaccio-config.yaml
+registry_local="http://localhost:${registry_port}"
+registry_log=${temp_dir}/verdaccio.log
+verdaccio_config=${temp_dir}/verdaccio-config.yaml
 verdaccio_pid=""
 
 # cleanup on exit
 cleanup() {
-
   exit_status=$?
 
   # shut down verdaccio
-  if [ -n "$verdaccio_pid" ]; then
+  if [ -n "${verdaccio_pid}" ]; then
     echo Shutting down verdaccio
-    kill -9 $verdaccio_pid 2>/dev/null
-    wait $verdaccio_pid 2>/dev/null
+    kill -9 ${verdaccio_pid} 2>/dev/null
+    wait ${verdaccio_pid} 2>/dev/null
   fi
 
   # delete authToken
   # WARNING: The original authToken cannot be restored because it is protected and cannot be read with 'npm config get'.
-  npm config delete "//localhost:$registry_port/:_authToken"
+  npm config delete "//localhost:${registry_port}/:_authToken"
 
   # remove temp directory
-  rm -rf $temp_dir
+  rm -rf "${temp_dir}"
 
   # return to working directory
-  cd $cwd
+  cd "${cwd}" || exit
 
-  if [ $exit_status -ne 0 ]; then
+  if [ ${exit_status} -ne 0 ]; then
     echo Error
   else
     echo Done
@@ -50,7 +51,7 @@ trap cleanup EXIT
 #   - allow anyone to publish to avoid npm login
 #   - increase body size to accommodate current package tarball size
 echo "
-storage: $temp_dir/storage
+storage: ${temp_dir}/storage
 max_body_size: 50mb
 packages:
   npm-check-updates:
@@ -62,43 +63,43 @@ packages:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
-" >$verdaccio_config
+" >"${verdaccio_config}"
 
 # start verdaccio and wait for it to boot
 echo Starting local registry
-nohup verdaccio -l $registry_port -c $verdaccio_config &>$registry_log &
+nohup verdaccio -l ${registry_port} -c "${verdaccio_config}" &>"${registry_log}" &
 verdaccio_pid=$!
-grep -q 'http address' <(tail -f $registry_log)
+grep -q 'http address' <(tail -f "${registry_log}")
 
 # set dummy authToken which is required to publish
 # https://github.com/verdaccio/verdaccio/issues/212#issuecomment-308578500
-npm config set "//localhost:$registry_port/:_authToken=e2e_dummy"
+npm config set "//localhost:${registry_port}/:_authToken=e2e_dummy"
 
 # publish to local registry
 echo Publishing to local registry
-npm publish --registry $registry_local
+npm publish --registry ${registry_local}
 
 # wait for published version to become visible in verdaccio.
 # verdaccio can accept npm publish before npm view/npx can resolve the package metadata.
 # without this retry loop, e2e can fail intermittently with "no such package available".
 package_version=$(node -p "require('./package.json').version")
-echo "Waiting for npm-check-updates@$package_version in local registry"
+echo "Waiting for npm-check-updates@${package_version} in local registry"
 publish_visible=false
-for i in {1..20}; do
-  if npm view "npm-check-updates@$package_version" version --registry $registry_local >/dev/null 2>&1; then
+for _ in {1..20}; do
+  if npm view "npm-check-updates@${package_version}" version --registry ${registry_local} >/dev/null 2>&1; then
     publish_visible=true
     break
   fi
   sleep 1
 done
 
-if [ "$publish_visible" = false ]; then
-  echo "Warning: npm-check-updates@$package_version not visible in local registry after retry window"
+if [ "${publish_visible}" = false ]; then
+  echo "Warning: npm-check-updates@${package_version} not visible in local registry after retry window"
 fi
 
 # Test: ncu -v
 echo ncu -v
-npx --registry $registry_local npm-check-updates -v
+npx --registry ${registry_local} npm-check-updates -v
 
 # Test: cli
 # Create a package.json file with a dependency on npm-check-updates since it is already published to the local registry
@@ -107,32 +108,32 @@ echo '{
   "dependencies": {
     "npm-check-updates": "1.0.0"
   }
-}' >$temp_dir/package.json
+}' >"${temp_dir}/package.json"
 
 # --configFilePath to avoid reading the repo .ncurc
 # --cwd to point to the temp package file
 # --pre 1 to ensure that an upgrade is always suggested even if npm-check-updates is on a prerelease version
-npx --registry $registry_local npm-check-updates --configFilePath $temp_dir --cwd $temp_dir --pre 1 --registry $registry_local
+npx --registry ${registry_local} npm-check-updates --configFilePath "${temp_dir}" --cwd "${temp_dir}" --pre 1 --registry ${registry_local}
 
-rm $temp_dir/package.json
-cp -r $e2e_dir/e2e $temp_dir
+rm "${temp_dir}/package.json"
+cp -r "${e2e_dir}/e2e" "${temp_dir}"
 
 # Test: cjs
 echo Test: cjs
-cd $temp_dir/e2e/cjs
+cd "${temp_dir}/e2e/cjs" || exit
 
 echo Installing
-npm i npm-check-updates@latest --registry $registry_local
+npm i npm-check-updates@latest --registry ${registry_local}
 
 echo Running test
-REGISTRY=$registry_local node $temp_dir/e2e/cjs/index.js || { exit 1; }
+REGISTRY=${registry_local} node "${temp_dir}/e2e/cjs/index.js" || { exit 1; }
 
 # Test: esm
 echo Test: esm
-cd $temp_dir/e2e/esm
+cd "${temp_dir}/e2e/esm" || exit
 
 echo Installing
-npm i npm-check-updates@latest --registry $registry_local
+npm i npm-check-updates@latest --registry ${registry_local}
 
 echo Running test
-REGISTRY=$registry_local node $temp_dir/e2e/esm/index.js || { exit 1; }
+REGISTRY=${registry_local} node "${temp_dir}/e2e/esm/index.js" || { exit 1; }


### PR DESCRIPTION
- enable require-variable-braces, add braces around all variables
- quote path/arg expansions
- add || exit to cd calls since set -e isn't set
- use _ for the unused loop var