### PR TITLE
target semver: respect explicit upper bounds like `^9.5.0 <10`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Advanced filters: [filter](https://github.com/raineorshine/npm-check-updates#fil
 - Choose what level to upgrade to:
   - With `--target semver`, update according to your specified [semver](https://semver.org/) version ranges:
     - `^1.1.0` → `^1.9.99`
+    - An explicit upper bound is respected and preserved, so the upgrade never exceeds it:
+      - `^9.5.0 <10` → `^9.7.0 <10`
   - With `--target minor`, strictly update the patch and minor versions (including major version zero):
     - `0.1.0` → `0.2.1`
   - With `--target patch`, strictly update the patch version (including major version zero):

--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -477,7 +477,7 @@ export function upgradeDependencyDeclaration(
   declaration: string,
   latestVersion: string | null,
   options: UpgradeOptions = {},
-) {
+): string {
   options.wildcard = options.wildcard || DEFAULT_WILDCARD
 
   if (!latestVersion) {
@@ -506,6 +506,16 @@ export function upgradeDependencyDeclaration(
   )
 
   const [declaredSemver] = parsedRange
+
+  // Preserve an explicit upper bound (e.g. the "<10" in "^9.5.0 <10") when the upgraded version
+  // still falls within it, so an upgrade never exceeds a declared ceiling. Only the caret/tilde
+  // lower bound is bumped; the upper bound is kept verbatim.
+  const upperBound = parsedRange.find(range => range.operator === '<' || range.operator === '<=')
+  const lowerBound = parsedRange.find(range => range.operator === '^' || range.operator === '~')
+  if (upperBound && lowerBound && semver.valid(latestVersion) && semver.satisfies(latestVersion, declaration)) {
+    const upgradedLower = upgradeDependencyDeclaration(lowerBound.semver!, latestVersion, options)
+    return `${upgradedLower} ${upperBound.semver}`
+  }
 
   /**
    * Chooses version parts between the declared version and the latest.

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -46,6 +46,12 @@ const isExplicitRange = (spec: VersionSpec) => {
   return range.some(parsed => EXPLICIT_RANGE_OPS.has(parsed.operator || ''))
 }
 
+/** Returns true if the spec has a caret or tilde bound (e.g. `^9.5.0 <10`, `~5.0.4`). */
+const hasCaretOrTilde = (spec: VersionSpec) => {
+  const range = parseRange(spec)
+  return range.some(parsed => parsed.operator === '^' || parsed.operator === '~')
+}
+
 /** Returns true if the version is sa valid, exact version. */
 const isExactVersion = (version: Version) =>
   version && (!nodeSemver.validRange(version) || versionUtil.isWildCard(version))
@@ -1236,8 +1242,10 @@ export const semver: GetVersion = async (
   npmConfig?: NpmConfig,
   npmConfigProject?: NpmConfig,
 ): Promise<VersionResult> => {
-  // ignore explicit version ranges
-  if (isExplicitRange(currentVersion)) return { version: null }
+  // ignore explicit version ranges (e.g. `>1`, `1 || 2`, `1.0.0 - 1.3.0`) since there is no clear
+  // upgrade target, but still upgrade caret/tilde ranges that carry an explicit upper bound
+  // (e.g. `^9.5.0 <10`), staying within the declared range
+  if (isExplicitRange(currentVersion) && !hasCaretOrTilde(currentVersion)) return { version: null }
 
   const fields: (keyof Packument)[] = ['versions']
 

--- a/test/target.test.ts
+++ b/test/target.test.ts
@@ -382,6 +382,62 @@ describe('target', () => {
         })
       })
     })
+
+    describe('bounded ^ and ~ ranges', () => {
+      it('upgrade within an explicit upper bound', async () => {
+        const data = await ncu({
+          jsonAll: true,
+          packageData: {
+            dependencies: {
+              'ncu-test-semver': '^1.0.0 <2',
+            },
+          },
+          target: 'semver',
+        })
+
+        expect(data).toStrictEqual({
+          dependencies: {
+            'ncu-test-semver': '^1.2.0 <2',
+          },
+        })
+      })
+
+      it('do not exceed an upper bound tighter than the caret range', async () => {
+        const data = await ncu({
+          jsonAll: true,
+          packageData: {
+            dependencies: {
+              'ncu-test-semver': '^1.0.0 <1.2',
+            },
+          },
+          target: 'semver',
+        })
+
+        expect(data).toStrictEqual({
+          dependencies: {
+            'ncu-test-semver': '^1.1.1 <1.2',
+          },
+        })
+      })
+
+      it('upgrade a tilde range within an explicit upper bound', async () => {
+        const data = await ncu({
+          jsonAll: true,
+          packageData: {
+            dependencies: {
+              'ncu-test-semver': '~1.1.0 <1.2',
+            },
+          },
+          target: 'semver',
+        })
+
+        expect(data).toStrictEqual({
+          dependencies: {
+            'ncu-test-semver': '~1.1.1 <1.2',
+          },
+        })
+      })
+    })
   })
 
   describe('custom', () => {

--- a/test/version-util.test.ts
+++ b/test/version-util.test.ts
@@ -55,6 +55,18 @@ describe('version-util', () => {
       expect(versionUtil.upgradeDependencyDeclaration('^0.15.7', '0.16.0-beta.3')).toBe('^0.16.0-beta.3')
     })
 
+    it('preserve an explicit upper bound when the new version stays within it', () => {
+      expect(versionUtil.upgradeDependencyDeclaration('^9.5.0 <10', '9.7.0')).toBe('^9.7.0 <10')
+      expect(versionUtil.upgradeDependencyDeclaration('~5.0.4 <5.1', '5.0.9')).toBe('~5.0.9 <5.1')
+      expect(versionUtil.upgradeDependencyDeclaration('^1.0.0 <1.2', '1.1.1')).toBe('^1.1.1 <1.2')
+      expect(versionUtil.upgradeDependencyDeclaration('^3.1.8 <4', '3.9.9')).toBe('^3.9.9 <4')
+    })
+
+    it('drop the upper bound when the new version exceeds it (e.g. --target latest)', () => {
+      expect(versionUtil.upgradeDependencyDeclaration('^9.5.0 <10', '12.0.0')).toBe('^12')
+      expect(versionUtil.upgradeDependencyDeclaration('~5.0.4 <5.1', '6.0.0')).toBe('^6.0')
+    })
+
     it('replace multiple ranges with ^', () => {
       expect(versionUtil.upgradeDependencyDeclaration('>1.0 >2.0 < 3.0', '3.1.0')).toBe('^3.1')
     })


### PR DESCRIPTION
Fixes #1409