### PR TITLE
CI: remove concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,6 @@ env:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -7,10 +7,6 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   cleanup:
     name: Delete caches for the closed PR

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,10 +12,6 @@ on:
     - cron: '0 2 * * 5'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,6 @@ env:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,6 @@ env:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   run:
     name: Node ${{ matrix.node }} on ${{ matrix.os }}


### PR DESCRIPTION
Since we merge too fast on main, this is causing failures.