### PR TITLE
fix(test): use vitest expect() instead of chai should in version-util tests

### DIFF
--- a/test/version-util.test.ts
+++ b/test/version-util.test.ts
@@ -399,13 +399,13 @@ describe('version-util', () => {
       // upgradeDependencyDeclaration converts a "<" or "<=" declaration into a "^" range,
       // e.g. "<1.2.3" -> "^1.2.9". from and to no longer share the same leading character,
       // which used to prevent the operator from being stripped before comparing parts.
-      versionUtil.partChanged('<1.2.3', '^1.2.9')!.should.equal('patch')
-      versionUtil.partChanged('<1.2.3', '^1.3.0')!.should.equal('minor')
-      versionUtil.partChanged('<1.2.3', '^2.0.0')!.should.equal('major')
-      versionUtil.partChanged('<=1.2.3', '^1.2.9')!.should.equal('patch')
+      expect(versionUtil.partChanged('<1.2.3', '^1.2.9')).toBe('patch')
+      expect(versionUtil.partChanged('<1.2.3', '^1.3.0')).toBe('minor')
+      expect(versionUtil.partChanged('<1.2.3', '^2.0.0')).toBe('major')
+      expect(versionUtil.partChanged('<=1.2.3', '^1.2.9')).toBe('patch')
       // a bare "from" that gains a wildcard in "to" hits the same code path
-      versionUtil.partChanged('1.2.3', '^1.2.9')!.should.equal('patch')
-      versionUtil.partChanged('1.2.3', '^1.3.0')!.should.equal('minor')
+      expect(versionUtil.partChanged('1.2.3', '^1.2.9')).toBe('patch')
+      expect(versionUtil.partChanged('1.2.3', '^1.3.0')).toBe('minor')
     })
   })
 
@@ -438,9 +438,9 @@ describe('version-util', () => {
     it('handle a leading range operator that differs between from and to', () => {
       // "<1.2.3" -> "^1.2.9" used to color the entire string red since the leading "<" on
       // `from` blocked the "^" from being stripped off `to` before the parts were compared.
-      versionUtil.colorizeDiff('<1.2.3', '^1.2.9').should.equal(`^1.2.${chalk.green('9')}`)
-      versionUtil.colorizeDiff('<1.2.3', '^1.3.0').should.equal(`^1.${chalk.cyan('3.0')}`)
-      versionUtil.colorizeDiff('1.2.3', '^1.2.9').should.equal(`^1.2.${chalk.green('9')}`)
+      expect(versionUtil.colorizeDiff('<1.2.3', '^1.2.9')).toBe(`^1.2.${chalk.green('9')}`)
+      expect(versionUtil.colorizeDiff('<1.2.3', '^1.3.0')).toBe(`^1.${chalk.cyan('3.0')}`)
+      expect(versionUtil.colorizeDiff('1.2.3', '^1.2.9')).toBe(`^1.2.${chalk.green('9')}`)
     })
   })
 


### PR DESCRIPTION
## Why

`tsc --noEmit` was failing with `Property 'should' does not exist` errors in `test/version-util.test.ts`. Two recently added test cases used chai-style `.should.equal()` assertions, but this suite runs on vitest and never sets up chai's `should` extension, so the assertions failed to type-check (and would fail at runtime).

## What

Converted the nine offending assertions in the "handle a leading range operator that differs between from and to" tests (for both `partChanged` and `colorizeDiff`) from `value.should.equal(expected)` to the `expect(value).toBe(expected)` style used throughout the rest of the file. Also dropped the now-unnecessary non-null assertions (`!`) since `expect().toBe()` doesn't require them.

No production code changed. `tsc --noEmit` now passes and all 84 tests in the file pass.