### PR TITLE
refactor prettifyCooldown and share the cooldown regex

### DIFF
--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -18,6 +18,7 @@ import getPackageJson from './getPackageJson'
 import getPackageVersion from './getPackageVersion'
 import getRepoUrl from './getRepoUrl'
 import isFetchable from './isFetchable'
+import { COOLDOWN_PATTERN } from './parseCooldown'
 import {
   WILDCARDS,
   colorizeDiff,
@@ -146,29 +147,15 @@ function prettifyCooldown(input: string | number | undefined | CooldownFunction)
   }
 
   const str = String(input).trim().toLowerCase()
-
-  // Case 1: input contains a unit (5d, 30m, 15h)
-  const match = str.match(/^(\d+(?:\.\d+)?)(d|h|m)$/)
-  if (match) {
-    const value = Number(match[1])
-    const unit = match[2]
-
-    const unitMap: Record<string, string> = {
-      d: 'day',
-      h: 'hour',
-      m: 'minute',
-    }
-
-    return `${+value.toFixed(1)}-${unitMap[unit]} cooldown`
+  const match = str.match(COOLDOWN_PATTERN)
+  const value = match ? Number(match[1]) : Number(str)
+  if (isNaN(value)) {
+    return 'cooldown'
   }
 
-  // Case 2: input is a plain number or numeric string → treat as days
-  const days = Number(str)
-  if (!isNaN(days)) {
-    return `${+days.toFixed(1)}-day cooldown`
-  }
-
-  return 'cooldown'
+  const units: Record<string, string> = { d: 'day', h: 'hour', m: 'minute' }
+  const unit = match ? units[match[2]] : 'day'
+  return `${+value.toFixed(1)}-${unit} cooldown`
 }
 
 /**

--- a/src/lib/parseCooldown.ts
+++ b/src/lib/parseCooldown.ts
@@ -1,9 +1,12 @@
+/** Matches a unit-suffixed cooldown string: "6d", "12h", "30m". Group 1 is the number, group 2 the unit. */
+export const COOLDOWN_PATTERN = /^(\d+(?:\.\d+)?)(d|h|m)$/
+
 /**
  * Parses a cooldown string (e.g. "6d", "12h", "30m") into a number of days.
  * Returns `null` if the string does not match a valid format.
  */
 function parseCooldown(s: string): number | null {
-  const match = s.match(/^(\d+(?:\.\d+)?)(d|h|m)$/)
+  const match = s.match(COOLDOWN_PATTERN)
   if (!match) return null
 
   const value = parseFloat(match[1])


### PR DESCRIPTION
- collapse prettifyCooldown's unit and plain-number paths into one expression
- export COOLDOWN_PATTERN from parseCooldown and reuse it in logging