### PR TITLE
build: stub unused iconv-lite out of the bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,23 @@ function chmodBinPlugin(): Plugin {
   }
 }
 
+/**
+ * Replaces the given module ids with an empty default export.
+ * Used to drop optional dependencies that are bundled but never reached at runtime.
+ */
+function stubModulesPlugin(ids: string[]): Plugin {
+  return {
+    name: 'stub-modules',
+    enforce: 'pre',
+    resolveId(id) {
+      return ids.includes(id) ? id : null
+    },
+    load(id) {
+      return ids.includes(id) ? 'export default {}' : null
+    },
+  }
+}
+
 /** A simple helper to run analyzer plugin only once */
 function analyzerOnce(): Plugin {
   let ran = false
@@ -68,6 +85,11 @@ export default defineConfig(({ mode }) => ({
       outDirs: 'build',
     }),
     chmodBinPlugin(),
+    /**
+     * iconv-lite is an optional dep of minipass-fetch, only used by textConverted(),
+     * which ncu never calls. Stub it so it stays out of the bundle.
+     */
+    stubModulesPlugin(['iconv-lite']),
     ...(process.env.ANALYZER ? [analyzerOnce()] : []),
   ],
   ssr: {


### PR DESCRIPTION
| Artifact            | main | this branch | Difference       |
|---------------------|-------------|--------------|------------------|
| Modules transformed | 715         | 693          | 22 fewer modules |
| build/index.js      | 1.50 MB     | 1.20 MB      | ~300 KB smaller  |
| build/index.cjs     | 1.20 MB     | 0.93 MB      | ~270 KB smaller  |
| Tarball size        | 3.2 MB      | 2.6 MB       | ~600 KB smaller  |
| Unpacked size       | 12.2 MB     | 10.9 MB      | ~1.3 MB smaller  |

Should also save ~8-10% from API load time, and ~5% from CLI load time.