### PR TITLE
Switch mocha tests to parallel

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -8,6 +8,7 @@
     "trace-warnings",
     "no-warnings=TimeoutNaNWarning"
   ],
+  "parallel": true,
   "timeout": 60000,
   "recursive": true,
   "exit": true

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -688,8 +688,9 @@ async function fetchUpgradedPackument(
   npmConfigWorkspaceProject?: NpmConfig,
 ): Promise<Partial<Packument> | undefined> {
   // See: /test/helpers/stubVersions
-  if (process.env.STUB_VERSIONS) {
-    const mockReturnedVersions = JSON.parse(process.env.STUB_VERSIONS)
+  const _stubKey = `STUB_VERSIONS_${process.env.MOCHA_WORKER_ID ?? '0'}`
+  if (process.env[_stubKey]) {
+    const mockReturnedVersions = JSON.parse(process.env[_stubKey]!)
     return npmApi.mockFetchUpgradedPackument(mockReturnedVersions)(packageName, fields, currentVersion, options)
   }
 

--- a/test/helpers/stubVersions.ts
+++ b/test/helpers/stubVersions.ts
@@ -7,10 +7,12 @@ const stubVersions = (mockReturnedVersions: MockedVersions, { spawn }: { spawn?:
   // stub child process
   // the only way to stub functionality in spawned child processes is to pass data through process.env and stub internally
   if (spawn) {
-    process.env.STUB_VERSIONS = JSON.stringify(mockReturnedVersions)
+    // namespace by worker so parallel mocha workers don't clobber each other
+    const stubKey = `STUB_VERSIONS_${process.env.MOCHA_WORKER_ID ?? '0'}`
+    process.env[stubKey] = JSON.stringify(mockReturnedVersions)
     return {
       restore: () => {
-        process.env.STUB_VERSIONS = ''
+        process.env[stubKey] = ''
       },
     }
   }


### PR DESCRIPTION
Should be significantly faster depending on the CPU threads.

It has some limitations, but does seem to work any we'll replace it with vitest later anyway. I just got tired waiting for 2 minutes for `test:unit` to pass on my dev VM :)