### PR TITLE
package.json: remove unneeded overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,6 +1154,16 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/@microsoft/api-extractor/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
       "version": "10.2.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
@@ -10490,6 +10500,16 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/mocha/node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -12353,9 +12373,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -14000,9 +14020,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "camelcase": "^9.0.0",
         "chai": "^6.2.2",
         "chai-as-promised": "^8.0.2",
-        "chai-string": "^1.6.0",
+        "chai-string": "^2.0.0",
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -4494,13 +4494,13 @@
       }
     },
     "node_modules/chai-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.6.0.tgz",
-      "integrity": "sha512-sXV7whDmpax+8H++YaZelgin7aur1LGf9ZhjZa3ojETFJ0uPVuS4XEXuIagpZ/c8uVOtsSh4MwOjy5CBLjJSXA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-2.0.0.tgz",
+      "integrity": "sha512-zQt5v29IuVKYsgCEptigA0r12u81ZFRh3xf1gISsbVsZqZ09jqscv3ruqziAmgltpX0rRgYXpbnGHRXPV027MQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "chai": "^4.1.2"
+        "chai": ">= 4"
       }
     },
     "node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -71,9 +71,13 @@
       "eslint-plugin-n": "$eslint-plugin-n",
       "eslint-plugin-promise": "$eslint-plugin-promise"
     },
-    "diff": ">=8.0.3",
-    "serialize-javascript": ">=7.0.3",
-    "uuid": ">=14.0.0"
+    "mocha": {
+      "diff": "^8.0.3",
+      "serialize-javascript": "^7.0.3"
+    },
+    "@cypress/request": {
+      "uuid": "^14.0.0"
+    }
   },
   "devDependencies": {
     "@eslint/compat": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -71,12 +71,7 @@
       "eslint-plugin-n": "$eslint-plugin-n",
       "eslint-plugin-promise": "$eslint-plugin-promise"
     },
-    "@verdaccio/core": ">=8.0.0-next-8.33",
-    "chai-string": {
-      "chai": "$chai"
-    },
     "diff": ">=8.0.3",
-    "ip-address": ">=10.1.1",
     "serialize-javascript": ">=7.0.3",
     "uuid": ">=14.0.0"
   },
@@ -108,7 +103,7 @@
     "camelcase": "^9.0.0",
     "chai": "^6.2.2",
     "chai-as-promised": "^8.0.2",
-    "chai-string": "^1.6.0",
+    "chai-string": "^2.0.0",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",


### PR DESCRIPTION
These deps have been already patched:

```
C:\Users\xmr\Desktop\npm-check-updates>npm ls @verdaccio/core
npm-check-updates@22.2.7 C:\Users\xmr\Desktop\npm-check-updates
`-- verdaccio@6.7.2
  +-- @verdaccio/auth@8.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/config@8.1.1
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/core@8.1.1
  +-- @verdaccio/hooks@8.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/loaders@8.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/local-storage-legacy@11.3.3
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/logger@8.0.2
  | `-- @verdaccio/logger-commons@8.0.2
  |   `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/middleware@8.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/package-filter@13.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/signature@8.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/tarball@13.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/url@13.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- @verdaccio/utils@8.1.2
  | `-- @verdaccio/core@8.1.1 deduped
  +-- verdaccio-audit@13.0.2
  | `-- @verdaccio/core@8.1.1 deduped
  `-- verdaccio-htpasswd@13.0.2
    `-- @verdaccio/core@8.1.1 deduped


C:\Users\xmr\Desktop\npm-check-updates>npm ls chai
npm-check-updates@22.2.7 C:\Users\xmr\Desktop\npm-check-updates
+-- chai-as-promised@8.0.2
| `-- chai@6.2.2 deduped
+-- chai-string@2.0.0
| `-- chai@6.2.2 deduped
`-- chai@6.2.2


C:\Users\xmr\Desktop\npm-check-updates>npm ls ip-address
npm-check-updates@22.2.7 C:\Users\xmr\Desktop\npm-check-updates
`-- npm-registry-fetch@19.1.1
  `-- make-fetch-happen@15.0.5
    `-- @npmcli/agent@4.0.0
      `-- socks-proxy-agent@8.0.5
        `-- socks@2.8.7
          `-- ip-address@10.2.0
```