### PR TITLE
Replace forEach with for...of

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -76,7 +76,7 @@ ${chalk.dim.underline(
     } else {
       await chalkInit()
       const nonHelpArgs = [...rawArgs.slice(0, indexHelp), ...rawArgs.slice(indexHelp + 1)]
-      nonHelpArgs.forEach(arg => {
+      for (const arg of nonHelpArgs) {
         // match option by long or short
         const query = arg.replace(/^-*/, '')
         const option = cliOptions.find(
@@ -100,7 +100,7 @@ ${chalk.dim.underline(
         } else {
           console.info(`Unknown option: ${arg}`)
         }
-      })
+      }
     }
     process.exit(0)
   }
@@ -136,7 +136,7 @@ ${chalk.dim.underline(
     })
 
   // add cli options
-  cliOptions.forEach(({ long, short, arg, description, default: defaultValue, help, parse, type }) => {
+  for (const { long, short, arg, description, default: defaultValue, help, parse, type } of cliOptions) {
     const flags = `${short ? `-${short}, ` : ''}--${long}${arg ? ` <${arg}>` : ''}`
     // format description for cli by removing inline code ticks
     // point to help in description if extended help text is available
@@ -150,7 +150,7 @@ ${chalk.dim.underline(
     if (type === 'boolean') {
       program.addOption(new Option(`--no-${long}`).default(false).hideHelp())
     }
-  })
+  }
 
   // set version option at the end
   program.version(pkg.version)

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -108,28 +108,28 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
       (long === 'packageManager' && options.packageManager === 'staticRegistry'),
   )
   if (deprecatedOptions.length > 0) {
-    deprecatedOptions.forEach(({ long, description }) => {
+    for (const { long, description } of deprecatedOptions) {
       const deprecationMessage =
         long === 'packageManager'
           ? '--packageManager staticRegistry is deprecated. Use --registryType json.'
           : `--${long}: ${description}`
       print(options, chalk.yellow(deprecationMessage), 'warn')
-    })
+    }
     print(options, '', 'warn')
   }
 
   // validate options with predefined choices
-  cliOptions.forEach(({ long, choices }) => {
-    if (!choices || choices.length === 0) return
+  for (const { long, choices } of cliOptions) {
+    if (!choices || choices.length === 0) continue
     const value = options[long as keyof Options]
     const values = Array.isArray(value) ? value : [value]
-    if (values.length === 0) return
+    if (values.length === 0) continue
     // make sure the option value is valid
     // if an array of values is given, make sure each one is a valid choice
     if (values.every(value => !choices.includes(value))) {
       programError(options, `Invalid option value: --${long} ${value}. Valid values are: ${choices.join(', ')}.`)
     }
-  })
+  }
 
   // validate options.cwd
   if (options.cwd && !(await exists(options.cwd))) {

--- a/src/lib/keyValueBy.ts
+++ b/src/lib/keyValueBy.ts
@@ -26,9 +26,9 @@ export function keyValueBy<T, R = true>(
     const o = isArray
       ? (keyValue as ArrayKeyValueGenerator<T, R>)(value, i, accum)
       : (keyValue as ObjectKeyValueGenerator<T, R>)(key, value, accum)
-    Object.entries(o || {}).forEach(entry => {
-      accum[entry[0]] = entry[1]
-    })
+    for (const [k, v] of Object.entries(o || {})) {
+      accum[k] = v
+    }
   })
 
   return accum

--- a/src/lib/mergeOptions.ts
+++ b/src/lib/mergeOptions.ts
@@ -15,11 +15,12 @@ function mergeOptions(rawOptions1: Options | null, rawOptions2: Options | null) 
   const options1: Options = rawOptions1 || {}
   const options2: Options = rawOptions2 || {}
   const result = { ...options1, ...options2 }
-  ;(Object.keys(result) as OptionKey[]).forEach(key => {
+
+  for (const key of Object.keys(result) as OptionKey[]) {
     if (Array.isArray(options1[key]) && Array.isArray(options2[key])) {
       result[key] = mergeArrays(options1[key] as any[], options2[key] as any[]) as any
     }
-  })
+  }
   return result
 }
 

--- a/src/lib/upgradePackageData.ts
+++ b/src/lib/upgradePackageData.ts
@@ -61,46 +61,46 @@ async function upgradePackageData(
       const reconstructedUpdates: { path: string[]; newValue: string }[] = []
 
       if (catalogData.catalogs) {
-        Object.entries(catalogData.catalogs).forEach(([catalogName, catalog]) => {
-          Object.entries(upgraded).forEach(([dep, version]) => {
+        for (const [catalogName, catalog] of Object.entries(catalogData.catalogs)) {
+          for (const [dep, version] of Object.entries(upgraded)) {
             if (catalog[dep]) {
               reconstructedUpdates.push({ path: ['catalogs', catalogName, dep], newValue: version })
             }
-          })
-        })
+          }
+        }
       }
 
       if (catalogData.catalog) {
-        Object.entries(upgraded).forEach(([dep, version]) => {
+        for (const [dep, version] of Object.entries(upgraded)) {
           if (catalogData.catalog?.[dep]) {
             reconstructedUpdates.push({ path: ['catalog', dep], newValue: version })
           }
-        })
+        }
       }
 
       // Handle nested workspaces.catalog and workspaces.catalogs format
       const workspacesData = catalogData.workspaces
       if (workspacesData && !Array.isArray(workspacesData)) {
         if (workspacesData.catalogs) {
-          Object.entries(workspacesData.catalogs).forEach(([catalogName, catalog]) => {
-            Object.entries(upgraded).forEach(([dep, version]) => {
+          for (const [catalogName, catalog] of Object.entries(workspacesData.catalogs)) {
+            for (const [dep, version] of Object.entries(upgraded)) {
               if (catalog[dep]) {
                 reconstructedUpdates.push({ path: ['workspaces', 'catalogs', catalogName, dep], newValue: version })
               }
-            })
-          })
+            }
+          }
         }
         if (workspacesData.catalog) {
-          Object.entries(upgraded).forEach(([dep, version]) => {
+          for (const [dep, version] of Object.entries(upgraded)) {
             if (workspacesData.catalog?.[dep]) {
               reconstructedUpdates.push({ path: ['workspaces', 'catalog', dep], newValue: version })
             }
-          })
+          }
         }
       }
 
       let updatedContent = yamlContent
-      reconstructedUpdates.forEach(upgrade => {
+      for (const upgrade of reconstructedUpdates) {
         const updatedYaml = updateYamlCatalogDependencies({
           fileContent: updatedContent,
           upgrade,
@@ -110,7 +110,7 @@ async function upgradePackageData(
         if (updatedYaml) {
           updatedContent = updatedYaml
         }
-      })
+      }
 
       return updatedContent
     }

--- a/src/lib/wrap.ts
+++ b/src/lib/wrap.ts
@@ -2,11 +2,11 @@
 const wrap = (s: string, maxLineLength = 92) => {
   const linesIn = s.split('\n')
   const linesOut: string[] = []
-  linesIn.forEach(lineIn => {
+  for (const lineIn of linesIn) {
     let i = 0
     if (lineIn.length === 0) {
       linesOut.push('')
-      return
+      continue
     }
 
     while (i < lineIn.length) {
@@ -37,7 +37,7 @@ const wrap = (s: string, maxLineLength = 92) => {
       linesOut.push(line.trimEnd())
       i += line.length
     }
-  })
+  }
   return linesOut.join('\n').trim()
 }
 

--- a/test/cli-options.test.ts
+++ b/test/cli-options.test.ts
@@ -5,9 +5,9 @@ chaiSetup()
 
 describe('cli-options', () => {
   it('require long and description properties', () => {
-    cliOptions.forEach(option => {
+    for (const option of cliOptions) {
       option.should.have.property('long')
       option.should.have.property('description')
-    })
+    }
   })
 })

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -1946,7 +1946,7 @@ describe('cooldown', () => {
     }
 
     const targets = ['latest', 'newest', 'greatest', 'minor', 'patch', 'semver', '@latest'] as const
-    targets.forEach(async target => {
+    for (const target of targets) {
       it(`handles "target: ${target}" when all versions are within cooldown (no fallback possible)`, async () => {
         // Given: cooldown set to 10, test-package@1.0.0 installed
         // latest dist-tag (1.0.2) released 5 days ago (within 10-day cooldown)
@@ -1998,7 +1998,7 @@ describe('cooldown', () => {
         logSpy.restore()
         stub.restore()
       })
-    })
+    }
   })
 
   describe('when installed version matches target version and is within cooldown', () => {
@@ -2024,7 +2024,7 @@ describe('cooldown', () => {
       format: ['cooldown'],
     }
     const targets = ['latest', '@latest', 'newest', 'greatest'] as const
-    targets.forEach(async target => {
+    for (const target of targets) {
       it(`handles "target: ${target}" correctly within cooldown`, async () => {
         const cooldown = 6
 
@@ -2043,7 +2043,7 @@ describe('cooldown', () => {
         logSpy.restore()
         stub.restore()
       })
-    })
+    }
   })
 
   describe(`Don't skip by cooldown when package metadata doesn't have "time"`, () => {
@@ -2096,7 +2096,7 @@ describe('cooldown', () => {
     after(() => stub.restore())
 
     const targets = ['latest', 'greatest', 'minor', 'patch', 'semver'] as const
-    targets.forEach(async target => {
+    for (const target of targets) {
       it(`handles "target: ${target}" correctly within cooldown`, async () => {
         // greatest version time was deleted, all teaget function should return
         // test-package-with-no-time: 1.0.2 or 1.0.3-pre.0, for newest and greatest for the upgrade
@@ -2120,7 +2120,7 @@ describe('cooldown', () => {
 
         logSpy.restore()
       })
-    })
+    }
 
     it(`handles "target: '@latest'" correctly within cooldown`, async () => {
       stub = stubVersions(versions)

--- a/test/helpers/silenceProgressBar.ts
+++ b/test/helpers/silenceProgressBar.ts
@@ -20,6 +20,8 @@ export function silenceProgressBar() {
   ]
 
   afterEach(() => {
-    stubs.forEach(s => s.restore())
+    for (const s of stubs) {
+      s.restore()
+    }
   })
 }


### PR DESCRIPTION
I think `for...of` is cleaner and doesn't fire a callback each time. I kept the vendored files as is, and the `keyValueBy` instance.

Let me know if you want me to make any changes or drop this altogether.