### PR TITLE
Match npm's scoped-package URL escaping

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -57,6 +57,15 @@ const hasCaretOrTilde = (spec: VersionSpec) => {
 const isExactVersion = (version: Version) =>
   version && (!nodeSemver.validRange(version) || versionUtil.isWildcard(version))
 
+/**
+ * Escapes a package name for a registry URL path segment the way npm does: literal leading @ and a
+ * lowercase %2f. Encoding the whole name first keeps a crafted name on the registry origin.
+ * https://github.com/raineorshine/npm-check-updates/issues/1330
+ * https://github.com/raineorshine/npm-check-updates/issues/1456
+ */
+export const escapePackageName = (name: string): string =>
+  encodeURIComponent(name).replace(/^%40/, '@').replace(/%2F/g, '%2f')
+
 /** Fetches a packument or dist-tag from the npm registry. */
 const fetchPartialPackument = async (
   name: string,
@@ -78,8 +87,7 @@ const fetchPartialPackument = async (
     ...opts.headers,
   }
   const url = new URL(
-    // Encode package name but preserve leading @ to avoid 404 errors
-    encodeURIComponent(name).replace(/^%40/, '@'),
+    escapePackageName(name),
     // Ensure registry URL has trailing slash (URL constructor removes last segment)
     registry.endsWith('/') ? registry : `${registry}/`,
   )

--- a/test/package-managers/npm/index.test.ts
+++ b/test/package-managers/npm/index.test.ts
@@ -97,11 +97,47 @@ describe('npm', () => {
     }
   })
 
-  // the leading @ must not be encoded to %40, which some registries reject with a 404
-  // https://github.com/raineorshine/npm-check-updates/issues/1330
-  it('does not percent-encode the @ of a scoped package name', async () => {
+  // end-to-end check that the escaped name reaches the registry as npm would send it
+  // https://github.com/raineorshine/npm-check-updates/issues/1456
+  it('requests a scoped package the same way npm does', async () => {
     await expect(npm.getEngines('@angular/core', '0.0.0-nonexistent')).rejects.toThrow(
-      '404 Not Found - GET https://registry.npmjs.org/@angular%2Fcore/0.0.0-nonexistent',
+      '404 Not Found - GET https://registry.npmjs.org/@angular%2fcore/0.0.0-nonexistent',
+    )
+  })
+
+  describe('escapePackageName', () => {
+    // some registries and proxies reject %40 or an uppercase %2F but let npm's own requests through
+    // https://github.com/raineorshine/npm-check-updates/issues/1330
+    it('leaves an unscoped name untouched', () => {
+      expect(npm.escapePackageName('lodash')).toBe('lodash')
+    })
+
+    it('preserves the leading @ and lowercases the scope slash', () => {
+      expect(npm.escapePackageName('@angular/core')).toBe('@angular%2fcore')
+    })
+
+    it('does not encode dots, dashes, underscores, or tildes', () => {
+      expect(npm.escapePackageName('@foo-bar/baz.qux_1~2')).toBe('@foo-bar%2fbaz.qux_1~2')
+    })
+
+    // only the leading @ marks a scope; any other @ must stay encoded
+    it('encodes an @ that is not the scope prefix', () => {
+      expect(npm.escapePackageName('foo@bar')).toBe('foo%40bar')
+    })
+
+    // a literal %2f in the name must not survive as a decodable slash
+    it('double-encodes a percent already present in the name', () => {
+      expect(npm.escapePackageName('foo%2fbar')).toBe('foo%252fbar')
+    })
+
+    // a crafted name must not steer the request off the registry origin
+    it.each(['//evil.com/x', '\\\\evil.com\\x', '../../etc/passwd', 'foo?x=1', 'foo#bar'])(
+      'keeps %j on the registry origin',
+      name => {
+        expect(new URL(npm.escapePackageName(name), 'https://registry.npmjs.org/').origin).toBe(
+          'https://registry.npmjs.org',
+        )
+      },
     )
   })
 


### PR DESCRIPTION
Need a confirmation if this fixes #1456. I doubt the `%2F` case matters and the issue is probably already fixed in v23.0.0, but you never know...