### PR TITLE
vite: remove workaround for p-map

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -99,7 +99,6 @@ export default defineConfig(({ mode }) => ({
         {
           format: 'cjs',
           entryFileNames: '[name].cjs',
-          chunkFileNames: 'chunks/[name]-[hash].cjs', // The fix for p-map
           exports: 'named',
         },
       ],


### PR DESCRIPTION
It doesn't seem that this is needed anymore.