### PR TITLE
build(deps): downgrade ini from 7.0.0 to 6.0.0 to restore Node 20 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "fp-and-or": "^1.0.2",
         "globals": "^17.6.0",
         "hosted-git-info": "^9.0.3",
-        "ini": "^7.0.0",
+        "ini": "^6.0.0",
         "jsonc-parser": "^3.3.1",
         "jsonlines": "^0.1.1",
         "lilconfig": "^3.1.3",
@@ -7820,13 +7820,13 @@
       "license": "ISC"
     },
     "node_modules/ini": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
-      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/internal-slot": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "fp-and-or": "^1.0.2",
     "globals": "^17.6.0",
     "hosted-git-info": "^9.0.3",
-    "ini": "^7.0.0",
+    "ini": "^6.0.0",
     "jsonc-parser": "^3.3.1",
     "jsonlines": "^0.1.1",
     "lilconfig": "^3.1.3",


### PR DESCRIPTION
## Problem

`ini` was bumped to `^7.0.0` in #1726 (commit `ccb1e6c3`, 2026-05-24). `ini@7.0.0` requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, which dropped Node 20 support and produced an `EBADENGINE` warning:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE package: 'ini@7.0.0',
npm warn EBADENGINE required: { node: '^22.22.2 || ^24.15.0 || >=26.0.0' },
npm warn EBADENGINE current: { node: 'v24.8.0', npm: '11.6.0' }
npm warn EBADENGINE }
```

This project's `engines` is `^20.19.0 || ^22.12.0 || >=24.0.0`, so Node 20 must remain supported.

## Fix

Pin `ini` back to `^6.0.0`, whose engines (`^20.17.0 || >=22.9.0`) are compatible with all supported Node versions. Lockfile updated accordingly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>