### PR TITLE
test/e2e.sh: further tweaks

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -6,50 +6,53 @@
 # set -o pipefail
 # When set -e is enabled, we can drop `|| exit (1)?` from commands that are expected to fail
 
-cwd=$(pwd)
-e2e_dir=$(dirname "$(readlink -f "$0")")
-temp_dir=$(mktemp -d)
+cwd="$(pwd)"
+e2e_dir="$(dirname "$(readlink -f "$0")")"
+temp_dir="$(mktemp -d)"
+registry_host=127.0.0.1
 registry_port=4873
-registry_local="http://localhost:${registry_port}"
-registry_log=${temp_dir}/verdaccio.log
-verdaccio_config=${temp_dir}/verdaccio-config.yaml
+registry_addr="${registry_host}:${registry_port}"
+registry_local="http://${registry_addr}"
+registry_log="${temp_dir}/verdaccio.log"
+verdaccio_config="${temp_dir}/verdaccio-config.yaml"
+
 verdaccio_pid=""
 
 # cleanup on exit
 cleanup() {
-  exit_status=$?
+  local exit_status=$?
 
   # shut down verdaccio
   if [[ -n "${verdaccio_pid}" ]]; then
     echo Shutting down verdaccio
-    kill -9 ${verdaccio_pid} 2>/dev/null || true
-    wait ${verdaccio_pid} 2>/dev/null || true
+    kill -9 "${verdaccio_pid}" 2>/dev/null || true
+    wait "${verdaccio_pid}" 2>/dev/null || true
   fi
 
   # delete authToken
   # WARNING: The original authToken cannot be restored because it is protected and cannot be read with 'npm config get'.
-  npm config delete "//localhost:${registry_port}/:_authToken" || true
+  npm config delete "//${registry_addr}/:_authToken" || true
+
+  # return to working directory before removing temp dir
+  cd "${cwd}" || true
 
   # remove temp directory
   rm -rf -- "${temp_dir}"
 
-  # return to working directory
-  cd "${cwd}" || exit
-
-  if [[ ${exit_status} -ne 0 ]]; then
+  if [[ "${exit_status}" -ne 0 ]]; then
     echo Error
   else
     echo Done
   fi
 }
 
-trap cleanup EXIT
+trap 'cleanup' EXIT
 
 # create verdaccio config
 #   - store packages in temp directory so they are deleted on exit
 #   - allow anyone to publish to avoid npm login
 #   - increase body size to accommodate current package tarball size
-echo "
+cat <<EOF > "${verdaccio_config}"
 storage: ${temp_dir}/storage
 max_body_size: 50mb
 packages:
@@ -62,30 +65,36 @@ packages:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
-" >"${verdaccio_config}"
+EOF
 
 # start verdaccio and wait for it to boot
 echo Starting local registry
-nohup verdaccio -l ${registry_port} -c "${verdaccio_config}" &>"${registry_log}" &
+nohup verdaccio -l "${registry_addr}" -c "${verdaccio_config}" >"${registry_log}" 2>&1 &
 verdaccio_pid=$!
-grep -q 'http address' <(tail -f "${registry_log}")
+
+if ! timeout 30 grep -q 'http address' <(tail -f "${registry_log}"); then
+  echo "verdaccio did not start within 30s" >&2
+  cat "${registry_log}" >&2
+  exit 1
+fi
 
 # set dummy authToken which is required to publish
 # https://github.com/verdaccio/verdaccio/issues/212#issuecomment-308578500
-npm config set "//localhost:${registry_port}/:_authToken=e2e_dummy"
+npm config set "//${registry_addr}/:_authToken=e2e_dummy"
 
 # publish to local registry
 echo Publishing to local registry
-npm publish --registry ${registry_local}
+npm publish --registry "${registry_local}"
 
 # wait for published version to become visible in verdaccio.
 # verdaccio can accept npm publish before npm view/npx can resolve the package metadata.
 # without this retry loop, e2e can fail intermittently with "no such package available".
-package_version=$(node -p "require('./package.json').version")
+package_version="$(node -p "require('./package.json').version")"
 echo "Waiting for npm-check-updates@${package_version} in local registry"
+
 publish_visible=false
 for _ in {1..20}; do
-  if npm view "npm-check-updates@${package_version}" version --registry ${registry_local} >/dev/null 2>&1; then
+  if npm view "npm-check-updates@${package_version}" version --registry "${registry_local}" >/dev/null 2>&1; then
     publish_visible=true
     break
   fi
@@ -98,21 +107,27 @@ fi
 
 # Test: ncu -v
 echo ncu -v
-npx --registry ${registry_local} npm-check-updates -v
+npx --registry "${registry_local}" npm-check-updates -v
 
 # Test: cli
 # Create a package.json file with a dependency on npm-check-updates since it is already published to the local registry
 echo Test: cli
-echo '{
+cat <<'EOF' > "${temp_dir}/package.json"
+{
   "dependencies": {
     "npm-check-updates": "1.0.0"
   }
-}' >"${temp_dir}/package.json"
+}
+EOF
 
 # --configFilePath to avoid reading the repo .ncurc
 # --cwd to point to the temp package file
 # --pre 1 to ensure that an upgrade is always suggested even if npm-check-updates is on a prerelease version
-npx --registry ${registry_local} npm-check-updates --configFilePath "${temp_dir}" --cwd "${temp_dir}" --pre 1 --registry ${registry_local}
+npx --registry "${registry_local}" npm-check-updates \
+  --configFilePath "${temp_dir}" \
+  --cwd "${temp_dir}" \
+  --pre 1 \
+  --registry "${registry_local}"
 
 rm -f -- "${temp_dir}/package.json"
 cp -r "${e2e_dir}/e2e" "${temp_dir}"
@@ -122,17 +137,17 @@ echo Test: cjs
 cd "${temp_dir}/e2e/cjs" || exit
 
 echo Installing
-npm i npm-check-updates@latest --registry ${registry_local}
+npm i npm-check-updates@latest --registry "${registry_local}"
 
 echo Running test
-REGISTRY=${registry_local} node "${temp_dir}/e2e/cjs/index.js" || exit 1
+REGISTRY="${registry_local}" node "${temp_dir}/e2e/cjs/index.js" || exit 1
 
 # Test: esm
 echo Test: esm
 cd "${temp_dir}/e2e/esm" || exit
 
 echo Installing
-npm i npm-check-updates@latest --registry ${registry_local}
+npm i npm-check-updates@latest --registry "${registry_local}"
 
 echo Running test
-REGISTRY=${registry_local} node "${temp_dir}/e2e/esm/index.js" || exit 1
+REGISTRY="${registry_local}" node "${temp_dir}/e2e/esm/index.js" || exit 1

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -33,7 +33,7 @@ cleanup() {
   # WARNING: The original authToken cannot be restored because it is protected and cannot be read with 'npm config get'.
   npm config delete "//${registry_addr}/:_authToken" || true
 
-  # return to working directory before removing temp dir
+  # return to working directory
   cd "${cwd}" || true
 
   # remove temp directory


### PR DESCRIPTION
* quote variable expansions throughout
* add `registry_addr` variable to avoid repeating `host:port`
* bind registry to 127.0.0.1 instead of localhost to avoid hangs
* time out the verdaccio boot wait after 30s and dump the log on failure
* cd back to cwd before removing the temp dir
* use `local` for the cleanup exit_status
* quote the `trap` argument
* replace echo blocks with `cat <<EOF` heredocs
* replace `&>` with `>file 2>&1`

This was hanging for a long time in my Fedora machine due to the IP family mismatch. The fix should work everywhere.