### PR TITLE
Change default format to `group`

### DIFF
--- a/.ncurc.js
+++ b/.ncurc.js
@@ -1,3 +1,0 @@
-export default {
-  format: 'group',
-}

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
   </tr>
   <tr>
     <td><a href="#format">--format &lt;value&gt;</a></td>
-    <td>Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. (default: ["group"])</td>
+    <td>Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. <code>group</code> is the only value included by default; use <code>--format no-group</code> to disable it. (default: ["group"])</td>
   </tr>
   <tr>
     <td>-g, --global</td>
@@ -693,6 +693,7 @@ Modify the output formatting or show additional information. Specify one or more
   <tr><td>time</td><td>Shows the publish time of each upgrade.</td></tr>
   <tr><td>cooldown</td><td>Shows a list of packages that were skipped due to the --cooldown threshold.</td></tr>
 </table>
+`group` is the only value included by default. Prefix it with "no-" to remove it instead of replacing the entire list, e.g. `--format no-group` to disable the default grouping.
 
 ## groupFunction
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
   </tr>
   <tr>
     <td><a href="#format">--format &lt;value&gt;</a></td>
-    <td>Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. (default: [])</td>
+    <td>Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. (default: ["group"])</td>
   </tr>
   <tr>
     <td>-g, --global</td>
@@ -676,6 +676,8 @@ filterVersion: (name, semver) => {
 Usage:
 
     ncu --format [value]
+
+Default: group
 
 Modify the output formatting or show additional information. Specify one or more comma-delimited values.
 

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -833,7 +833,7 @@ const cliOptions: CLIOption[] = [
     description:
       'Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown.',
     parse: value => (typeof value === 'string' ? value.split(/,|\s/) : value),
-    default: [],
+    default: ['group'],
     type: 'readonly string[]',
     choices: [
       'dep',

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -200,6 +200,7 @@ const extendedHelpFormat: ExtendedHelp = ({ markdown }) => {
   })
 
   return `${header}\n\n${padLeft(tableString, markdown ? 0 : 4)}
+\`group\` is the only value included by default. Prefix it with "no-" to remove it instead of replacing the entire list, e.g. \`--format no-group\` to disable the default grouping.
 `
 }
 
@@ -681,6 +682,9 @@ ${codeBlock(
 `
 }
 
+// the default value of --format, shared with its parse function so that "no-" prefixed values can negate it
+const FORMAT_DEFAULT = ['group']
+
 // store CLI options separately from bin file so that they can be used to build type definitions
 const cliOptions: CLIOption[] = [
   {
@@ -831,9 +835,16 @@ const cliOptions: CLIOption[] = [
     long: 'format',
     arg: 'value',
     description:
-      'Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown.',
-    parse: value => (typeof value === 'string' ? value.split(/,|\s/) : value),
-    default: ['group'],
+      'Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. `group` is the only value included by default; use `--format no-group` to disable it.',
+    parse: value => {
+      if (typeof value !== 'string') return value
+      const values = value.split(/,|\s/).filter(Boolean)
+      const negated = values.filter(v => v.startsWith('no-')).map(v => v.slice(3))
+      if (negated.length === 0) return values
+      const positive = values.filter(v => !v.startsWith('no-'))
+      return [...new Set([...FORMAT_DEFAULT.filter(v => !negated.includes(v)), ...positive])]
+    },
+    default: FORMAT_DEFAULT,
     type: 'readonly string[]',
     choices: [
       'dep',

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -357,11 +357,11 @@ export async function printUpgradesTable(
   if (options.format?.includes('group')) {
     const groups = getDependencyGroups(upgraded, current, options)
 
-    for (const { heading, packages } of groups) {
-      print(options, '\n' + heading)
-      print(
-        options,
-        await toDependencyTable({
+    // build the tables in parallel so per-group disk reads (e.g. --format repo) overlap, then print in order
+    const rendered = await Promise.all(
+      groups.map(async ({ heading, packages }) => ({
+        heading,
+        table: await toDependencyTable({
           from: current,
           to: packages,
           skippedByCooldown,
@@ -370,7 +370,12 @@ export async function printUpgradesTable(
           pkgFile,
           time,
         }),
-      )
+      })),
+    )
+
+    for (const { heading, table } of rendered) {
+      print(options, '\n' + heading)
+      print(options, table)
     }
   } else {
     if (options.format?.includes('lines')) {

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -170,7 +170,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. Run \"ncu --help --format\" for details.",
+          "description": "Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. `group` is the only value included by default; use `--format no-group` to disable it. Run \"ncu --help --format\" for details.",
           "default": ["group"]
         },
         "global": {

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -170,7 +170,8 @@
           "items": {
             "type": "string"
           },
-          "description": "Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. Run \"ncu --help --format\" for details."
+          "description": "Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. Run \"ncu --help --format\" for details.",
+          "default": ["group"]
         },
         "global": {
           "type": "boolean",

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -89,7 +89,7 @@ export interface RunOptions {
   /** Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filterVersion" for details. */
   filterVersion?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
 
-  /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. Run "ncu --help --format" for details.
+  /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. `group` is the only value included by default; use `--format no-group` to disable it. Run "ncu --help --format" for details.
    *
    * @default ["group"]
    */

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -89,7 +89,10 @@ export interface RunOptions {
   /** Filter on package version using comma-or-space-delimited list, /regex/, or predicate function. Run "ncu --help --filterVersion" for details. */
   filterVersion?: string | RegExp | readonly (string | RegExp)[] | FilterFunction
 
-  /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. Run "ncu --help --format" for details. */
+  /** Modify the output formatting or show additional information. Specify one or more comma-delimited values: dep, group, ownerChanged, repo, time, lines, installedVersion, cooldown. Run "ncu --help --format" for details.
+   *
+   * @default ["group"]
+   */
   format?: readonly string[]
 
   /** Check global packages instead of in the current project. */

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -73,6 +73,26 @@ describe('bin', () => {
     stub.restore()
   })
 
+  it('--format no-group disables the default grouping', async () => {
+    const stub = stubVersions('99.9.9', { spawn: true })
+    const { stdout } = await spawn('node', [bin, '--format', 'no-group', '--stdin'], {
+      stdin: JSON.stringify({ dependencies: { express: '1.0.0' } }),
+    })
+    expect(stripAnsi(stdout)).not.toContain('Major   Potentially breaking API changes')
+    stub.restore()
+  })
+
+  it('--format no-group,dep combines negation with another format value', async () => {
+    const stub = stubVersions('99.9.9', { spawn: true })
+    const { stdout } = await spawn('node', [bin, '--format', 'no-group,dep', '--stdin'], {
+      stdin: JSON.stringify({ dependencies: { express: '1.0.0' } }),
+    })
+    const stripped = stripAnsi(stdout)
+    expect(stripped).not.toContain('Major   Potentially breaking API changes')
+    expect(stripped).toContain('express')
+    stub.restore()
+  })
+
   it('reject out-of-date stdin with errorLevel 2', async () => {
     const stub = stubVersions('99.9.9', { spawn: true })
     await expect(

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -60,7 +60,16 @@ describe('bin', () => {
     const { stdout } = await spawn('node', [bin, '--stdin'], {
       stdin: JSON.stringify({ dependencies: { express: '1' } }),
     })
-    expect(stdout.trim().startsWith('express')).toBe(true)
+    expect(stdout).toContain('express')
+    stub.restore()
+  })
+
+  it('group by update type by default', async () => {
+    const stub = stubVersions('99.9.9', { spawn: true })
+    const { stdout } = await spawn('node', [bin, '--stdin'], {
+      stdin: JSON.stringify({ dependencies: { express: '1.0.0' } }),
+    })
+    expect(stripAnsi(stdout)).toContain('Major   Potentially breaking API changes')
     stub.restore()
   })
 
@@ -295,7 +304,7 @@ describe('bin', () => {
       const { stdout } = await spawn('node', [bin, '--stdin'], { stdin: JSON.stringify({ dependencies }) })
       expect(
         stripAnsi(stdout).trim().replace(/\s+/g, ' '), // Replace all whitespace sequences with a single space
-      ).toBe('ncu-test-v2 https://github.com/raineorshine/ncu-test-v2.git#v1.0.0 → v2.0.0')
+      ).toContain('ncu-test-v2 https://github.com/raineorshine/ncu-test-v2.git#v1.0.0 → v2.0.0')
     })
 
     it('strip prefix from npm alias in "to" output', async () => {
@@ -304,7 +313,7 @@ describe('bin', () => {
         request: 'npm:ncu-test-v2@1.0.0',
       }
       const { stdout } = await spawn('node', [bin, '--stdin'], { stdin: JSON.stringify({ dependencies }) })
-      expect(stripAnsi(stdout).trim()).toBe('request  npm:ncu-test-v2@1.0.0  →  99.9.9')
+      expect(stripAnsi(stdout).replace(/\s+/g, ' ')).toContain('request npm:ncu-test-v2@1.0.0 → 99.9.9')
       stub.restore()
     })
   })

--- a/test/interactive.test.ts
+++ b/test/interactive.test.ts
@@ -110,6 +110,45 @@ describe('--interactive', () => {
     }
   })
 
+  it('with --format no-group', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+    const pkgFile = path.join(tempDir, 'package.json')
+    await fs.writeFile(
+      pkgFile,
+      JSON.stringify({
+        dependencies: { 'ncu-test-v2': '1.0.0', 'ncu-test-return-version': '1.0.0', 'ncu-test-tag': '1.0.0' },
+      }),
+      'utf-8',
+    )
+    try {
+      await spawn(
+        'node',
+        [bin, '--interactive', '--format', 'no-group'],
+        {},
+        {
+          cwd: tempDir,
+          env: {
+            ...process.env,
+            INJECT_PROMPTS: JSON.stringify([['ncu-test-v2', 'ncu-test-return-version'], true]),
+          },
+        },
+      )
+
+      const upgradedPkg = JSON.parse(await fs.readFile(pkgFile, 'utf-8'))
+      expect(upgradedPkg.dependencies).toStrictEqual({
+        // upgraded
+        'ncu-test-v2': '2.0.0',
+        'ncu-test-return-version': '2.0.0',
+        // no upgraded
+        'ncu-test-tag': '1.0.0',
+      })
+
+      // prompts does not print during injection, so we cannot assert the output in interactive mode
+    } finally {
+      await removeDir(tempDir)
+    }
+  })
+
   it('with --format group and custom group function', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
     const pkgFile = path.join(tempDir, 'package.json')


### PR DESCRIPTION
Fixes #1379

Not sure about the parallelized group formatting patch, though. I don't think it's really needed.