### PR TITLE
Remove the unused libnpmconfig.d.ts

### DIFF
--- a/src/types/libnpmconfig.d.ts
+++ b/src/types/libnpmconfig.d.ts
@@ -1,2 +1,0 @@
-// add to tsconfig compilerOptions.paths
-declare module 'libnpmconfig'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
     "incremental": true,
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo",
     "paths": {
-      "libnpmconfig": ["./src/types/libnpmconfig"],
       "prompts-ncu": ["./src/types/prompts-ncu"]
     }
   }


### PR DESCRIPTION
I wonder what's the replacement for libnpmconfig nowadays? Maybe it won't be too hard to migrate and drop the custom vendored files from the repo.