### PR TITLE
Fix CodeQL issues

### DIFF
--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -102,7 +102,6 @@ async function getNcuRc({
       rawResult = await explorer.load(targetFile)
     } else {
       rawResult = await explorer.search(cwd)
-      targetFile = rawResult?.filepath
     }
   } catch (err: any) {
     const errorMessage = err.message || ''

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -309,7 +309,7 @@ async function printSkippedByCooldownTable({
 
     const wildcard = WILDCARDS.includes(currentVersion[0]) ? currentVersion[0] : ''
     const caf = wildcard + stripRange(fallbackVersion ?? currentVersion)
-    const target = wildcard + stripRange(version || '')
+    const target = wildcard + stripRange(version)
 
     currentAfterFallback[name] = caf
     skippedUpgrades[name] = colorizeDiff(caf, target)

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -117,7 +117,6 @@ const fetchPartialPackument = async (
         if (parseError) throw parseError
         if (foundAll) break
       }
-      if (parseError) throw parseError
 
       return partialPackument
     }


### PR DESCRIPTION
The `1 configuration not found` warning is because the old config needs to be removed from the repo settings.