### PR TITLE
fix: inline semver-utils types in the d.ts rollup

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,7 +91,13 @@ export default defineConfig(({ mode }) => ({
     dts({
       entryRoot: 'src',
       include: ['src'],
-      bundleTypes: true,
+      /**
+       * Inline semver-utils types so the emitted .d.ts has no external import.
+       * semver-utils is bundled into the JS, not a runtime dependency.
+       */
+      bundleTypes: {
+        bundledPackages: ['semver-utils', '@types/semver-utils'],
+      },
       insertTypesEntry: true,
       outDirs: 'build',
     }),


### PR DESCRIPTION
Fixes #1461

`bundleTypes: true` is for internal types only. External types must be specified explicitly as it seems.