### PR TITLE
Report npm's stderr and the real command when npm ls outputs no JSON

### DIFF
--- a/src/lib/doctor.ts
+++ b/src/lib/doctor.ts
@@ -27,7 +27,7 @@ const npm = (
   options: Options,
   print?: boolean,
   { spawnOptions, spawnPleaseOptions }: { spawnOptions?: SpawnOptions; spawnPleaseOptions?: SpawnPleaseOptions } = {},
-): Promise<string> => {
+): Promise<unknown> => {
   if (print) {
     console.log(chalk.blue([options.packageManager, ...args].join(' ')))
   }

--- a/src/lib/spawnCommand.ts
+++ b/src/lib/spawnCommand.ts
@@ -18,9 +18,10 @@ async function spawnCommand(
 ) {
   const commands = getSpawnCommands(command)
 
-  for (const [index, command] of commands.entries()) {
+  for (const [index, resolvedCommand] of commands.entries()) {
     try {
-      return await spawn(command, args, spawnPleaseOptions, spawnOptions)
+      const result = await spawn(resolvedCommand, args, spawnPleaseOptions, spawnOptions)
+      return { ...result, command: resolvedCommand }
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== 'ENOENT' || index === commands.length - 1) {
         throw e

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -534,15 +534,16 @@ npmApi.findNpmConfig = memoize((): NpmConfig => {
  * @param data
  * @returns
  */
-export function parseJson<R>(result: string, data: { command?: string; packageName?: string }): R {
+export function parseJson<R>(result: string, data: { command?: string; packageName?: string; stderr?: string }): R {
   let json
   try {
     json = JSON.parse(result)
   } catch (err) {
+    const stderr = data.stderr?.trim()
     throw new Error(
       `Expected JSON from "${data.command}".${
         data.packageName ? ` There could be problems with the ${data.packageName} package.` : ''
-      } ${result ? 'Instead received: ' + result : 'Received empty response.'}`,
+      } ${result ? 'Instead received: ' + result : 'Received empty response.'}${stderr ? `\n\n${stderr}` : ''}`,
       { cause: err },
     )
   }
@@ -827,15 +828,15 @@ async function spawnNpm(
   npmOptions: NpmOptions = {},
   spawnPleaseOptions: SpawnPleaseOptions = {},
   spawnOptions: Index<any> = {},
-): Promise<any> {
+): Promise<{ stdout: string; stderr: string; command: string }> {
   const fullArgs = [
     ...(npmOptions.global ? [`--global`] : []),
     ...(npmOptions.prefix ? [`--prefix=${npmOptions.prefix}`] : []),
     '--json',
     ...(Array.isArray(args) ? args : [args]),
   ]
-  const { stdout } = await spawnCommand('npm', fullArgs, spawnPleaseOptions, spawnOptions)
-  return stdout
+  const { stdout, stderr, command } = await spawnCommand('npm', fullArgs, spawnPleaseOptions, spawnOptions)
+  return { stdout, stderr, command: [command, ...fullArgs].join(' ') }
 }
 
 /**
@@ -944,8 +945,8 @@ export const getPeerDependencies = async (
   spawnOptions: SpawnOptions,
 ): Promise<Index<Version>> => {
   const args = ['view', `${packageName}@${version}`, 'peerDependencies']
-  const result = await spawnNpm(args, {}, { rejectOnError: false }, spawnOptions)
-  return result ? parseJson(result, { command: [...args, '--json'].join(' ') }) : {}
+  const { stdout, stderr, command } = await spawnNpm(args, {}, { rejectOnError: false }, spawnOptions)
+  return stdout ? parseJson(stdout, { command, stderr }) : {}
 }
 
 /**
@@ -978,7 +979,8 @@ export const getEngines = async (
  * @returns
  */
 export const list = async (options: Options = {}): Promise<Index<string | undefined>> => {
-  const result = await spawnNpm(
+  // npm ls exits non-zero on tree problems (e.g. unmet peers) but still prints usable JSON
+  const { stdout, stderr, command } = await spawnNpm(
     ['ls', '--depth=0'],
     {
       ...(options.global ? { global: true } : null),
@@ -993,9 +995,7 @@ export const list = async (options: Options = {}): Promise<Index<string | undefi
   )
   const dependencies = parseJson<{
     dependencies: Index<{ version?: Version; required?: { version: Version } }>
-  }>(result, {
-    command: `npm${process.platform === 'win32' ? '.cmd' : ''} ls --json${options.global ? ' --global' : ''}`,
-  }).dependencies
+  }>(stdout, { command, stderr }).dependencies
 
   return keyValueBy(dependencies, (name, info) => ({
     // unmet peer dependencies have a different structure

--- a/test/package-managers/npm/index.test.ts
+++ b/test/package-managers/npm/index.test.ts
@@ -38,6 +38,25 @@ describe('npm', () => {
     })
   })
 
+  // npm prints its diagnostics to stderr when it outputs no JSON
+  describe('parseJson', () => {
+    it('appends stderr to the error', () => {
+      expect(() =>
+        npm.parseJson('', { command: 'npm --json ls --depth=0', stderr: 'npm does not support Node.js v18.20.4\n' }),
+      ).toThrow(
+        new Error(
+          'Expected JSON from "npm --json ls --depth=0". Received empty response.\n\nnpm does not support Node.js v18.20.4',
+        ),
+      )
+    })
+
+    it('omits stderr when it is empty', () => {
+      expect(() => npm.parseJson('not json', { command: 'npm --json ls --depth=0', stderr: '  ' })).toThrow(
+        new Error('Expected JSON from "npm --json ls --depth=0". Instead received: not json'),
+      )
+    })
+  })
+
   it('getEngines', async () => {
     await expect(npm.getEngines('del', '2.0.0')).resolves.toStrictEqual({ node: '>=0.10.0' })
     await expect(npm.getEngines('ncu-test-return-version', '1.0.0')).resolves.toStrictEqual({})


### PR DESCRIPTION
Does not fix #1473, but npm's stderr and the real command line now make it into the error instead of a bare `Received empty response.`

Closes #1473
