### PR TITLE
Remove lodash-es

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@types/hosted-git-info": "^3.0.5",
         "@types/ini": "^4.1.1",
         "@types/jsonlines": "^0.1.5",
-        "@types/lodash-es": "^4.17.12",
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.9.2",
         "@types/npm-registry-fetch": "^8.0.9",
@@ -67,7 +66,6 @@
         "jsonc-parser": "^3.3.1",
         "jsonlines": "^0.1.1",
         "lockfile-lint": "^5.0.0",
-        "lodash-es": "^4.18.1",
         "markdownlint-cli": "^0.48.0",
         "mocha": "^11.7.6",
         "npm-registry-fetch": "^19.1.1",
@@ -2221,23 +2219,6 @@
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     },
     "diff": ">=8.0.3",
     "ip-address": ">=10.1.1",
-    "lodash": ">=4.18.1",
     "serialize-javascript": ">=7.0.3",
     "uuid": ">=14.0.0"
   },
@@ -94,7 +93,6 @@
     "@types/hosted-git-info": "^3.0.5",
     "@types/ini": "^4.1.1",
     "@types/jsonlines": "^0.1.5",
-    "@types/lodash-es": "^4.17.12",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.9.2",
     "@types/npm-registry-fetch": "^8.0.9",
@@ -136,7 +134,6 @@
     "jsonc-parser": "^3.3.1",
     "jsonlines": "^0.1.1",
     "lockfile-lint": "^5.0.0",
-    "lodash-es": "^4.18.1",
     "markdownlint-cli": "^0.48.0",
     "mocha": "^11.7.6",
     "npm-registry-fetch": "^19.1.1",

--- a/src/lib/escapeRegExp.ts
+++ b/src/lib/escapeRegExp.ts
@@ -1,0 +1,4 @@
+/** Escapes the RegExp special characters in a string. */
+export function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/src/lib/filterAndReject.ts
+++ b/src/lib/filterAndReject.ts
@@ -1,5 +1,4 @@
 import { and, or } from 'fp-and-or'
-import { identity } from 'lodash-es'
 import picomatch from 'picomatch'
 import { parseRange } from 'semver-utils'
 import { type FilterPattern } from '../types/FilterPattern'
@@ -19,7 +18,7 @@ function composeFilter(filterPattern: FilterPattern): (name: string, versionSpec
 
   // no filter
   if (!filterPattern) {
-    predicate = identity
+    predicate = () => true
   }
   // string
   else if (typeof filterPattern === 'string') {

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -1,4 +1,3 @@
-import { propertyOf } from 'lodash-es'
 import picomatch from 'picomatch'
 import cliOptions from '../cli-options'
 import { print } from '../lib/logging'
@@ -94,7 +93,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
 
   const json = Object.keys(options)
     .filter(option => option.startsWith('json'))
-    .some(propertyOf(options))
+    .some(option => options[option as keyof Options])
 
   if (!json && loglevel !== 'silent' && options.rcConfigPath && !options.doctor) {
     print(options, `Using config file ${options.rcConfigPath}`)

--- a/src/lib/upgradeDependencies.ts
+++ b/src/lib/upgradeDependencies.ts
@@ -1,4 +1,3 @@
-import { flow } from 'lodash-es'
 import { parseRange } from 'semver-utils'
 import { type Index } from '../types/IndexType'
 import { type Options } from '../types/Options'
@@ -45,7 +44,7 @@ function upgradeDependencies(
       removeRange: options.removeRange,
     })
 
-  return flow([
+  const pipeline: ((deps: any) => any)[] = [
     // only include packages for which a latest version was fetched
     (deps: Index<VersionSpec>): Index<VersionSpec> =>
       pickBy(deps, (current, packageName) => packageName in latestVersions),
@@ -104,7 +103,9 @@ function upgradeDependencies(
         },
         {},
       ),
-  ])(currentDependencies)
+  ]
+
+  return pipeline.reduce((deps, fn) => fn(deps), currentDependencies as Index<VersionSpec>)
 }
 
 export default upgradeDependencies

--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -1,4 +1,4 @@
-import { escapeRegExp, propertyOf } from 'lodash-es'
+import { propertyOf } from 'lodash-es'
 import parseGitHubUrl from 'parse-github-url'
 import semver from 'semver'
 import semverutils, { type SemVer, parse, parseRange } from 'semver-utils'
@@ -10,6 +10,7 @@ import { type Options } from '../types/Options'
 import { type UpgradeGroup } from '../types/UpgradeGroup'
 import { type VersionLevel } from '../types/VersionLevel'
 import chalk from './chalk'
+import { escapeRegExp } from './escapeRegExp'
 import { keyValueBy } from './keyValueBy'
 import { sortBy } from './sortBy'
 

--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -1,4 +1,3 @@
-import { propertyOf } from 'lodash-es'
 import parseGitHubUrl from 'parse-github-url'
 import semver from 'semver'
 import semverutils, { type SemVer, parse, parseRange } from 'semver-utils'
@@ -110,7 +109,9 @@ export function stringify(semver: SemVer, precision?: VersionPart) {
 export function getPrecision(version: string) {
   const [semver] = semverutils.parseRange(version)
   // expects VERSION_PARTS to be in correct order
-  return VERSION_PARTS.slice().reverse().find(propertyOf(semver))
+  return VERSION_PARTS.slice()
+    .reverse()
+    .find(part => semver?.[part])
 }
 
 /**

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -1,7 +1,6 @@
 import memoize from 'fast-memoize'
 import fs from 'fs/promises'
 import jsonlines from 'jsonlines'
-import { curry } from 'lodash-es'
 import os from 'os'
 import path from 'path'
 import { parse as parseYaml } from 'yaml'
@@ -58,7 +57,7 @@ const interpolate = (s: string, data: Index<string | undefined>): string =>
   )
 
 /** Reads an auth token from a yarn config, interpolates it, and returns it as an npm config key-value pair. */
-export const npmAuthTokenKeyValue = curry((npmConfig: Index<string | boolean>, dep: string, scopedConfig: NpmScope) => {
+export const npmAuthTokenKeyValue = (npmConfig: Index<string | boolean>) => (dep: string, scopedConfig: NpmScope) => {
   if (scopedConfig.npmAuthToken) {
     // get registry server from this config or a previous config (assumes setNpmRegistry has already been called on all npm scopes)
     const registryServer = scopedConfig.npmRegistryServer || (npmConfig[`@${dep}:registry`] as string | undefined)
@@ -78,7 +77,7 @@ export const npmAuthTokenKeyValue = curry((npmConfig: Index<string | boolean>, d
   }
 
   return null
-})
+}
 
 /** Reads a registry from a yarn config. interpolates it, and returns it as an npm config key-value pair. */
 const npmRegistryKeyValue = (dep: string, scopedConfig: NpmScope): null | Index<VersionSpec> =>

--- a/test/package-managers/yarn/index.test.ts
+++ b/test/package-managers/yarn/index.test.ts
@@ -81,7 +81,7 @@ describe('yarn', function () {
 
   describe('npmAuthTokenKeyValue', () => {
     it('npmRegistryServer with trailing slash', () => {
-      const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {
+      const authToken = yarn.npmAuthTokenKeyValue({})('fortawesome', {
         npmAlwaysAuth: true,
         npmAuthToken: 'MY-AUTH-TOKEN',
         npmRegistryServer: 'https://npm.fontawesome.com/',
@@ -93,7 +93,7 @@ describe('yarn', function () {
     })
 
     it('npmRegistryServer without trailing slash', () => {
-      const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {
+      const authToken = yarn.npmAuthTokenKeyValue({})('fortawesome', {
         npmAlwaysAuth: true,
         npmAuthToken: 'MY-AUTH-TOKEN',
         npmRegistryServer: 'https://npm.fontawesome.com',
@@ -105,7 +105,7 @@ describe('yarn', function () {
     })
 
     it('returns null when no npmAlwaysAuth', () => {
-      const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {
+      const authToken = yarn.npmAuthTokenKeyValue({})('fortawesome', {
         npmAlwaysAuth: true,
         // undefined: npmAuthToken: 'MY-AUTH-TOKEN',
         npmRegistryServer: 'https://npm.fontawesome.com/',
@@ -115,7 +115,7 @@ describe('yarn', function () {
     })
 
     it('returns null when no registry server', () => {
-      const authToken = yarn.npmAuthTokenKeyValue({}, 'fortawesome', {
+      const authToken = yarn.npmAuthTokenKeyValue({})('fortawesome', {
         npmAlwaysAuth: true,
         npmAuthToken: 'MY-AUTH-TOKEN',
         // undefined: npmRegistryServer: 'https://npm.fontawesome.com/',


### PR DESCRIPTION
@raineorshine: I kept the patches as separate commits. I think it'd be better if these landed without a squash for future reference.

I tried to cover all cases regarding undefined/null values which lodash usually covers silently. Let me know if you spot any issues. :)

This change reduces the modules that are transformed from 1403 to 764 and should also speed up the build due to that (most noticeable on Windows). Also, decreases the built files's size and npm pack size, not by a lot, but still.