### PR TITLE
cache test: remove any previous stale cache file to prevent failures

### DIFF
--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -17,6 +17,10 @@ const NOW = Date.now()
 const getTime = (daysAgo: number) => new Date(NOW - daysAgo * DAY).toISOString()
 
 describe('cache', () => {
+  before(async () => {
+    await fs.rm(resolvedDefaultCacheFile, { recursive: true, force: true })
+  })
+
   it('cache latest versions', async () => {
     const stub = stubVersions({
       'ncu-test-v2': { version: '2.0.0', time: { '2.0.0': getTime(10) } },


### PR DESCRIPTION
I only hit this a couple of times on my dev VM, I probably killed the process and the cache file wasn't cleaned up. Or I did run `ncu` on my dev VM between test runs.

Let me know if it doesn't make sense to delete the cache file before the cache tests, maybe I'm missing something.