### PR TITLE
fix padLeft adding trailing spaces to blank lines

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -15,7 +15,7 @@ const supportedVersionTargets = ['latest', 'newest', 'greatest', 'minor', 'patch
 const padLeft = (s: string, n: number) =>
   s
     .split('\n')
-    .map(line => `${''.padStart(n, ' ')}${line}`)
+    .map(line => (line ? `${''.padStart(n, ' ')}${line}` : line))
     .join('\n')
 
 /** Formats a code block for CLI or markdown. */


### PR DESCRIPTION
This was only visible on Windows native CMD, something adds trailing spaces on blank lines and caused this failure on my Windows dev VM:


```
 1) doctor
       npm
         print instructions when -u is not specified:

      AssertionError: expected 'Usage: ncu --doctor\n\nIteratively installs upgrades and runs your project\'s tests to identify breaking upgrades. Reverts broken upgrades and updates package.json with working upgrades.\n\nRequires `-u` to execute (modifies your package file, lock file, and node_modules)\n\nTo be more precise:\n\n1. Runs `npm install` and `npm test` to ensure tests are currently passing.\n2. Runs `ncu -u` to optimistically upgrade all dependencies.\n3. If tests pass, hurray!\n4. If tests fail, restores package file and lock file.\n5. For each dependency, install upgrade and run tests.\n6. Prints broken upgrades with test error.\n7. Saves working upgrades to package.json.\n\nAdditional options:\n\n┌─────────────────┬────────────────────────────────────────────────────────────────┐\n│ --doctorInstall │ specify a custom install script (default: npm install or yarn) │\n├─────────────────┼────────────────────────────────────────────────────────────────┤\n│ --doctorTest    │ specify a custom test script (default: npm test)               │\n└─────────────────┴────────────────────────────────────────────────────────────────┘\n\nExample:\n\n    $ ncu --doctor -u\n    Running tests before upgrading\n    npm install\n    npm run test\n    Upgrading all dependencies and re-running tests\n    ncu -u\n    npm install\n    npm run test\n    Tests failed\n    Identifying broken dependencies\n    npm install\n    npm install --no-save react@16.0.0\n    npm run test\n      ✓ react 15.0.0 → 16.0.0\n    npm install --no-save react-redux@7.0.0\n    npm run test\n      ✗ react-redux 6.0.0 → 7.0.0\n    \n    /projects/myproject/test.js:13\n      throw new Error(\'Test failed!\')\n      ^\n    \n    npm install --no-save react-dnd@11.1.3\n    npm run test\n      ✓ react-dnd 10.0.0 → 11.1.3\n    Saving partially upgraded package.json\n\n' to equal 'Usage: ncu --doctor\n\nIteratively installs upgrades and runs your project\'s tests to identify breaking upgrades. Reverts broken upgrades and updates package.json with working upgrades.\n\nRequires `-u` to execute (modifies your package file, lock file, and node_modules)\n\nTo be more precise:\n\n1. Runs `npm install` and `npm test` to ensure tests are currently passing.\n2. Runs `ncu -u` to optimistically upgrade all dependencies.\n3. If tests pass, hurray!\n4. If tests fail, restores package file and lock file.\n5. For each dependency, install upgrade and run tests.\n6. Prints broken upgrades with test error.\n7. Saves working upgrades to package.json.\n\nAdditional options:\n\n┌─────────────────┬────────────────────────────────────────────────────────────────┐\n│ --doctorInstall │ specify a custom install script (default: npm install or yarn) │\n├─────────────────┼────────────────────────────────────────────────────────────────┤\n│ --doctorTest    │ specify a custom test script (default: npm test)               │\n└─────────────────┴────────────────────────────────────────────────────────────────┘\n\nExample:\n\n    $ ncu --doctor -u\n    Running tests before upgrading\n    npm install\n    npm run test\n    Upgrading all dependencies and re-running tests\n    ncu -u\n    npm install\n    npm run test\n    Tests failed\n    Identifying broken dependencies\n    npm install\n    npm install --no-save react@16.0.0\n    npm run test\n      ✓ react 15.0.0 → 16.0.0\n    npm install --no-save react-redux@7.0.0\n    npm run test\n      ✗ react-redux 6.0.0 → 7.0.0\n\n    /projects/myproject/test.js:13\n      throw new Error(\'Test failed!\')\n      ^\n\n    npm install --no-save react-dnd@11.1.3\n    npm run test\n      ✓ react-dnd 10.0.0 → 11.1.3\n    Saving partially upgraded package.json\n\n'
      + expected - actual

             ✓ react 15.0.0 → 16.0.0
           npm install --no-save react-redux@7.0.0
           npm run test
             ✗ react-redux 6.0.0 → 7.0.0
      -
      +
           /projects/myproject/test.js:13
             throw new Error('Test failed!')
             ^
      -
      +
           npm install --no-save react-dnd@11.1.3
           npm run test
             ✓ react-dnd 10.0.0 → 11.1.3
           Saving partially upgraded package.json

      at Context.<anonymous> (test\doctor.test.ts:51:39)
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

This, along with the other fixes so far, makes everything pass again on native Windows CMD/environment minus the e2e tests, which is accepted to me :)