### PR TITLE
Update overrides to fix the remaining npm vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2657,22 +2657,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@verdaccio/middleware/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@verdaccio/package-filter": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/@verdaccio/package-filter/-/package-filter-13.1.0.tgz",
@@ -13218,22 +13202,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/verdaccio-audit/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/verdaccio-htpasswd": {
       "version": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,15 @@
       "eslint-plugin-n": "$eslint-plugin-n",
       "eslint-plugin-promise": "$eslint-plugin-promise"
     },
-    "@cypress/request": {
-      "uuid": "^14.0.0"
+    "@verdaccio/middleware": {
+      "express": {
+        "qs": "^6.15.2"
+      }
+    },
+    "verdaccio-audit": {
+      "express": {
+        "qs": "^6.15.2"
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Naming both parents is required; npm 10 ignores nested rules that skip a level

Should be dropped if/when verdaccio updates those packages.

After #1967 and this PR we should be down to zero vulnerabilities. Not that it's so important since those were mostly devDependencies.