### PR TITLE
Fix 404 for scoped packages when the registry rejects an encoded `@`

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -71,21 +71,9 @@ const fetchPartialPackument = async (
     ...opts.headers,
   }
   const url = new URL(
-    // since the registry API expects /package or /package/version encoding
-    // scoped packages is needed as to not treat the package scope as the full
-    // package name and the actual package name as the version/dist-tag
-    encodeURIComponent(name),
-    // the WhatWG URL standard, when given a base URL to place the first
-    // parameter relative to, will find the dirname of the base, treating the
-    // last segment as a file name and not a directory name if it isn't
-    // terminated by a / and thus remove it before adding the first argument
-    // to the URL.
-    // this is undesirable for registries configured without a trailing slash
-    // in the npm config since, for example looking up the package @foo/bar
-    // will give the following results given these configured registry URL:s
-    //    https://example.com/npm  => https://example.com/%40foo%2fbar
-    //    https://example.com/npm/ => https://example.com/npm/%40foo%2fbar
-    // however, like npm itself does there should be leniency allowed in this.
+    // Encode package name but preserve leading @ to avoid 404 errors
+    encodeURIComponent(name).replace(/^%40/, '@'),
+    // Ensure registry URL has trailing slash (URL constructor removes last segment)
     registry.endsWith('/') ? registry : `${registry}/`,
   )
   if (version) {

--- a/test/package-managers/npm/index.test.ts
+++ b/test/package-managers/npm/index.test.ts
@@ -42,4 +42,12 @@ describe('npm', () => {
       '404 Not Found - GET https://registry.npmjs.org/ncu-test-return-version/1.0',
     )
   })
+
+  // the leading @ must not be encoded to %40, which some registries reject with a 404
+  // https://github.com/raineorshine/npm-check-updates/issues/1330
+  it('does not percent-encode the @ of a scoped package name', async () => {
+    await expect(npm.getEngines('@angular/core', '0.0.0-nonexistent')).rejects.toThrow(
+      '404 Not Found - GET https://registry.npmjs.org/@angular%2Fcore/0.0.0-nonexistent',
+    )
+  })
 })


### PR DESCRIPTION
Fixes #1330.