### PR TITLE
Shorten long build metadata in the upgrades table

### DIFF
--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -26,6 +26,7 @@ import {
   isGitHubUrl,
   isNpmAlias,
   parseNpmAlias,
+  shortenBuildMetadata,
   stripRange,
 } from './version-util.ts'
 
@@ -213,7 +214,7 @@ export async function toDependencyTable({
                 : ''
               : '*unknown*'
             : ''
-          const toColorized = colorizeDiff(getVersion(from), to)
+          const toColorized = colorizeDiff(getVersion(from), shortenBuildMetadata(to))
           const homepageUrl = format?.includes('homepage') ? packageJson?.homepage || '' : ''
           const repoUrl = format?.includes('repo')
             ? (await getRepoUrl(dep, packageJson ?? undefined, { pkgFile })) || ''
@@ -247,7 +248,7 @@ export async function toDependencyTable({
           return [
             dep,
             ...(format?.includes('dep') ? [depType ? chalk.gray(depType) : ''] : []),
-            from,
+            shortenBuildMetadata(from),
             '→',
             toColorized,
             ...(showCooldownCol ? [cooldown] : []),

--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -161,11 +161,15 @@ export function isWildPart(versionPartValue: Maybe<string>) {
 /** Strips semver range prefixes (^, ~, >=, <=, >, <) from a version string. */
 export const stripRange = (version: string): string => version.replace(/^[~^<>=]+/, '')
 
-/** Matches build metadata longer than 20 characters, capturing the part that fits. Anchored to the end of the string so that a multi-part range is left alone. */
-const LONG_BUILD_METADATA_REGEX = /(\+\S{20})\S+$/
+/** Number of build metadata characters to keep, not counting the leading +. */
+const MAX_BUILD_METADATA_LENGTH = 20
 
-/** Truncates build metadata that is too long to display, e.g. the integrity hash pnpm writes into packageManager: 10.14.0+sha512.ad27a79641b49c... */
-export const shortenBuildMetadata = (version: string): string => version.replace(LONG_BUILD_METADATA_REGEX, '$1...')
+/** Truncates long build metadata, e.g. the pnpm packageManager hash 10.14.0+sha512.ad27a79641b49... Only matches at the end of the string, so multi-part ranges are left alone. */
+export const shortenBuildMetadata = (version: string): string => {
+  const metadata = version.match(/\+(\S+)$/)?.[1]
+  if (!metadata || metadata.length <= MAX_BUILD_METADATA_LENGTH) return version
+  return version.slice(0, version.length - metadata.length) + metadata.slice(0, MAX_BUILD_METADATA_LENGTH) + '...'
+}
 
 /**
  * Determines the part of a version string that has changed when comparing two versions. Assumes that the two version strings are in the same format. Returns null if no parts have changed.

--- a/src/lib/version-util.ts
+++ b/src/lib/version-util.ts
@@ -161,6 +161,12 @@ export function isWildPart(versionPartValue: Maybe<string>) {
 /** Strips semver range prefixes (^, ~, >=, <=, >, <) from a version string. */
 export const stripRange = (version: string): string => version.replace(/^[~^<>=]+/, '')
 
+/** Matches build metadata longer than 20 characters, capturing the part that fits. Anchored to the end of the string so that a multi-part range is left alone. */
+const LONG_BUILD_METADATA_REGEX = /(\+\S{20})\S+$/
+
+/** Truncates build metadata that is too long to display, e.g. the integrity hash pnpm writes into packageManager: 10.14.0+sha512.ad27a79641b49c... */
+export const shortenBuildMetadata = (version: string): string => version.replace(LONG_BUILD_METADATA_REGEX, '$1...')
+
 /**
  * Determines the part of a version string that has changed when comparing two versions. Assumes that the two version strings are in the same format. Returns null if no parts have changed.
  *

--- a/test/logging.test.ts
+++ b/test/logging.test.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
 import { describe, expect, it } from 'vitest'
 import { chalkInit } from '../src/lib/chalk.ts'
 import { toDependencyTable } from '../src/lib/logging.ts'
@@ -25,6 +26,18 @@ describe('toDependencyTable', () => {
       to: { a: 'https://github.com/r/x#v2.0.0' },
     })
     expect(table).toContain('v2.0.0')
+  })
+
+  // https://github.com/raineorshine/npm-check-updates/issues/1539
+  it('truncates the build metadata that pnpm writes into packageManager', async () => {
+    const table = await toDependencyTable({
+      from: {
+        pnpm: '10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748',
+      },
+      to: { pnpm: '10.15.0+sha512.76e2df756d24beb1e0a58e5d4c0c1c9a5ba9c0e8b7c8e5d1a2b3c4d5e6f7a8b9' },
+    })
+    expect(stripAnsi(table)).toContain('10.14.0+sha512.ad27a79641b49...')
+    expect(stripAnsi(table)).toContain('10.15.0+sha512.76e2df756d24b...')
   })
 
   it('adds a cooldown column for dependencies skipped by cooldown', async () => {

--- a/test/version-util.test.ts
+++ b/test/version-util.test.ts
@@ -426,6 +426,27 @@ describe('version-util', () => {
     })
   })
 
+  describe('shortenBuildMetadata', () => {
+    it('truncate long build metadata', () => {
+      expect(
+        versionUtil.shortenBuildMetadata(
+          '10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748',
+        ),
+      ).toBe('10.14.0+sha512.ad27a79641b49...')
+    })
+    it('keep short build metadata', () => {
+      expect(versionUtil.shortenBuildMetadata('1.0.0+20130313144700')).toBe('1.0.0+20130313144700')
+      expect(versionUtil.shortenBuildMetadata('1.0.0+exp.sha.5114f85')).toBe('1.0.0+exp.sha.5114f85')
+    })
+    it('keep versions without build metadata', () => {
+      expect(versionUtil.shortenBuildMetadata('1.0.0')).toBe('1.0.0')
+      expect(versionUtil.shortenBuildMetadata('^1.0.0-alpha.1')).toBe('^1.0.0-alpha.1')
+    })
+    it('leave a multi-part range alone', () => {
+      expect(versionUtil.shortenBuildMetadata('>=1.0.0+20130313144700 <2.0.0')).toBe('>=1.0.0+20130313144700 <2.0.0')
+    })
+  })
+
   describe('colorizeDiff', () => {
     chalkInit()
     it('do not colorize unchanged versions', () => {


### PR DESCRIPTION
Fixes #1539.

Should we also shorten the `to` column too?