### PR TITLE
Fix import-time side effects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,32 +26,40 @@ import { type VersionSpec } from './types/VersionSpec.ts'
 
 export type { RcOptions } from './types/RcOptions.ts'
 
-// allow prompt injection from environment variable for testing purposes
-if (process.env.INJECT_PROMPTS) {
-  prompts.inject(JSON.parse(process.env.INJECT_PROMPTS))
-}
-
 /** Tracks the (first) unhandled rejection so the process can exit with an error code at the end. This allows other errors to be logged before the process exits. */
 let unhandledRejectionError = false
 
 let lastRunOptions: Options | null = null
 
-// Use `node --trace-uncaught ...` to show where the exception was thrown.
-// See: https://nodejs.org/api/process.html#event-unhandledrejection
-process.on('unhandledRejection', (reason: string | Error) => {
-  // do not rethrow, as there may be other errors to print out
-  console.error(reason)
+let cliHandlersRegistered = false
 
-  // ensure the process exits with a non-zero code at the end
-  unhandledRejectionError = true
-})
+/** Registers CLI-only prompt injection and process handlers lazily, so importing the module has no side effects. */
+function registerCliHandlers() {
+  if (cliHandlersRegistered) return
+  cliHandlersRegistered = true
 
-// ensure that the process exits with an error code if there was an unhandled rejection
-process.on('exit', () => {
-  if (unhandledRejectionError && lastRunOptions) {
-    programError(lastRunOptions, `Unhandled Rejection! This is a bug and should be reported: ${pkg.bugs.url}`)
+  // allow prompt injection from environment variable for testing purposes
+  if (process.env.INJECT_PROMPTS) {
+    prompts.inject(JSON.parse(process.env.INJECT_PROMPTS))
   }
-})
+
+  // Use `node --trace-uncaught ...` to show where the exception was thrown.
+  // See: https://nodejs.org/api/process.html#event-unhandledrejection
+  process.on('unhandledRejection', (reason: string | Error) => {
+    // do not rethrow, as there may be other errors to print out
+    console.error(reason)
+
+    // ensure the process exits with a non-zero code at the end
+    unhandledRejectionError = true
+  })
+
+  // ensure that the process exits with an error code if there was an unhandled rejection
+  process.on('exit', () => {
+    if (unhandledRejectionError && lastRunOptions) {
+      programError(lastRunOptions, `Unhandled Rejection! This is a bug and should be reported: ${pkg.bugs.url}`)
+    }
+  })
+}
 
 /**
  * Volta is a tool for managing JavaScript tooling like Node and npm. Volta has
@@ -354,6 +362,10 @@ async function run(
   runOptions: RunOptions = {},
   { cli }: { cli?: boolean } = {},
 ): Promise<PackageFile | Index<VersionSpec> | void> {
+  if (cli) {
+    registerCliHandlers()
+  }
+
   unhandledRejectionError = false
 
   const options = await initOptions(runOptions, { cli })

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -484,10 +484,6 @@ npmApi.findNpmConfig = memoize((configPath?: string): NpmConfig | null => {
   return normalizeNpmConfig(config, configPath)
 })
 
-// get the base config that is used for all npm queries
-// this may be partially overwritten by .npmrc config files when using --deep
-const npmConfig = npmApi.findNpmConfig()
-
 /**
  * Parse JSON and throw an informative error on failure.
  *
@@ -528,7 +524,7 @@ export async function packageAuthorChanged(
 ): Promise<boolean> {
   const result = await fetchPartialPackument(packageName, ['versions'], null, {
     ...npmConfigLocal,
-    ...npmConfig,
+    ...npmApi.findNpmConfig(),
     fullMetadata: true,
     ...(options.registry ? { registry: options.registry, silent: true } : null),
   })
@@ -710,7 +706,7 @@ async function fetchUpgradedPackument(
 
   const npmConfigMerged = mergeNpmConfigs(
     {
-      npmConfigUser: { ...npmConfig, fullMetadata },
+      npmConfigUser: { ...npmApi.findNpmConfig(), fullMetadata },
       npmConfigLocal,
       npmConfigWorkspaceProject,
     },
@@ -926,7 +922,7 @@ export const getEngines = async (
     null,
     {
       ...npmConfigLocal,
-      ...npmConfig,
+      ...npmApi.findNpmConfig(),
       ...(options.registry ? { registry: options.registry, silent: true } : null),
     },
     version,

--- a/test/importSideEffects.test.ts
+++ b/test/importSideEffects.test.ts
@@ -1,0 +1,16 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
+import spawn from 'spawn-please'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+describe('import side effects', () => {
+  it('importing has no side effects', async () => {
+    const modulePath = path.join(__dirname, '../build/index.cjs')
+    const code = `require(process.argv[1]); console.log(process.listenerCount('exit'), process.listenerCount('unhandledRejection'))`
+    const { stdout } = await spawn('node', ['-e', code, modulePath])
+    expect(stripAnsi(stdout).trim()).toBe('0 0')
+  })
+})


### PR DESCRIPTION
- defer memoized findNpmConfig() to first run() instead of module scope
- register INJECT_PROMPTS and unhandledRejection/exit handlers lazily in cli mode only, so importing as a library has no side effects

Fixes #1524.

Requires #1895.