### PR TITLE
lint: add --continue-on-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build": "vite build",
     "build:options": "tsx scripts/build-options.ts",
     "build:analyze": "cross-env ANALYZER=true vite build",
-    "lint": "cross-env FORCE_COLOR=1 npm-run-all --parallel --aggregate-output lint:*",
+    "lint": "cross-env FORCE_COLOR=1 npm-run-all --parallel --continue-on-error --aggregate-output lint:*",
     "lint:lockfile": "lockfile-lint",
     "lint:types": "tsc --noEmit",
     "lint:markdown": "markdownlint \"**/*.md\" --ignore \"**/node_modules/**/*.md\" --ignore build --config .markdownlint.json",


### PR DESCRIPTION
This is so that we get all the scripts to finish and not bail out on the first error.