### PR TITLE
Dockerfile: use lts-alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM        node:latest
+FROM node:lts-alpine
 
-RUN         npm install -g npm-check-updates
+RUN npm install -g npm-check-updates
 
-WORKDIR     /app
+WORKDIR /app
 
-ENTRYPOINT  ["npm-check-updates"]
+ENTRYPOINT ["npm-check-updates"]


### PR DESCRIPTION
Much smaller, less vulnerabilities, more predictable.