### PR TITLE
Fix major/minor/patch grouping when a range operator changes

### DIFF
--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -158,6 +158,9 @@ export function isWildPart(versionPartValue: Maybe<string>) {
   return versionPartValue === '*' || versionPartValue === 'x'
 }
 
+/** Strips semver range prefixes (^, ~, >=, <=, >, <) from a version string. */
+export const stripRange = (version: string): string => version.replace(/^[~^<>=]+/, '')
+
 /**
  * Determines the part of a version string that has changed when comparing two versions. Assumes that the two version strings are in the same format. Returns null if no parts have changed.
  *
@@ -167,11 +170,12 @@ export function isWildPart(versionPartValue: Maybe<string>) {
 export function partChanged(from: string, to: string): UpgradeGroup {
   if (from === to) return 'none'
 
-  // separate out leading ^ or ~
-  if (/^[~^]/.test(to) && to[0] === from[0]) {
-    to = to.slice(1)
-    from = from.slice(1)
-  }
+  // Strip any leading range operator (^, ~, <, <=, >, >=) from from and to independently,
+  // since an upgrade commonly changes the operator, e.g. "<1.2.3" -> "^1.2.9". Comparing the
+  // raw strings would leave the operator glued to the first numeric part and throw off the
+  // positional diff below.
+  to = stripRange(to)
+  from = stripRange(from)
 
   // split into parts
   const partsTo = to.split('.')
@@ -247,24 +251,29 @@ export function getDependencyGroups(
 export function colorizeDiff(from: string, to: string) {
   let leadingWildcard = ''
 
-  // separate out leading ^ or ~
-  if (/^[~^]/.test(to) && to[0] === from[0]) {
+  // separate out leading ^ or ~ so it can be re-attached uncolored in front of the result
+  if (/^[~^]/.test(to)) {
     leadingWildcard = to[0]
     to = to.slice(1)
-    from = from.slice(1)
   }
 
-  // split into parts
+  // split into parts for the displayed portion of `to`
   const partsToColor = to.split('.')
-  const partsToCompare = from.split('.')
 
-  let i = partsToColor.findIndex((part, i) => part !== partsToCompare[i])
-  i = i >= 0 ? i : partsToColor.length
+  // Determine the position of the diff using fully range-stripped copies of `from` and `to`.
+  // `from` is never part of the output, and an upgrade commonly changes the leading range
+  // operator entirely, e.g. "<1.2.3" -> "^1.2.9", which would otherwise leave the operator
+  // glued to the first numeric part and throw off the positional diff below.
+  const partsFromCompare = stripRange(from).split('.')
+  const partsToCompare = stripRange(to).split('.')
+
+  let i = partsToCompare.findIndex((part, i) => part !== partsFromCompare[i])
+  i = i >= 0 ? i : partsToCompare.length
 
   // major = red (or any change before 1.0.0)
   // minor = cyan
   // patch = green
-  const color = i === 0 || partsToColor[0] === '0' ? 'red' : i === 1 ? 'cyan' : 'green'
+  const color = i === 0 || partsToCompare[0] === '0' ? 'red' : i === 1 ? 'cyan' : 'green'
 
   // if we are colorizing only part of the word, add a dot in the middle
   const middot = i > 0 && i < partsToColor.length ? '.' : ''
@@ -571,6 +580,3 @@ export const upgradeGitHubUrl = (declaration: string, upgraded: string) => {
   const tag = decodeURIComponent(parsedUrl.branch).replace(/^semver:/, '')
   return declaration.replace(tag, upgradeDependencyDeclaration(tag, revertPseudoVersion(tag, upgradedNormalized)))
 }
-
-/** Strips semver range prefixes (^, ~, >=, <=, >, <) from a version string. */
-export const stripRange = (version: string): string => version.replace(/^[~^<>=]+/, '')

--- a/test/version-util.test.ts
+++ b/test/version-util.test.ts
@@ -397,6 +397,18 @@ describe('version-util', () => {
       versionUtil.partChanged('0.1.0', '0.1.1')!.should.equal('majorVersionZero')
       versionUtil.partChanged('~0.1.0', '~0.1.1')!.should.equal('majorVersionZero')
     })
+    it('handle a leading range operator that differs between from and to', () => {
+      // upgradeDependencyDeclaration converts a "<" or "<=" declaration into a "^" range,
+      // e.g. "<1.2.3" -> "^1.2.9". from and to no longer share the same leading character,
+      // which used to prevent the operator from being stripped before comparing parts.
+      versionUtil.partChanged('<1.2.3', '^1.2.9')!.should.equal('patch')
+      versionUtil.partChanged('<1.2.3', '^1.3.0')!.should.equal('minor')
+      versionUtil.partChanged('<1.2.3', '^2.0.0')!.should.equal('major')
+      versionUtil.partChanged('<=1.2.3', '^1.2.9')!.should.equal('patch')
+      // a bare "from" that gains a wildcard in "to" hits the same code path
+      versionUtil.partChanged('1.2.3', '^1.2.9')!.should.equal('patch')
+      versionUtil.partChanged('1.2.3', '^1.3.0')!.should.equal('minor')
+    })
   })
 
   describe('colorizeDiff', () => {
@@ -424,6 +436,13 @@ describe('version-util', () => {
       versionUtil.colorizeDiff('0.1.0', '0.2.0').should.equal(`0.${chalk.red('2.0')}`)
       versionUtil.colorizeDiff('0.1.0', '0.1.1').should.equal(`0.1.${chalk.red('1')}`)
       versionUtil.colorizeDiff('~0.1.0', '~0.1.1').should.equal(`~0.1.${chalk.red('1')}`)
+    })
+    it('handle a leading range operator that differs between from and to', () => {
+      // "<1.2.3" -> "^1.2.9" used to color the entire string red since the leading "<" on
+      // `from` blocked the "^" from being stripped off `to` before the parts were compared.
+      versionUtil.colorizeDiff('<1.2.3', '^1.2.9').should.equal(`^1.2.${chalk.green('9')}`)
+      versionUtil.colorizeDiff('<1.2.3', '^1.3.0').should.equal(`^1.${chalk.cyan('3.0')}`)
+      versionUtil.colorizeDiff('1.2.3', '^1.2.9').should.equal(`^1.2.${chalk.green('9')}`)
     })
   })
 


### PR DESCRIPTION
`partChanged` and `colorizeDiff` strip the leading `^`/`~` before comparing versions, but only when `from` and `to` start with the same character. That assumption breaks for `<` and `<=` declarations, since `upgradeDependencyDeclaration` normalizes those into a `^` range. For example `"<4.17.20"` upgrading to `"^4.18.1"` is really a minor bump, but the leftover `<` on `from` blocks the wildcard stripping, so the whole thing gets diffed as `major` and shown in red under `--format group`.

I switched both functions to strip the operator off each side independently, reusing the `stripRange` helper that already existed for this exact regex. Added a test for each function with the `<`/`<=` → `^` case, and confirmed it fails on the current code and passes after the fix. Also checked against a real `lodash` upgrade with the CLI to see the group heading flip from "Major" to "Minor".