### PR TITLE
package.json: remove duplicate typecheck script

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,6 +47,3 @@ jobs:
 
       - name: Run lint
         run: npm run lint
-
-      - name: Run TypeScript type check
-        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "test:bun": "mocha test/bun",
     "test:unit": "mocha test --ignore \"test/bun/*\"",
     "test:e2e": "./test/e2e.sh",
-    "typecheck": "tsc --noEmit",
     "ncu": "node build/cli.js"
   },
   "repository": {


### PR DESCRIPTION
`npm run lint` already runs the `lint:types` script so it was running twice.