### PR TITLE
Lazy-load npm-registry-fetch to speed up API import

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -4,7 +4,7 @@ import { JSONParser } from '@streamparser/json'
 import camelCase from 'camelcase'
 import memoize from 'fast-memoize'
 import ini from 'ini'
-import npmRegistryFetch from 'npm-registry-fetch'
+import type npmRegistryFetch from 'npm-registry-fetch'
 import nodeSemver from 'semver'
 import { parseRange } from 'semver-utils'
 import untildify from 'untildify'
@@ -27,6 +27,16 @@ import type { Version } from '../types/Version.ts'
 import type { CooldownInfo, VersionResult } from '../types/VersionResult.ts'
 import type { VersionSpec } from '../types/VersionSpec.ts'
 import { filterPredicate, satisfiesCooldownPeriod } from './filters.ts'
+
+/**
+ * Dynamically imports npm-registry-fetch, lazily so importing the ncu API does not eagerly pull in
+ * its http/https/tls/dns/net networking stack and pay the ESM instantiation cost.
+ */
+const importRegistryFetch = () => import('npm-registry-fetch')
+let registryFetchPromise: ReturnType<typeof importRegistryFetch> | undefined
+
+/** Lazily loads npm-registry-fetch, caching the import promise after the first call. */
+const loadRegistryFetch = async () => (await (registryFetchPromise ??= importRegistryFetch())).default
 
 const EXPLICIT_RANGE_OPS = new Set(['-', '||', '&&', '<', '<=', '>', '>='])
 
@@ -51,6 +61,7 @@ const fetchPartialPackument = async (
   const corgiDoc = 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
   const fullDoc = 'application/json'
 
+  const npmRegistryFetch = await loadRegistryFetch()
   const registry = npmRegistryFetch.pickRegistry(name, opts)
   const headers = {
     'user-agent': opts.userAgent || `npm-check-updates/${pkg.version} node/${process.version}`,


### PR DESCRIPTION
| case | main | xmr/major | delta |
|---|---|---|---|
| API ESM | 88.8 ms (min 84.7) | 57.6 ms (min 53.8) | -35% (-31.2 ms) |
| API CJS | 80.2 ms (min 75.9) | 54.5 ms (min 51.7) | -32% (-25.6 ms) |
| CLI ESM | 107.7 ms (min 104.1) | 90.7 ms (min 84.7) | -16% (-17.0 ms) |
| CLI CJS | 106.9 ms (min 101.6) | 87.9 ms (min 83.4) | -18% (-19.0 ms) |
| node baseline | 24.4 ms (min 23.0) | 24.7 ms (min 23.0) | - |

| artifact | main | xmr/major |
|---|---|---|
| build/index.js | 1137.3 kB | 694.1 kB |
| build/index.cjs | 880.7 kB | 536.1 kB |

So, all this time even doing `--version` payed the penalty of loading the whole networking stack.