### PR TITLE
replace zod with valibot to reduce bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,12 +86,12 @@
         "unplugin-dts": "^1.0.3",
         "untildify": "^6.0.0",
         "update-notifier": "^7.3.1",
+        "valibot": "^1.4.1",
         "verdaccio": "^6.7.4",
         "vite": "^8.1.0",
         "vite-bundle-analyzer": "^1.3.8",
         "yaml": "^2.9.0",
-        "yarn": "^1.22.22",
-        "zod": "^4.4.3"
+        "yarn": "^1.22.22"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -14147,6 +14147,21 @@
         "uuid": "dist-node/bin/uuid"
       }
     },
+    "node_modules/valibot": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
+      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
@@ -14973,16 +14988,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -152,12 +152,12 @@
     "unplugin-dts": "^1.0.3",
     "untildify": "^6.0.0",
     "update-notifier": "^7.3.1",
+    "valibot": "^1.4.1",
     "verdaccio": "^6.7.4",
     "vite": "^8.1.0",
     "vite-bundle-analyzer": "^1.3.8",
     "yaml": "^2.9.0",
-    "yarn": "^1.22.22",
-    "zod": "^4.4.3"
+    "yarn": "^1.22.22"
   },
   "files": [
     "build"

--- a/src/lib/upgradePackageData.ts
+++ b/src/lib/upgradePackageData.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { parseDocument } from 'yaml'
-import { CatalogsConfig } from '../types/CatalogConfig'
+import { type CatalogsConfig, parseCatalogsConfig } from '../types/CatalogConfig'
 import { type Index } from '../types/IndexType'
 import { type Options } from '../types/Options'
 import { type PackageFile } from '../types/PackageFile'
@@ -49,7 +49,7 @@ async function upgradePackageData(
     // Handle yaml catalog files
     if (fileName === 'pnpm-workspace.yaml' || fileName === '.yarnrc.yml') {
       const yamlContent = await fs.readFile(pkgFile, 'utf-8')
-      const catalogData: CatalogsConfig = CatalogsConfig.parse(parseDocument(yamlContent).toJSON())
+      const catalogData: CatalogsConfig = parseCatalogsConfig(parseDocument(yamlContent).toJSON())
 
       // Reconstruct the list of updates to apply unfortunately we lost the path information during extraction before
       const reconstructedUpdates: { path: string[]; newValue: string }[] = []

--- a/src/lib/upgradeYamlCatalogDependencies.ts
+++ b/src/lib/upgradeYamlCatalogDependencies.ts
@@ -1,5 +1,5 @@
 import { CST, type Document, isCollection, isPair, isScalar, parseDocument } from 'yaml'
-import { CatalogsConfig } from '../types/CatalogConfig'
+import { type CatalogsConfig, parseCatalogsConfig } from '../types/CatalogConfig'
 import type { Options } from '../types/Options'
 import programError from './programError'
 
@@ -124,7 +124,7 @@ export function updateYamlCatalogDependencies({
   }
 
   try {
-    parsedContents = CatalogsConfig.parse(document.toJSON())
+    parsedContents = parseCatalogsConfig(document.toJSON())
   } catch {
     return null
   }

--- a/src/types/CatalogConfig.ts
+++ b/src/types/CatalogConfig.ts
@@ -1,14 +1,17 @@
-import { z } from 'zod'
+import * as v from 'valibot'
 
 const catalogFields = {
-  catalog: z.optional(z.record(z.string(), z.string())),
-  catalogs: z.optional(z.record(z.string(), z.record(z.string(), z.string()))).catch(undefined),
+  catalog: v.optional(v.record(v.string(), v.string())),
+  catalogs: v.fallback(v.optional(v.record(v.string(), v.record(v.string(), v.string()))), undefined),
 }
 
-export const CatalogsConfig = z.object({
+export const CatalogsConfig = v.object({
   ...catalogFields,
   // Support catalogs nested under a `workspaces` key (e.g. workspaces.catalog, workspaces.catalogs)
-  workspaces: z.optional(z.union([z.array(z.string()), z.object(catalogFields).passthrough()])).catch(undefined),
+  workspaces: v.fallback(v.optional(v.union([v.array(v.string()), v.looseObject(catalogFields)])), undefined),
 })
 
-export type CatalogsConfig = z.infer<typeof CatalogsConfig>
+export type CatalogsConfig = v.InferOutput<typeof CatalogsConfig>
+
+/** Parses and validates an unknown value against the catalogs config schema. */
+export const parseCatalogsConfig = (data: unknown): CatalogsConfig => v.parse(CatalogsConfig, data)


### PR DESCRIPTION
| Build Metric            | main          | this branch  |
|-------------------------|---------------|--------------|
| Modules transformed     | 720           | 642          |
| build/index.js          | 1,211.27 kB   | 1,139.13 kB  |
| build/index.js (gzip)   | 313.85 kB     | 297.47 kB    |
| build/index.js.map      | 3,550.42 kB   | 3,425.53 kB  |
| build/index.cjs         | 936.61 kB     | 881.06 kB    |
| build/index.cjs (gzip)  | 281.52 kB     | 266.97 kB    |
| build/index.cjs.map     | 3,538.27 kB   | 3,414.44 kB  |
| Tarball size            | 2.6 MB        | 2.5 MB       |
| Unpacked size           | 10.9 MB       | 10.5 MB      |
