### PR TITLE
Move configs out of package.json

### DIFF
--- a/.lockfile-lintrc.json
+++ b/.lockfile-lintrc.json
@@ -1,0 +1,7 @@
+{
+  "allowed-schemes": ["https:"],
+  "allowed-hosts": ["npm"],
+  "empty-hostname": false,
+  "type": "npm",
+  "path": "package-lock.json"
+}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,14 @@
+{
+  "check-leaks": true,
+  "extension": ["test.ts"],
+  "node-option": [
+    "import=tsx",
+    "enable-source-maps",
+    "trace-deprecation",
+    "trace-warnings",
+    "no-warnings=TimeoutNaNWarning"
+  ],
+  "timeout": 60000,
+  "recursive": true,
+  "exit": true
+}

--- a/package.json
+++ b/package.json
@@ -164,21 +164,5 @@
   "files": [
     "build",
     "!**/test/**"
-  ],
-  "mocha": {
-    "check-leaks": true,
-    "extension": [
-      "test.ts"
-    ],
-    "node-option": [
-      "import=tsx",
-      "enable-source-maps",
-      "trace-deprecation",
-      "trace-warnings",
-      "no-warnings=TimeoutNaNWarning"
-    ],
-    "timeout": 60000,
-    "recursive": true,
-    "exit": true
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -165,19 +165,6 @@
     "build",
     "!**/test/**"
   ],
-  "lockfile-lint": {
-    "allowed-schemes": [
-      "https:",
-      "git+ssh:"
-    ],
-    "allowed-hosts": [
-      "npm",
-      "github.com"
-    ],
-    "empty-hostname": false,
-    "type": "npm ",
-    "path": "package-lock.json"
-  },
   "mocha": {
     "check-leaks": true,
     "extension": [


### PR DESCRIPTION
I'm in the between myself about this. On one hand, the package.json file is growing. On the other hand, we end up with multiple files at root. I mostly prefer this approach in my projects but let me know and I will just rebase to keep the lockfile-lint tightening.