### PR TITLE
fix: skip cache write when cooldown is active

### DIFF
--- a/src/lib/queryVersions.ts
+++ b/src/lib/queryVersions.ts
@@ -142,7 +142,8 @@ async function queryVersions(packageMap: Index<VersionSpec>, options: Options = 
 
     bar?.tick()
 
-    if (versionResult.version) {
+    // don't cache the cooldown fallback under the plain key (see the skipped read above)
+    if (versionResult.version && !options.cooldown) {
       options.cacher?.set(name, target, versionResult.version, versionResult.time)
     }
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises'
 import ncu from '../src/'
 import { CACHE_DELIMITER, resolvedDefaultCacheFile } from '../src/lib/cache'
 import { CURRENT_CACHE_SCHEMA, type CacheData } from '../src/types/Cacher'
+import type { Packument } from '../src/types/Packument'
 import chaiSetup from './helpers/chaiSetup'
 import stubVersions from './helpers/stubVersions'
 
@@ -193,5 +194,53 @@ describe('cache', () => {
       await fs.rm(resolvedDefaultCacheFile, { recursive: true, force: true })
       stub.restore()
     }
+  })
+
+  describe('cooldown', () => {
+    // 2.0.0 is within the cooldown window, so a cooldown run resolves to the 1.5.0 fallback
+    const mockVersions = {
+      'ncu-test-v2': {
+        version: '2.0.0',
+        'dist-tags': { latest: '2.0.0' },
+        versions: {
+          '1.0.0': { version: '1.0.0' } as Packument,
+          '1.5.0': { version: '1.5.0' } as Packument,
+          '2.0.0': { version: '2.0.0' } as Packument,
+        },
+        time: {
+          '1.0.0': getTime(30),
+          '1.5.0': getTime(20),
+          '2.0.0': getTime(1),
+        },
+      },
+    }
+    const packageData = { dependencies: { 'ncu-test-v2': '^1.0.0' } }
+
+    it('does not write to the cache when cooldown is active', async () => {
+      const stub = stubVersions(mockVersions)
+      try {
+        await ncu({ packageData, cache: true, cooldown: 7 })
+
+        const cacheData: CacheData = JSON.parse(await fs.readFile(resolvedDefaultCacheFile, 'utf-8'))
+        expect(cacheData.packages).deep.eq({})
+      } finally {
+        await fs.rm(resolvedDefaultCacheFile, { recursive: true, force: true })
+        stub.restore()
+      }
+    })
+
+    it('does not poison the cache for a later non-cooldown run', async () => {
+      const stub = stubVersions(mockVersions)
+      try {
+        await ncu({ packageData, cache: true, cooldown: 7 })
+
+        // a subsequent non-cooldown run must report the real latest, not the cached fallback
+        const result = await ncu({ packageData, cache: true })
+        expect(result).deep.eq({ 'ncu-test-v2': '^2.0.0' })
+      } finally {
+        await fs.rm(resolvedDefaultCacheFile, { recursive: true, force: true })
+        stub.restore()
+      }
+    })
   })
 })

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -3,8 +3,8 @@ import fs from 'fs/promises'
 import ncu from '../src/'
 import { CACHE_DELIMITER, resolvedDefaultCacheFile } from '../src/lib/cache'
 import { CURRENT_CACHE_SCHEMA, type CacheData } from '../src/types/Cacher'
-import type { Packument } from '../src/types/Packument'
 import chaiSetup from './helpers/chaiSetup'
+import createMockVersion from './helpers/createMockVersion'
 import stubVersions from './helpers/stubVersions'
 
 chaiSetup()
@@ -199,20 +199,15 @@ describe('cache', () => {
   describe('cooldown', () => {
     // 2.0.0 is within the cooldown window, so a cooldown run resolves to the 1.5.0 fallback
     const mockVersions = {
-      'ncu-test-v2': {
-        version: '2.0.0',
-        'dist-tags': { latest: '2.0.0' },
+      'ncu-test-v2': createMockVersion({
+        name: 'ncu-test-v2',
         versions: {
-          '1.0.0': { version: '1.0.0' } as Packument,
-          '1.5.0': { version: '1.5.0' } as Packument,
-          '2.0.0': { version: '2.0.0' } as Packument,
-        },
-        time: {
           '1.0.0': getTime(30),
           '1.5.0': getTime(20),
           '2.0.0': getTime(1),
         },
-      },
+        distTags: { latest: '2.0.0' },
+      }),
     }
     const packageData = { dependencies: { 'ncu-test-v2': '^1.0.0' } }
 

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -11,8 +11,8 @@ import { npmApi } from '../src/package-managers/npm'
 import { pnpmApi } from '../src/package-managers/pnpm'
 import { yarnApi } from '../src/package-managers/yarn'
 import type { PackageFile } from '../src/types/PackageFile'
-import type { Packument } from '../src/types/Packument'
 import chaiSetup from './helpers/chaiSetup'
+import createMockVersion from './helpers/createMockVersion'
 import { silenceProgressBar } from './helpers/silenceProgressBar'
 import stubVersions from './helpers/stubVersions'
 
@@ -20,31 +20,6 @@ chaiSetup()
 
 const DAY = 24 * 60 * 60 * 1000
 const NOW = Date.now()
-
-interface CreateMockParams {
-  name: string
-  versions: Record<string, string>
-  distTags?: Record<string, string>
-}
-
-/**
- * Creates a mock package version object for testing purposes.
- *
- * @param params - The parameters for creating the mock version.
- * @param params.name - The name of the package.
- * @param params.versions - An object mapping version strings to their corresponding release dates.
- * @param params.distTags - An object representing distribution tags for the package.
- * @returns An object representing mocked package versions, including name, versions, time, and distTags.
- */
-const createMockVersion = ({ name, versions, distTags }: CreateMockParams): Partial<Packument> => {
-  return {
-    name,
-    version: Object.keys(versions)[0],
-    versions: Object.fromEntries(Object.entries(versions).map(([version]) => [version, { version } as Packument])),
-    time: Object.fromEntries(Object.entries(versions).map(([version, date]) => [version, date])),
-    'dist-tags': distTags,
-  }
-}
 
 /**
  * Processes log arguments by removing ANSI escape codes, collapsing all

--- a/test/helpers/createMockVersion.ts
+++ b/test/helpers/createMockVersion.ts
@@ -1,0 +1,28 @@
+import type { Packument } from '../../src/types/Packument'
+
+interface CreateMockParams {
+  name: string
+  versions: Record<string, string>
+  distTags?: Record<string, string>
+}
+
+/**
+ * Creates a mock package version object for testing purposes.
+ *
+ * @param params - The parameters for creating the mock version.
+ * @param params.name - The name of the package.
+ * @param params.versions - An object mapping version strings to their corresponding release dates.
+ * @param params.distTags - An object representing distribution tags for the package.
+ * @returns An object representing mocked package versions, including name, versions, time, and distTags.
+ */
+const createMockVersion = ({ name, versions, distTags }: CreateMockParams): Partial<Packument> => {
+  return {
+    name,
+    version: Object.keys(versions)[0],
+    versions: Object.fromEntries(Object.entries(versions).map(([version]) => [version, { version } as Packument])),
+    time: Object.fromEntries(Object.entries(versions).map(([version, date]) => [version, date])),
+    'dist-tags': distTags,
+  }
+}
+
+export default createMockVersion


### PR DESCRIPTION
The read was already skipped, so a cooldown fallback poisoned later non-cooldown runs.