### PR TITLE
Replace dequal with node:util isDeepStrictEqual

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "commander": "^14.0.3",
         "cosmiconfig": "^9.0.1",
         "cross-env": "^10.1.0",
-        "dequal": "^2.0.3",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-config-raine": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "commander": "^14.0.3",
     "cosmiconfig": "^9.0.1",
     "cross-env": "^10.1.0",
-    "dequal": "^2.0.3",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-config-raine": "^0.5.0",

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -1,4 +1,3 @@
-import { dequal } from 'dequal'
 import { propertyOf } from 'lodash-es'
 import picomatch from 'picomatch'
 import cliOptions from '../cli-options'
@@ -148,7 +147,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
 
   // convert to string for comparison purposes
   // otherwise ['a b'] will not match ['a', 'b']
-  if (options.filter && args && !dequal(args.join(' '), Array.isArray(filter) ? filter.join(' ') : filter)) {
+  if (options.filter && args && args.join(' ') !== (Array.isArray(filter) ? filter.join(' ') : filter)) {
     programError(
       options,
       'Cannot specify a filter using both --filter and args. Did you forget to quote an argument?\nSee: https://github.com/raineorshine/npm-check-updates/issues/759#issuecomment-723587297',

--- a/src/lib/upgradePackageDefinitions.ts
+++ b/src/lib/upgradePackageDefinitions.ts
@@ -1,4 +1,4 @@
-import { dequal } from 'dequal'
+import { isDeepStrictEqual } from 'node:util'
 import { intersects, satisfies, validRange } from 'semver'
 import { parse, parseRange } from 'semver-utils'
 import { type Index } from '../types/IndexType'
@@ -117,7 +117,7 @@ export async function upgradePackageDefinitions(
     let checkPeerViolationResult: CheckIfInPeerViolationResult
 
     if (
-      dequal(options.peerDependencies, {
+      isDeepStrictEqual(options.peerDependencies, {
         ...options.peerDependencies,
         ...upgradedPeerDependencies,
       })
@@ -146,7 +146,7 @@ export async function upgradePackageDefinitions(
         ...options.peerDependencies,
         ...checkPeerViolationResult.upgradedPeerDependencies,
       }
-      if (dequal(options.peerDependencies, peerDependenciesAfterUpgrade)) {
+      if (isDeepStrictEqual(options.peerDependencies, peerDependenciesAfterUpgrade)) {
         // We can't find anything to do, will not upgrade anything
         return [{}, latestVersionResults, options.peerDependencies]
       }


### PR DESCRIPTION
Small savings, but we can do the same with the native isDeepStrictEqual.