### PR TITLE
ESLint: bump to es2023 globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,7 @@ export default [
         ...globals.browser,
         ...globals.mocha,
         ...globals.node,
-        ...globals.es2021,
+        ...globals.es2023,
         ...globals.jest,
         ...raineConfig.globals,
       },
@@ -106,7 +106,7 @@ export default [
       },
       globals: {
         ...globals.node,
-        ...globals.es2021,
+        ...globals.es2023,
       },
     },
     plugins: {


### PR DESCRIPTION
This is to align with what we are targeting for.