### PR TITLE
Vite: use 'oxc' for minify

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -112,8 +112,8 @@ export default defineConfig(({ mode }) => ({
     target: 'node20',
     outDir: 'build',
     sourcemap: true,
-    minify: mode === 'production' && 'esbuild',
-    rollupOptions: {
+    minify: mode === 'production' && 'oxc',
+    rolldownOptions: {
       checks: {
         pluginTimings: false,
       },


### PR DESCRIPTION
esbuild is deprecated and vite 8 is using oxc by default.

esbuild still worked because it happened to be a transitive dependency.

Also, rename rollupOptions to rolldownOptions since it's an alias already

@raineorshine: did you keep `esbuild` for a reason or is it a leftover?