### PR TITLE
Downgrade ts-json-schema-generator to v2.4.0 for Node.js 20 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "sinon": "^22.0.0",
         "spawn-please": "^3.0.0",
         "timeago.js": "^4.0.2",
-        "ts-json-schema-generator": "^2.9.0",
+        "ts-json-schema-generator": "2.4.0",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3",
         "unplugin-dts": "^1.0.2",
@@ -13293,26 +13293,36 @@
       }
     },
     "node_modules/ts-json-schema-generator": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.9.0.tgz",
-      "integrity": "sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-2.4.0.tgz",
+      "integrity": "sha512-HbmNsgs58CfdJq0gpteRTxPXG26zumezOs+SB9tgky6MpqiFgQwieCn2MW70+sxpHouZ/w9LW0V6L4ZQO4y1Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.15",
-        "commander": "^14.0.3",
-        "glob": "^13.0.6",
+        "commander": "^13.1.0",
+        "glob": "^11.0.1",
         "json5": "^2.2.3",
         "normalize-path": "^3.0.0",
         "safe-stable-stringify": "^2.5.0",
         "tslib": "^2.8.1",
-        "typescript": "^5.9.3"
+        "typescript": "^5.8.2"
       },
       "bin": {
         "ts-json-schema-generator": "bin/ts-json-schema-generator.js"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-json-schema-generator/node_modules/balanced-match": {
@@ -13338,19 +13348,52 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/ts-json-schema-generator/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-json-schema-generator/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ts-json-schema-generator/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "sinon": "^22.0.0",
     "spawn-please": "^3.0.0",
     "timeago.js": "^4.0.2",
-    "ts-json-schema-generator": "^2.9.0",
+    "ts-json-schema-generator": "2.4.0",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "unplugin-dts": "^1.0.2",


### PR DESCRIPTION
Spotted in #1847.

We can unpin it in #1844.