### PR TITLE
Fix DEP0190 warning in bun test bun-version check

### DIFF
--- a/test/bun/index.test.ts
+++ b/test/bun/index.test.ts
@@ -18,7 +18,7 @@ const mockNpmVersions = {
 describe('bun', () => {
   // Use a synchronous check to fail the suite immediately if bun is missing
   beforeAll(() => {
-    const result = spawnSync('bun', ['--version'], {
+    const result = spawnSync('bun --version', {
       shell: true,
       encoding: 'utf8',
     })


### PR DESCRIPTION
Fixes this:

```
 npm-check-updates@22.2.9 test:bun
> vitest run --config vitest.config.bun.js


 RUN  v4.1.10 D:/a/npm-check-updates/npm-check-updates

(node:8668) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
 ✓ test/bun/index.test.ts (7 tests) 3273ms
     ✓ packageAuthorChanged  1002ms
       ✓ upgrade dependencies when tests pass  456ms
       ✓ identify broken upgrade  1199ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  17:49:28
   Duration  3.83s (transform 265ms, setup 24ms, import 359ms, tests 3.27s, environment 0ms)
```