### PR TITLE
Remove predicate function support from filterVersion/rejectVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
   </tr>
   <tr>
     <td><a href="#filterversion">--filterVersion &lt;p&gt;</a></td>
-    <td>Filter on package version using comma-or-space-delimited list, /regex/, or predicate function.</td>
+    <td>Filter on package version using comma-or-space-delimited list or /regex/.</td>
   </tr>
   <tr>
     <td><a href="#format">--format &lt;value&gt;</a></td>
@@ -348,7 +348,7 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
   </tr>
   <tr>
     <td><a href="#rejectversion">--rejectVersion &lt;p&gt;</a></td>
-    <td>Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function.</td>
+    <td>Exclude package.json versions using comma-or-space-delimited list or /regex/.</td>
   </tr>
   <tr>
     <td>--removeRange</td>
@@ -648,28 +648,11 @@ Usage:
 
     ncu --filterVersion [p]
 
-Include only versions matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function.
+Include only versions matching the given string, wildcard, glob, comma-or-space-delimited list, or /regex/.
 
 `--filterVersion` runs _before_ new versions are fetched, in contrast to `--filterResults` which runs _after_.
 
-You can also specify a custom function in your .ncurc.js file, or when importing npm-check-updates as a module.
-
-> :warning: The predicate function is only available in .ncurc.js or when importing npm-check-updates as a module, not on the command line. To convert a JSON config to a JS config, follow the instructions at https://github.com/raineorshine/npm-check-updates#config-functions. This function is an alias for the `filter` option function.
-
-```js
-/**
-  @param name     The name of the dependency.
-  @param semver   A parsed Semver array of the current version.
-    (See: https://git.coolaj86.com/coolaj86/semver-utils.js#semverutils-parse-semverstring)
-  @returns        True if the package should be included, false if it should be excluded.
-*/
-filterVersion: (name, semver) => {
-  if (name.startsWith('@myorg/') && parseInt(semver[0]?.major) > 5) {
-    return false
-  }
-  return true
-}
-```
+To filter with a predicate function, use `filter` instead. It receives the package name and the parsed current version, so it can match on both name and version.
 
 ## format
 
@@ -862,28 +845,11 @@ Usage:
 
     ncu --rejectVersion [p]
 
-The inverse of `--filterVersion`. Exclude versions matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function.
+The inverse of `--filterVersion`. Exclude versions matching the given string, wildcard, glob, comma-or-space-delimited list, or /regex/.
 
 `--rejectVersion` runs _before_ new versions are fetched, in contrast to `--filterResults` which runs _after_.
 
-You can also specify a custom function in your .ncurc.js file, or when importing npm-check-updates as a module.
-
-> :warning: The predicate function is only available in .ncurc.js or when importing npm-check-updates as a module, not on the command line. To convert a JSON config to a JS config, follow the instructions at https://github.com/raineorshine/npm-check-updates#config-functions. This function is an alias for the reject option function.
-
-```js
-/**
-  @param name     The name of the dependency.
-  @param semver   A parsed Semver array of the current version.
-    (See: https://git.coolaj86.com/coolaj86/semver-utils.js#semverutils-parse-semverstring)
-  @returns        True if the package should be excluded, false if it should be included.
-*/
-rejectVersion: (name, semver) => {
-  if (name.startsWith('@myorg/') && parseInt(semver[0]?.major) > 5) {
-    return true
-  }
-  return false
-}
-```
+To reject with a predicate function, use `reject` instead. It receives the package name and the parsed current version, so it can match on both name and version.
 
 ## target
 

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -264,34 +264,13 @@ const extendedHelpFilterVersionFunction: ExtendedHelp = ({ markdown }) => {
   /** If markdown, surround inline code with backticks. */
   const codeInline = (code: string) => (markdown ? `\`${code}\`` : code)
 
-  return `Include only versions matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function.
+  return `Include only versions matching the given string, wildcard, glob, comma-or-space-delimited list, or /regex/.
 
 ${codeInline('--filterVersion')} runs _before_ new versions are fetched, in contrast to ${codeInline(
     '--filterResults',
   )} which runs _after_.
 
-You can also specify a custom function in your .ncurc.js file, or when importing npm-check-updates as a module.
-
-> :warning: The predicate function is only available in .ncurc.js or when importing npm-check-updates as a module, not on the command line. To convert a JSON config to a JS config, follow the instructions at https://github.com/raineorshine/npm-check-updates#config-functions. This function is an alias for the ${codeInline('filter')} option function.
-
-${codeBlock(
-  `${chalk.gray(`/**
-  @param name     The name of the dependency.
-  @param semver   A parsed Semver array of the current version.
-    (See: https://git.coolaj86.com/coolaj86/semver-utils.js#semverutils-parse-semverstring)
-  @returns        True if the package should be included, false if it should be excluded.
-*/`)}
-${chalk.green('filterVersion')}: (name, semver) ${chalk.cyan('=>')} {
-  ${chalk.red('if')} (name.startsWith(${chalk.yellow(`'@myorg/'`)}) ${chalk.red(
-    '&&',
-  )} parseInt(semver[0]?.major) ${chalk.cyan('>')} ${chalk.cyan(`5`)}) {
-    ${chalk.red('return')} ${chalk.cyan('false')}
-  }
-  ${chalk.red('return')} ${chalk.cyan('true')}
-}`,
-  { markdown },
-)}
-
+To filter with a predicate function, use ${codeInline('filter')} instead. It receives the package name and the parsed current version, so it can match on both name and version.
 `
 }
 
@@ -340,33 +319,13 @@ const extendedHelpRejectVersionFunction: ExtendedHelp = ({ markdown }) => {
 
   return `The inverse of ${codeInline(
     '--filterVersion',
-  )}. Exclude versions matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function.
+  )}. Exclude versions matching the given string, wildcard, glob, comma-or-space-delimited list, or /regex/.
 
 ${codeInline('--rejectVersion')} runs _before_ new versions are fetched, in contrast to ${codeInline(
     '--filterResults',
   )} which runs _after_.
 
-You can also specify a custom function in your .ncurc.js file, or when importing npm-check-updates as a module.
-
-> :warning: The predicate function is only available in .ncurc.js or when importing npm-check-updates as a module, not on the command line. To convert a JSON config to a JS config, follow the instructions at https://github.com/raineorshine/npm-check-updates#config-functions. This function is an alias for the reject option function.
-
-${codeBlock(
-  `${chalk.gray(`/**
-  @param name     The name of the dependency.
-  @param semver   A parsed Semver array of the current version.
-    (See: https://git.coolaj86.com/coolaj86/semver-utils.js#semverutils-parse-semverstring)
-  @returns        True if the package should be excluded, false if it should be included.
-*/`)}
-${chalk.green('rejectVersion')}: (name, semver) ${chalk.cyan('=>')} {
-  ${chalk.red('if')} (name.startsWith(${chalk.yellow(`'@myorg/'`)}) ${chalk.red(
-    '&&',
-  )} parseInt(semver[0]?.major) ${chalk.cyan('>')} ${chalk.cyan(`5`)}) {
-    ${chalk.red('return')} ${chalk.cyan('true')}
-  }
-  ${chalk.red('return')} ${chalk.cyan('false')}
-}`,
-  { markdown },
-)}
+To reject with a predicate function, use ${codeInline('reject')} instead. It receives the package name and the parsed current version, so it can match on both name and version.
 
 `
 }
@@ -822,8 +781,8 @@ const cliOptions: CLIOption[] = [
   {
     long: 'filterVersion',
     arg: 'p',
-    description: 'Filter on package version using comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | RegExp | readonly (string | RegExp)[] | FilterFunction',
+    description: 'Filter on package version using comma-or-space-delimited list or /regex/.',
+    type: 'string | RegExp | readonly (string | RegExp)[]',
     parse: (value, accum) => [...(accum || []), value],
     help: extendedHelpFilterVersionFunction,
   },
@@ -991,8 +950,8 @@ const cliOptions: CLIOption[] = [
   {
     long: 'rejectVersion',
     arg: 'p',
-    description: 'Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function.',
-    type: 'string | RegExp | readonly (string | RegExp)[] | FilterFunction',
+    description: 'Exclude package.json versions using comma-or-space-delimited list or /regex/.',
+    type: 'string | RegExp | readonly (string | RegExp)[]',
     parse: (value, accum) => [...(accum || []), value],
     help: extendedHelpRejectVersionFunction,
   },

--- a/src/lib/filterAndReject.ts
+++ b/src/lib/filterAndReject.ts
@@ -13,7 +13,10 @@ import { type VersionSpec } from '../types/VersionSpec.ts'
  * @param [filterPattern]
  * @returns
  */
-function composeFilter(filterPattern: FilterPattern): (name: string, versionSpec?: string) => boolean {
+function composeFilter(
+  filterPattern: FilterPattern,
+  { allowFunction = true }: { allowFunction?: boolean } = {},
+): (name: string, versionSpec?: string) => boolean {
   let predicate: (name: string, versionSpec?: string) => boolean
 
   // no filter
@@ -48,7 +51,7 @@ function composeFilter(filterPattern: FilterPattern): (name: string, versionSpec
   // array
   else if (Array.isArray(filterPattern)) {
     predicate = (dependencyName: string, versionSpec?: string) =>
-      filterPattern.some(subpattern => composeFilter(subpattern)(dependencyName, versionSpec))
+      filterPattern.some(subpattern => composeFilter(subpattern, { allowFunction })(dependencyName, versionSpec))
   }
   // raw RegExp
   else if (filterPattern instanceof RegExp) {
@@ -56,6 +59,11 @@ function composeFilter(filterPattern: FilterPattern): (name: string, versionSpec
   }
   // function
   else if (typeof filterPattern === 'function') {
+    if (!allowFunction) {
+      throw new TypeError(
+        'filterVersion and rejectVersion do not support predicate functions. Use filter or reject instead, which receive the package name and parsed current version.',
+      )
+    }
     predicate = (dependencyName: string, versionSpec?: string) =>
       filterPattern(dependencyName, parseRange(versionSpec ?? dependencyName))
   } else {
@@ -90,8 +98,8 @@ function filterAndReject(
     // filter version
     (dependencyName: VersionSpec, version: string) =>
       and(
-        filterVersion ? composeFilter(filterVersion) : true,
-        rejectVersion ? (...args) => !composeFilter(rejectVersion)(...args) : true,
+        filterVersion ? composeFilter(filterVersion, { allowFunction: false }) : true,
+        rejectVersion ? (...args) => !composeFilter(rejectVersion, { allowFunction: false })(...args) : true,
       )(version),
   )
 }

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -329,7 +329,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
     ...(packageManager === 'deno' ? { dep: ['imports', 'prod', 'dev', 'optional', 'packageManager'] } : null),
     ...(options.format && options.format.length > 0 ? { format: options.format } : null),
     filter: args || filter,
-    filterVersion,
+    filterVersion: filterVersion as Options['filterVersion'],
     // add shortcut for any keys that start with 'json'
     json,
     loglevel,
@@ -338,7 +338,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
     // this is overridden on a per-dependency basis in queryVersions to allow prereleases to be upgraded to newer prereleases
     ...(options.pre != null || autoPre ? { pre: options.pre != null ? !!options.pre : autoPre } : null),
     reject,
-    rejectVersion,
+    rejectVersion: rejectVersion as Options['rejectVersion'],
     target,
     // imply upgrade in interactive mode when json is not specified as the output
     ...(options.interactive && options.upgrade === undefined ? { upgrade: !json } : null),

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -158,12 +158,9 @@
                   }
                 ]
               }
-            },
-            {
-              "$ref": "#/definitions/FilterFunction"
             }
           ],
-          "description": "Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run \"ncu --help --filterVersion\" for details."
+          "description": "Filter on package version using comma-or-space-delimited list or /regex/. Run \"ncu --help --filterVersion\" for details."
         },
         "format": {
           "type": "array",
@@ -307,12 +304,9 @@
                   }
                 ]
               }
-            },
-            {
-              "$ref": "#/definitions/FilterFunction"
             }
           ],
-          "description": "Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function. Run \"ncu --help --rejectVersion\" for details."
+          "description": "Exclude package.json versions using comma-or-space-delimited list or /regex/. Run \"ncu --help --rejectVersion\" for details."
         },
         "removeRange": {
           "type": "boolean",

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -86,8 +86,8 @@ export interface RunOptions {
   /** Filters results based on a user provided predicate function after fetching new versions. Run "ncu --help --filterResults" for details. */
   filterResults?: FilterResultsFunction
 
-  /** Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filterVersion" for details. */
-  filterVersion?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
+  /** Filter on package version using comma-or-space-delimited list or /regex/. Run "ncu --help --filterVersion" for details. */
+  filterVersion?: string | RegExp | readonly (string | RegExp)[]
 
   /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. Run "ncu --help --format" for details. */
   format?: readonly string[]
@@ -155,8 +155,8 @@ export interface RunOptions {
   /** Exclude packages matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --reject" for details. */
   reject?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
 
-  /** Exclude package.json versions using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --rejectVersion" for details. */
-  rejectVersion?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
+  /** Exclude package.json versions using comma-or-space-delimited list or /regex/. Run "ncu --help --rejectVersion" for details. */
+  rejectVersion?: string | RegExp | readonly (string | RegExp)[]
 
   /** Remove version ranges from the final package version. */
   removeRange?: boolean

--- a/test/getCurrentDependencies.test.ts
+++ b/test/getCurrentDependencies.test.ts
@@ -195,17 +195,12 @@ describe('getCurrentDependencies', () => {
       })
     })
 
-    it('filter dependencies by version spec with a filterVersion function', () => {
-      expect(
+    it('throw on a filterVersion function', () => {
+      expect(() =>
         getCurrentDependencies(deps, {
-          filterVersion: (name: string, versionSpec: SemVer[]) => versionSpec[0].major === '1',
+          filterVersion: ((name: string, versionSpec: SemVer[]) => versionSpec[0].major === '1') as never,
         }),
-      ).toStrictEqual({
-        mocha: '1.2',
-        moment: '^1.0.0',
-        chalk: '^1.1.0',
-        bluebird: '^1.0.0',
-      })
+      ).toThrow('do not support predicate functions')
     })
   })
 
@@ -313,13 +308,10 @@ describe('getCurrentDependencies', () => {
       })
     })
 
-    it('reject dependency versions by function', () => {
-      expect(getCurrentDependencies(deps, { rejectVersion: (s: string) => s.startsWith('^3') })).toStrictEqual({
-        mocha: '1.2',
-        moment: '^1.0.0',
-        chalk: '^1.1.0',
-        bluebird: '^1.0.0',
-      })
+    it('throw on a rejectVersion function', () => {
+      expect(() =>
+        getCurrentDependencies(deps, { rejectVersion: ((s: string) => s.startsWith('^3')) as never }),
+      ).toThrow('do not support predicate functions')
     })
   })
 })

--- a/test/rc-config.test.ts
+++ b/test/rc-config.test.ts
@@ -501,7 +501,7 @@ describe('rc-config', () => {
       }
     })
 
-    it('filterVersion function', async () => {
+    it('error on filterVersion function', async () => {
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
       const configFile = path.join(tempDir, '.ncurc.js')
       const pkgFile = path.join(tempDir, 'package.json')
@@ -519,10 +519,8 @@ describe('rc-config', () => {
       )
       try {
         // awkwardly, we have to set mergeConfig to enable autodetecting the rcconfig because otherwise it is explicitly disabled for tests
-        const { stdout } = await spawn('node', [bin, '--mergeConfig', '--jsonUpgraded'], {}, { cwd: tempDir })
-        const pkgData = JSON.parse(stdout)
-        expect(pkgData).toHaveProperty('ncu-test-v2')
-        expect(pkgData).not.toHaveProperty('ncu-test-tag')
+        const result = spawn('node', [bin, '--mergeConfig', '--jsonUpgraded'], {}, { cwd: tempDir })
+        await expect(result).rejects.toThrow('do not support predicate functions')
       } finally {
         await removeDir(tempDir)
       }
@@ -582,7 +580,7 @@ describe('rc-config', () => {
       }
     })
 
-    it('rejectVersion function', async () => {
+    it('error on rejectVersion function', async () => {
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
       const configFile = path.join(tempDir, '.ncurc.js')
       const pkgFile = path.join(tempDir, 'package.json')
@@ -600,10 +598,8 @@ describe('rc-config', () => {
       )
       try {
         // awkwardly, we have to set mergeConfig to enable autodetecting the rcconfig because otherwise it is explicitly disabled for tests
-        const { stdout } = await spawn('node', [bin, '--mergeConfig', '--jsonUpgraded'], {}, { cwd: tempDir })
-        const pkgData = JSON.parse(stdout)
-        expect(pkgData).not.toHaveProperty('ncu-test-v2')
-        expect(pkgData).toHaveProperty('ncu-test-tag')
+        const result = spawn('node', [bin, '--mergeConfig', '--jsonUpgraded'], {}, { cwd: tempDir })
+        await expect(result).rejects.toThrow('do not support predicate functions')
       } finally {
         await removeDir(tempDir)
       }


### PR DESCRIPTION
Closes #1442.

@raineorshine: this is a first patch. Let me know if you'd rather not throw an error for the old functionality or something else.