### PR TITLE
Fix `--enginesNode`/`--ownerChanged` ignoring the project .npmrc registry

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -517,42 +517,6 @@ export function parseJson<R>(result: string, data: { command?: string; packageNa
   return json as R
 }
 
-/**
- * Check if package author changed between current and upgraded version.
- *
- * @param packageName Name of the package
- * @param currentVersion Current version declaration (may be range)
- * @param upgradedVersion Upgraded version declaration (may be range)
- * @param npmConfigLocal Additional npm config variables that are merged into the system npm config
- * @returns A promise that fulfills with boolean value.
- */
-export async function packageAuthorChanged(
-  packageName: string,
-  currentVersion: VersionSpec,
-  upgradedVersion: VersionSpec,
-  options: Options = {},
-  npmConfigLocal?: NpmConfig,
-): Promise<boolean> {
-  const result = await fetchPartialPackument(packageName, ['versions'], null, {
-    ...npmConfigLocal,
-    ...npmApi.findNpmConfig(),
-    fullMetadata: true,
-    ...(options.registry ? { registry: options.registry, silent: true } : null),
-  })
-  if (result.versions) {
-    const pkgVersions = Object.keys(result.versions)
-    const current = nodeSemver.minSatisfying(pkgVersions, currentVersion)
-    const upgraded = nodeSemver.maxSatisfying(pkgVersions, upgradedVersion)
-    if (current && upgraded && result.versions[current]._npmUser && result.versions[upgraded]._npmUser) {
-      const currentAuthor = result.versions[current]._npmUser?.name
-      const latestAuthor = result.versions[upgraded]._npmUser?.name
-      return currentAuthor !== latestAuthor
-    }
-  }
-
-  return false
-}
-
 /** Returns true if an object is a Packument. */
 const isPackument = (o: any): o is Partial<Packument> => !!(o && (o.name || o.engines || o.version || o.versions))
 
@@ -681,6 +645,42 @@ const mergeNpmConfigs = memoize(
     return npmConfigMerged
   },
 )
+
+/**
+ * Check if package author changed between current and upgraded version.
+ *
+ * @param packageName Name of the package
+ * @param currentVersion Current version declaration (may be range)
+ * @param upgradedVersion Upgraded version declaration (may be range)
+ * @param npmConfigLocal Additional npm config variables that are merged into the system npm config
+ * @returns A promise that fulfills with boolean value.
+ */
+export async function packageAuthorChanged(
+  packageName: string,
+  currentVersion: VersionSpec,
+  upgradedVersion: VersionSpec,
+  options: Options = {},
+  npmConfigLocal?: NpmConfig,
+): Promise<boolean> {
+  // merge the project/cwd .npmrc so a scoped private registry is respected, like the main fetch path
+  const npmConfigMerged = mergeNpmConfigs(
+    { npmConfigUser: { ...npmApi.findNpmConfig(), fullMetadata: true }, npmConfigLocal },
+    options,
+  )
+  const result = await fetchPartialPackument(packageName, ['versions'], null, npmConfigMerged)
+  if (result.versions) {
+    const pkgVersions = Object.keys(result.versions)
+    const current = nodeSemver.minSatisfying(pkgVersions, currentVersion)
+    const upgraded = nodeSemver.maxSatisfying(pkgVersions, upgradedVersion)
+    if (current && upgraded && result.versions[current]._npmUser && result.versions[upgraded]._npmUser) {
+      const currentAuthor = result.versions[current]._npmUser?.name
+      const latestAuthor = result.versions[upgraded]._npmUser?.name
+      return currentAuthor !== latestAuthor
+    }
+  }
+
+  return false
+}
 
 /**
  * Returns an object of specified values retrieved by npm view.
@@ -927,17 +927,9 @@ export const getEngines = async (
   options: Options = {},
   npmConfigLocal?: NpmConfig,
 ): Promise<Index<VersionSpec | undefined>> => {
-  const result = await fetchPartialPackument(
-    packageName,
-    [`engines`],
-    null,
-    {
-      ...npmConfigLocal,
-      ...npmApi.findNpmConfig(),
-      ...(options.registry ? { registry: options.registry, silent: true } : null),
-    },
-    version,
-  )
+  // merge the project/cwd .npmrc so a scoped private registry is respected, like the main fetch path
+  const npmConfigMerged = mergeNpmConfigs({ npmConfigUser: { ...npmApi.findNpmConfig() }, npmConfigLocal }, options)
+  const result = await fetchPartialPackument(packageName, [`engines`], null, npmConfigMerged, version)
   return result.engines || {}
 }
 

--- a/test/package-managers/npm/index.test.ts
+++ b/test/package-managers/npm/index.test.ts
@@ -1,7 +1,10 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import * as npm from '../../../src/package-managers/npm.ts'
+import removeDir from '../../helpers/removeDir.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -41,5 +44,24 @@ describe('npm', () => {
     await expect(npm.getEngines('ncu-test-return-version', '1.0')).rejects.toThrow(
       '404 Not Found - GET https://registry.npmjs.org/ncu-test-return-version/1.0',
     )
+  })
+
+  // getEngines must respect a scoped registry from the project .npmrc, not default to npmjs
+  // https://github.com/raineorshine/npm-check-updates/issues/1506
+  it('getEngines uses a scoped registry configured in the project .npmrc', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+    await fs.writeFile(
+      path.join(tempDir, '.npmrc'),
+      '@enginestest:registry=https://registry.npmjs.org/ncu-1506-probe/\n',
+    )
+
+    try {
+      // 404 confirms the request went to the configured registry path rather than the default
+      await expect(npm.getEngines('@enginestest/foo', '1.0.0', { cwd: tempDir })).rejects.toThrow(
+        'https://registry.npmjs.org/ncu-1506-probe/',
+      )
+    } finally {
+      await removeDir(tempDir)
+    }
   })
 })


### PR DESCRIPTION
Fixes #1506.