### PR TITLE
Further e2e.sh improvements

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -118,7 +118,7 @@ fi
 
 # Test: ncu -v
 echo ncu -v
-npx --registry "${registry_local}" npm-check-updates -v
+npx --yes --registry "${registry_local}" npm-check-updates -v
 
 # Test: cli
 # Create a package.json file with a dependency on npm-check-updates since it is already published to the local registry
@@ -134,7 +134,7 @@ EOF
 # --configFilePath to avoid reading the repo .ncurc
 # --cwd to point to the temp package file
 # --pre 1 to ensure that an upgrade is always suggested even if npm-check-updates is on a prerelease version
-npx --registry "${registry_local}" npm-check-updates \
+npx --yes --registry "${registry_local}" npm-check-updates \
   --configFilePath "${temp_dir}" \
   --cwd "${temp_dir}" \
   --pre 1 \

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -18,25 +18,25 @@ verdaccio_config="${temp_dir}/verdaccio-config.yaml"
 
 verdaccio_pid=""
 
-# cleanup on exit
+# Cleanup on exit
 cleanup() {
   local exit_status=$?
 
-  # shut down verdaccio
+  # Shut down Verdaccio
   if [[ -n "${verdaccio_pid}" ]]; then
-    echo Shutting down verdaccio
+    echo Shutting down Verdaccio
     kill -9 "${verdaccio_pid}" 2>/dev/null || true
     wait "${verdaccio_pid}" 2>/dev/null || true
   fi
 
-  # delete authToken
+  # Delete authToken
   # WARNING: The original authToken cannot be restored because it is protected and cannot be read with 'npm config get'.
   npm config delete "//${registry_addr}/:_authToken" || true
 
-  # return to working directory
+  # Return to working directory
   cd "${cwd}" || true
 
-  # remove temp directory
+  # Remove temp directory
   rm -rf -- "${temp_dir}"
 
   if [[ "${exit_status}" -ne 0 ]]; then
@@ -48,7 +48,26 @@ cleanup() {
 
 trap 'cleanup' EXIT
 
-# create verdaccio config
+# Used instead of `timeout`, which is not available on macOS
+retry() {
+  local attempts=20
+  local arg="${1-}"
+  local i
+
+  if [[ "${arg}" =~ ^[0-9]+$ ]]; then
+    attempts="${arg}"
+    shift
+  fi
+
+  for ((i = 0; i < attempts; i++)); do
+    "$@" && return 0
+    sleep 1
+  done
+
+  return 1
+}
+
+# Create Verdaccio config
 #   - store packages in temp directory so they are deleted on exit
 #   - allow anyone to publish to avoid npm login
 #   - increase body size to accommodate current package tarball size
@@ -67,41 +86,32 @@ uplinks:
     url: https://registry.npmjs.org/
 EOF
 
-# start verdaccio and wait for it to boot
+# Start Verdaccio and wait for it to boot
 echo Starting local registry
 nohup verdaccio -l "${registry_addr}" -c "${verdaccio_config}" >"${registry_log}" 2>&1 &
 verdaccio_pid=$!
 
-if ! timeout 30 grep -q 'http address' <(tail -f "${registry_log}"); then
-  echo "verdaccio did not start within 30s" >&2
+if ! retry 30 grep -q 'http address' "${registry_log}"; then
+  echo "Verdaccio did not start within 30s" >&2
   cat "${registry_log}" >&2
   exit 1
 fi
 
-# set dummy authToken which is required to publish
+# Set dummy authToken which is required to publish
 # https://github.com/verdaccio/verdaccio/issues/212#issuecomment-308578500
 npm config set "//${registry_addr}/:_authToken=e2e_dummy"
 
-# publish to local registry
+# Publish to local registry
 echo Publishing to local registry
 npm publish --registry "${registry_local}"
 
-# wait for published version to become visible in verdaccio.
-# verdaccio can accept npm publish before npm view/npx can resolve the package metadata.
-# without this retry loop, e2e can fail intermittently with "no such package available".
+# Wait for published version to become visible in Verdaccio.
+# Verdaccio can accept npm publish before npm view/npx can resolve the package metadata.
+# Without this retry loop, e2e can fail intermittently with "no such package available".
 package_version="$(node -p "require('./package.json').version")"
 echo "Waiting for npm-check-updates@${package_version} in local registry"
 
-publish_visible=false
-for _ in {1..20}; do
-  if npm view "npm-check-updates@${package_version}" version --registry "${registry_local}" >/dev/null 2>&1; then
-    publish_visible=true
-    break
-  fi
-  sleep 1
-done
-
-if [[ "${publish_visible}" == false ]]; then
+if ! retry npm view "npm-check-updates@${package_version}" version --registry "${registry_local}" >/dev/null 2>&1; then
   echo "Warning: npm-check-updates@${package_version} not visible in local registry after retry window"
 fi
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-# These can be set once the fnm permission errors are figured out
-# See: https://github.com/Schniz/fnm
-# set -e
-# set -o pipefail
-# When set -e is enabled, we can drop `|| exit (1)?` from commands that are expected to fail
+# Enable strict mode:
+# -E: inherit ERR traps in functions/subshells
+# -e: exit on any command failure
+# -u: error on unset variables
+# -o pipefail: fail pipelines if any command fails
+set -Eeuo pipefail
 
 cwd="$(pwd)"
 e2e_dir="$(dirname "$(readlink -f "$0")")"
@@ -146,20 +147,20 @@ cp -r "${e2e_dir}/e2e" "${temp_dir}"
 
 # Test: cjs
 echo Test: cjs
-cd "${temp_dir}/e2e/cjs" || exit
+cd "${temp_dir}/e2e/cjs"
 
 echo Installing
 npm i npm-check-updates@latest --registry "${registry_local}"
 
 echo Running test
-REGISTRY="${registry_local}" node "${temp_dir}/e2e/cjs/index.js" || exit 1
+REGISTRY="${registry_local}" node "${temp_dir}/e2e/cjs/index.js"
 
 # Test: esm
 echo Test: esm
-cd "${temp_dir}/e2e/esm" || exit
+cd "${temp_dir}/e2e/esm"
 
 echo Installing
 npm i npm-check-updates@latest --registry "${registry_local}"
 
 echo Running test
-REGISTRY="${registry_local}" node "${temp_dir}/e2e/esm/index.js" || exit 1
+REGISTRY="${registry_local}" node "${temp_dir}/e2e/esm/index.js"

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -113,7 +113,8 @@ package_version="$(node -p "require('./package.json').version")"
 echo "Waiting for npm-check-updates@${package_version} in local registry"
 
 if ! retry npm view "npm-check-updates@${package_version}" version --registry "${registry_local}" >/dev/null 2>&1; then
-  echo "Warning: npm-check-updates@${package_version} not visible in local registry after retry window"
+  echo "npm-check-updates@${package_version} not visible in local registry after retry window" >&2
+  exit 1
 fi
 
 # Test: ncu -v

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -16,6 +16,11 @@ registry_local="http://${registry_addr}"
 registry_log="${temp_dir}/verdaccio.log"
 verdaccio_config="${temp_dir}/verdaccio-config.yaml"
 
+# Keep npm config and cache in the temp dir so the run never touches the user's,
+# and so npx cannot reuse a stale tarball of the same version from a previous run
+export NPM_CONFIG_USERCONFIG="${temp_dir}/npmrc"
+export NPM_CONFIG_CACHE="${temp_dir}/npm-cache"
+
 verdaccio_pid=""
 
 # Cleanup on exit
@@ -28,10 +33,6 @@ cleanup() {
     kill -9 "${verdaccio_pid}" 2>/dev/null || true
     wait "${verdaccio_pid}" 2>/dev/null || true
   fi
-
-  # Delete authToken
-  # WARNING: The original authToken cannot be restored because it is protected and cannot be read with 'npm config get'.
-  npm config delete "//${registry_addr}/:_authToken" || true
 
   # Return to working directory
   cd "${cwd}" || true


### PR DESCRIPTION
See the individual commits.

Would be nice if you could test it on macOS since the script was broken there after f4869532. I plan to change the E2E CI workflow to run on macOS later too.

I manually tested this on Fedora, and CI is also green.