### PR TITLE
Abort packument stream once required fields are parsed

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -91,7 +91,8 @@ const fetchPartialPackument = async (
       return npmRegistryFetch.json(url.href, fetchOptions)
     } else {
       tag = tag || 'latest'
-      const response = await npmRegistryFetch(url.href, fetchOptions)
+      const controller = new AbortController()
+      const response = await npmRegistryFetch(url.href, { ...fetchOptions, signal: controller.signal })
       const parser = new JSONParser({ paths: ['$.*'], keepStack: false })
       const partialPackument: Partial<Packument> = { name }
       let foundAll = false
@@ -117,6 +118,10 @@ const fetchPartialPackument = async (
         if (parseError) throw parseError
         if (foundAll) break
       }
+
+      // break alone does not tear down the minipass stream, so the
+      // rest of the packument keeps downloading. Abort to stop it.
+      if (foundAll) controller.abort()
 
       return partialPackument
     }


### PR DESCRIPTION
Closes #1351

I had to use AI to create a script to measure the bytes transferred, but it went down from **1.6MB** to **1.3KB** for typescript (it probably is gzipped). So the logic was correct, the abort controller was missing, it seems.

I could definitely use another set of eyes to confirm my findings just so that we are 100% sure it indeed fixes the issue.