### PR TITLE
Fix pnpm global config selection by version

### DIFF
--- a/src/package-managers/pnpm.ts
+++ b/src/package-managers/pnpm.ts
@@ -148,23 +148,6 @@ const getPnpmMajorVersion = async (): Promise<number | null> => {
   }
 }
 
-/** Reads the pnpm global minimumReleaseAge layer for the current pnpm major version. */
-const readPnpmGlobalMinimumReleaseAgeLayer = async (
-  globalConfigDir: string,
-  pnpmMajorVersion: number | null,
-): Promise<MinimumReleaseAgeLayer | null> => {
-  if (pnpmMajorVersion != null) {
-    return pnpmMajorVersion >= 11
-      ? readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'config.yaml'), 'yaml')
-      : readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'rc'), 'ini')
-  }
-
-  return (
-    (await readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'config.yaml'), 'yaml')) ??
-    (await readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'rc'), 'ini'))
-  )
-}
-
 /**
  * Reads minimumReleaseAge settings from pnpm's config, falling back through pnpm's config layers.
  *
@@ -179,14 +162,20 @@ const getPnpmWorkspaceMinimumReleaseAge = async (
 
   const pnpmWorkspacePath = await findUp('pnpm-workspace.yaml')
   const majorVersion = pnpmMajorVersion === undefined ? await getPnpmMajorVersion() : pnpmMajorVersion
-  const globalConfig = await readPnpmGlobalMinimumReleaseAgeLayer(globalConfigDir, majorVersion)
 
   // Ordered from highest to lowest precedence. Each entry resolves to a config layer (or null if absent).
   const layers = await Promise.all([
     // workspace / project config
     pnpmWorkspacePath ? readMinimumReleaseAgeLayer(pnpmWorkspacePath, 'yaml') : Promise.resolve(null),
     // pnpm global config for the current major version
-    Promise.resolve(globalConfig),
+    majorVersion === null
+      ? (async () =>
+          (await readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'config.yaml'), 'yaml')) ??
+          readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'rc'), 'ini'))()
+      : readMinimumReleaseAgeLayer(
+          path.join(globalConfigDir, majorVersion >= 11 ? 'config.yaml' : 'rc'),
+          majorVersion >= 11 ? 'yaml' : 'ini',
+        ),
   ])
 
   // Use the minimumReleaseAge from the highest-precedence layer that defines it.

--- a/src/package-managers/pnpm.ts
+++ b/src/package-managers/pnpm.ts
@@ -137,26 +137,56 @@ const readMinimumReleaseAgeLayer = async (
   return parseMinimumReleaseAgeLayer(parsed)
 }
 
+/** Returns the current pnpm major version, or null if pnpm is unavailable or unparsable. */
+const getPnpmMajorVersion = async (): Promise<number | null> => {
+  try {
+    const { stdout } = await spawnCommand('pnpm', ['--version'])
+    const major = Number(stdout.trim().split('.')[0])
+    return Number.isInteger(major) ? major : null
+  } catch {
+    return null
+  }
+}
+
+/** Reads the pnpm global minimumReleaseAge layer for the current pnpm major version. */
+const readPnpmGlobalMinimumReleaseAgeLayer = async (
+  globalConfigDir: string,
+  pnpmMajorVersion: number | null,
+): Promise<MinimumReleaseAgeLayer | null> => {
+  if (pnpmMajorVersion != null) {
+    return pnpmMajorVersion >= 11
+      ? readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'config.yaml'), 'yaml')
+      : readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'rc'), 'ini')
+  }
+
+  return (
+    (await readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'config.yaml'), 'yaml')) ??
+    (await readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'rc'), 'ini'))
+  )
+}
+
 /**
  * Reads minimumReleaseAge settings from pnpm's config, falling back through pnpm's config layers.
  *
- * pnpm-workspace.yaml takes precedence over pnpm's global config (config.yaml for pnpm >= 11, rc for
- * pnpm <= 10) for the minimumReleaseAge value. minimumReleaseAgeExclude patterns are merged across all
- * layers, matching pnpm's config resolution. Returns null if no layer defines a minimumReleaseAge.
+ * pnpm-workspace.yaml takes precedence over pnpm's global config. pnpm >= 11 reads config.yaml, while
+ * pnpm <= 10 reads rc. minimumReleaseAgeExclude patterns are merged from the workspace layer and the
+ * selected global layer. Returns null if no layer defines a minimumReleaseAge.
  */
-const getPnpmWorkspaceMinimumReleaseAge = async (): Promise<PnpmWorkspaceMinimumReleaseAge | null> => {
+const getPnpmWorkspaceMinimumReleaseAge = async (
+  pnpmMajorVersion?: number | null,
+): Promise<PnpmWorkspaceMinimumReleaseAge | null> => {
   const globalConfigDir = getPnpmGlobalConfigDir()
 
   const pnpmWorkspacePath = await findUp('pnpm-workspace.yaml')
+  const majorVersion = pnpmMajorVersion === undefined ? await getPnpmMajorVersion() : pnpmMajorVersion
+  const globalConfig = await readPnpmGlobalMinimumReleaseAgeLayer(globalConfigDir, majorVersion)
 
   // Ordered from highest to lowest precedence. Each entry resolves to a config layer (or null if absent).
   const layers = await Promise.all([
     // workspace / project config
     pnpmWorkspacePath ? readMinimumReleaseAgeLayer(pnpmWorkspacePath, 'yaml') : Promise.resolve(null),
-    // pnpm >= 11 global config
-    readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'config.yaml'), 'yaml'),
-    // pnpm <= 10 global config
-    readMinimumReleaseAgeLayer(path.join(globalConfigDir, 'rc'), 'ini'),
+    // pnpm global config for the current major version
+    Promise.resolve(globalConfig),
   ])
 
   // Use the minimumReleaseAge from the highest-precedence layer that defines it.

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -1649,7 +1649,7 @@ describe('cooldown', () => {
         'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  - react\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
 
       expect(result).to.deep.equal({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['react'] })
     })
@@ -1661,13 +1661,43 @@ describe('cooldown', () => {
         'minimumReleaseAge=10080\nminimumReleaseAgeExclude=["react"]\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(10)
 
       expect(result).to.deep.equal({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['react'] })
     })
 
+    it('ignores pnpm global rc when config.yaml exists for pnpm >= 11', async () => {
+      await fs.writeFile(
+        path.join(xdgDir, 'pnpm', 'config.yaml'),
+        'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  - react\n',
+      )
+      await fs.writeFile(
+        path.join(xdgDir, 'pnpm', 'rc'),
+        'minimumReleaseAge=1440\nminimumReleaseAgeExclude=["lodash"]\n',
+      )
+
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
+
+      expect(result).to.deep.equal({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['react'] })
+    })
+
+    it('ignores pnpm global config.yaml when rc exists for pnpm <= 10', async () => {
+      await fs.writeFile(
+        path.join(xdgDir, 'pnpm', 'config.yaml'),
+        'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  - react\n',
+      )
+      await fs.writeFile(
+        path.join(xdgDir, 'pnpm', 'rc'),
+        'minimumReleaseAge=1440\nminimumReleaseAgeExclude=["lodash"]\n',
+      )
+
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(10)
+
+      expect(result).to.deep.equal({ minimumReleaseAge: 1440, minimumReleaseAgeExclude: ['lodash'] })
+    })
+
     it('returns null when no config layer defines minimumReleaseAge', async () => {
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
       expect(result).to.equal(null)
     })
 
@@ -1681,7 +1711,7 @@ describe('cooldown', () => {
         'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  - react\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
 
       // workspace minimumReleaseAge wins; excludes from both layers are merged
       expect(result).to.deep.equal({ minimumReleaseAge: 1440, minimumReleaseAgeExclude: ['@myorg/*', 'react'] })
@@ -1697,7 +1727,7 @@ describe('cooldown', () => {
         'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  - react\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
 
       expect(result).to.deep.equal({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['@myorg/*', 'react'] })
     })


### PR DESCRIPTION
﻿## Summary
- Select pnpm global minimumReleaseAge config based on pnpm major version
- Use config.yaml for pnpm >= 11 and rc for pnpm <= 10 instead of merging both global files
- Add regression coverage for environments where both global config files exist

Fixes #1890

## Tests
- npx.cmd mocha test/cooldown.test.ts --grep "pnpm global minimumReleaseAge config fallback"
- npm.cmd run lint:types
- npm.cmd run prettier
- npm.cmd run lint:src
