### PR TITLE
Pin Docker base image by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
       github-actions:
         patterns:
           - '*'
+  - package-ecosystem: 'docker'
+    directory: '/'
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: 'weekly'
   - package-ecosystem: 'npm'
     directory: '/'
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     cooldown:
       default-days: 7
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
   - package-ecosystem: 'npm'
     directory: '/'
     cooldown:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:lts-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 RUN npm install -g npm-check-updates
 


### PR DESCRIPTION
Unsure if we want this... Sure, it's better practice, and we can get dependabot to update the hash on a weekly basis (we can move to monthly if you prefer). But it's extra churn.