### PR TITLE
Make the default export a callable, namespaced function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,9 +1060,6 @@ const upgraded = await ncu({
 console.log(upgraded) // { "mypackage": "^2.0.0", ... }
 ```
 
-The default export is also namespaced, so `ncu.run(...)` works the same as `ncu(...)`, and the named
-exports `import { run, defineConfig } from 'npm-check-updates'` are available too.
-
 ### CommonJS
 
 Use this for legacy projects using `"type": "commonjs"` or scripts using the `.cjs` extension.

--- a/README.md
+++ b/README.md
@@ -1046,9 +1046,9 @@ e.g. for VS Code:
 Use this for modern projects using `"type": "module"` in `package.json` or `.mjs` files.
 
 ```js
-import * as ncu from 'npm-check-updates'
+import ncu from 'npm-check-updates'
 
-const upgraded = await ncu.run({
+const upgraded = await ncu({
   // Pass any cli option
   packageFile: '../package.json',
   upgrade: true,
@@ -1060,6 +1060,9 @@ const upgraded = await ncu.run({
 console.log(upgraded) // { "mypackage": "^2.0.0", ... }
 ```
 
+The default export is also namespaced, so `ncu.run(...)` works the same as `ncu(...)`, and the named
+exports `import { run, defineConfig } from 'npm-check-updates'` are available too.
+
 ### CommonJS
 
 Use this for legacy projects using `"type": "commonjs"` or scripts using the `.cjs` extension.
@@ -1067,15 +1070,13 @@ Use this for legacy projects using `"type": "commonjs"` or scripts using the `.c
 ```js
 const ncu = require('npm-check-updates')
 
-// Since ncu.run() is an async function
-ncu
-  .run({
-    packageFile: './package.json',
-    upgrade: true,
-  })
-  .then(upgraded => {
-    console.log(upgraded)
-  })
+// ncu() is an async function
+ncu({
+  packageFile: './package.json',
+  upgrade: true,
+}).then(upgraded => {
+  console.log(upgraded)
+})
 ```
 
 ## Contributing

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import pkg from '../package.json'
 import { cliOptionsMap } from './cli-options'
 import { cacheClear } from './lib/cache'
 import chalk, { chalkInit } from './lib/chalk'
+import defineConfig from './lib/defineConfig'
 import determinePackageManager from './lib/determinePackageManager'
 import doctor from './lib/doctor'
 import findPackage from './lib/findPackage'
@@ -23,7 +24,6 @@ import { type PackageInfo } from './types/PackageInfo'
 import { type RunOptions } from './types/RunOptions'
 import { type VersionSpec } from './types/VersionSpec'
 
-export { default as defineConfig } from './lib/defineConfig'
 export type { RcOptions } from './types/RcOptions'
 
 // allow prompt injection from environment variable for testing purposes
@@ -338,12 +338,19 @@ async function runUpgrades(
   return analysis
 }
 
+/** The ncu module. Callable directly (`ncu(options)`) and namespaced (`ncu.run(options)`, `ncu.defineConfig(config)`). */
+export interface Ncu {
+  (runOptions?: RunOptions, options?: { cli?: boolean }): Promise<PackageFile | Index<VersionSpec> | void>
+  run: Ncu
+  defineConfig: typeof defineConfig
+}
+
 /** Main entry point.
  *
  * @returns The upgraded package file by default, an {@link Index} of only the
  * upgraded dependencies with `--jsonUpgraded`, or `void` with `--global`.
  */
-export async function run(
+async function run(
   runOptions: RunOptions = {},
   { cli }: { cli?: boolean } = {},
 ): Promise<PackageFile | Index<VersionSpec> | void> {
@@ -402,6 +409,13 @@ export async function run(
   }
 }
 
-export default run
+// expose run and defineConfig as properties so the default export is callable
+// and also namespaced: `ncu({...})`, `ncu.run({...})`, and `ncu.defineConfig(...)` all work
+const ncu = run as Ncu
+ncu.run = ncu
+ncu.defineConfig = defineConfig
 
+export default ncu
+
+export { ncu as run, defineConfig }
 export type { RunOptions }

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,0 +1,32 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { expect } from 'chai'
+import chaiSetup from './helpers/chaiSetup'
+
+// Resolve the builds at module load so the globals they set (e.g. zod's) land
+// before mocha's check-leaks baseline.
+
+chaiSetup()
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+
+const esm = await import(pathToFileURL(path.join(__dirname, '../build/index.js')).href)
+const cjs = require('../build/index.cjs')
+
+describe('package exports', () => {
+  it('ESM build: default export is callable and namespaced', () => {
+    expect(esm.default).to.be.a('function')
+    expect(esm.default.run).to.equal(esm.default)
+    expect(esm.default.defineConfig).to.be.a('function')
+    expect(esm.run).to.be.a('function')
+    expect(esm.defineConfig).to.be.a('function')
+  })
+
+  it('CJS build: require() returns the callable run function', () => {
+    expect(cjs).to.be.a('function')
+    expect(cjs.run).to.equal(cjs)
+    expect(cjs.defineConfig).to.be.a('function')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -128,6 +128,11 @@ export default defineConfig(({ mode }) => ({
           // keep CJS chunks as .cjs so that require() works
           chunkFileNames: 'chunks/[name]-[hash].cjs',
           exports: 'named',
+          // make require() return the callable run function, keeping .run/.defineConfig/.default
+          // as properties. Skip chunks without a run export (e.g. cli.cjs).
+          footer: chunk => {
+            return chunk.exports.includes('run') ? 'module.exports = Object.assign(exports.run, exports)' : ''
+          },
         },
       ],
     },


### PR DESCRIPTION
Closes #1404.

Personally I still think this feels hacky, but since you prefer it I made the PR. Feel free to push here to adapt it further @raineorshine.