### PR TITLE
package.json: specify allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,5 +162,10 @@
   },
   "files": [
     "build"
-  ]
+  ],
+  "allowScripts": {
+    "yarn@1.22.22": true,
+    "esbuild@0.28.1": true,
+    "unrs-resolver@1.11.1": true
+  }
 }


### PR DESCRIPTION
Newest npm version have begun warning about this:

```
npm warn allow-scripts 3 packages have install scripts not yet covered by allowScripts:
npm warn allow-scripts   esbuild@0.28.1 (install: (install scripts present))
npm warn allow-scripts   unrs-resolver@1.12.2 (postinstall: node postinstall.js)
npm warn allow-scripts   yarn@1.22.22 (install: (install scripts present))
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```

```
user@user-ws:~/repos-xmr/npm-check-updates (main =)$  npm ls esbuild unrs-resolver yarn
npm-check-updates@22.2.7 /home/user/repos-xmr/npm-check-updates
├─┬ eslint-import-resolver-typescript@4.4.5
│ ├─┬ eslint-import-context@0.1.9
│ │ └── unrs-resolver@1.11.1 deduped
│ └── unrs-resolver@1.11.1
├─┬ eslint-plugin-import-x@4.16.2
│ └── unrs-resolver@1.11.1 deduped
├─┬ tsx@4.22.4
│ └── esbuild@0.28.1
├─┬ unplugin-dts@1.0.2
│ └── esbuild@0.28.1 deduped
├─┬ vite@8.0.16
│ └── esbuild@0.28.1 deduped
└── yarn@1.22.22
```