### PR TITLE
feat(pnpm): read registries from pnpm-workspace.yaml

### DIFF
--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -231,7 +231,8 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
     if (packageManager === 'pnpm') {
       // Automatically apply pnpm's minimumReleaseAge from pnpm-workspace.yaml as cooldown if cooldown is not explicitly set.
       // pnpm does not read .npmrc min-release-age; only consult pnpm's own native config.
-      const pnpmWorkspaceConfig = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()
+      // undefined pnpmMajorVersion resolves the installed pnpm; cwd is honored so --cwd finds the right workspace
+      const pnpmWorkspaceConfig = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(undefined, options.cwd)
       if (pnpmWorkspaceConfig != null) {
         const { minimumReleaseAge, minimumReleaseAgeExclude } = pnpmWorkspaceConfig
         // pnpm's minimumReleaseAge is in minutes; convert to days

--- a/src/lib/initOptions.ts
+++ b/src/lib/initOptions.ts
@@ -232,7 +232,7 @@ async function initOptions(runOptions: RunOptions, { cli }: { cli?: boolean } = 
       // Automatically apply pnpm's minimumReleaseAge from pnpm-workspace.yaml as cooldown if cooldown is not explicitly set.
       // pnpm does not read .npmrc min-release-age; only consult pnpm's own native config.
       // undefined pnpmMajorVersion resolves the installed pnpm; cwd is honored so --cwd finds the right workspace
-      const pnpmWorkspaceConfig = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(undefined, options.cwd)
+      const pnpmWorkspaceConfig = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ cwd: options.cwd })
       if (pnpmWorkspaceConfig != null) {
         const { minimumReleaseAge, minimumReleaseAgeExclude } = pnpmWorkspaceConfig
         // pnpm's minimumReleaseAge is in minutes; convert to days

--- a/src/lib/interpolate.ts
+++ b/src/lib/interpolate.ts
@@ -1,0 +1,11 @@
+import { type Index } from '../types/IndexType.ts'
+
+/** Safely interpolates a string as a template string. Supports `${VAR}`, `${VAR-fallback}` and `${VAR:-fallback}`. */
+const interpolate = (s: string, data: Index<string | undefined>): string =>
+  s.replace(/\$\{(\w+)(?:(:)?-([^}]*))?\}/g, (_match, key, colon, fallback = '') => {
+    const value = data[key]
+    // ${VAR:-fallback} uses the fallback when unset or empty; ${VAR-fallback} only when unset
+    return colon ? value || fallback : (value ?? fallback)
+  })
+
+export default interpolate

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -694,11 +694,12 @@ export async function packageAuthorChanged(
   upgradedVersion: VersionSpec,
   options: Options = {},
   npmConfigLocal?: NpmConfig,
+  npmConfigWorkspaceProject?: NpmConfig,
 ): Promise<boolean> {
   const npmConfig = npmApi.findNpmConfig()
   // merge the project/cwd .npmrc so a scoped private registry is respected, like the main fetch path
   const npmConfigMerged = mergeNpmConfigs(
-    { npmConfigUser: { ...npmConfig, fullMetadata: true }, npmConfigLocal },
+    { npmConfigUser: { ...npmConfig, fullMetadata: true }, npmConfigLocal, npmConfigWorkspaceProject },
     options,
   )
   const result = await fetchPartialPackument(packageName, ['versions'], null, npmConfigMerged)
@@ -777,7 +778,15 @@ async function fetchUpgradedPackument(
     )
   } catch (err: any) {
     if (options.retry && ++retried <= options.retry) {
-      return fetchUpgradedPackument(packageName, fieldsExtended, currentVersion, options, retried, npmConfigLocal)
+      return fetchUpgradedPackument(
+        packageName,
+        fieldsExtended,
+        currentVersion,
+        options,
+        retried,
+        npmConfigLocal,
+        npmConfigWorkspaceProject,
+      )
     }
 
     throw err
@@ -963,9 +972,18 @@ export const getDistTags = async (
   packageName: string,
   options: Options = {},
   npmConfigLocal?: NpmConfig,
+  npmConfigWorkspaceProject?: NpmConfig,
 ): Promise<Index<Version>> => {
   // currentVersion is only used to short circuit unfetchable specs, which does not apply here
-  const packument = await npmApi.fetchUpgradedPackumentMemo(packageName, ['dist-tags'], '', options, 0, npmConfigLocal)
+  const packument = await npmApi.fetchUpgradedPackumentMemo(
+    packageName,
+    ['dist-tags'],
+    '',
+    options,
+    0,
+    npmConfigLocal,
+    npmConfigWorkspaceProject,
+  )
   return packument?.['dist-tags'] || {}
 }
 
@@ -981,10 +999,14 @@ export const getEngines = async (
   version: Version,
   options: Options = {},
   npmConfigLocal?: NpmConfig,
+  npmConfigWorkspaceProject?: NpmConfig,
 ): Promise<Index<VersionSpec | undefined>> => {
   const npmConfig = npmApi.findNpmConfig()
   // merge the project/cwd .npmrc so a scoped private registry is respected, like the main fetch path
-  const npmConfigMerged = mergeNpmConfigs({ npmConfigUser: { ...npmConfig }, npmConfigLocal }, options)
+  const npmConfigMerged = mergeNpmConfigs(
+    { npmConfigUser: { ...npmConfig }, npmConfigLocal, npmConfigWorkspaceProject },
+    options,
+  )
   const result = await fetchPartialPackument(packageName, [`engines`], null, npmConfigMerged, version)
   return result.engines || {}
 }

--- a/src/package-managers/pnpm.ts
+++ b/src/package-managers/pnpm.ts
@@ -32,7 +32,7 @@ type PnpmList = {
 }[]
 
 /** Shape of the pnpm-workspace.yaml minimumReleaseAge settings. */
-export interface PnpmWorkspaceMinimumReleaseAge {
+interface PnpmWorkspaceMinimumReleaseAge {
   /** Minimum release age in minutes (pnpm's native unit). */
   minimumReleaseAge: number
   /** List of package name glob patterns excluded from the minimum release age constraint. */
@@ -43,6 +43,14 @@ export interface PnpmWorkspaceMinimumReleaseAge {
 interface MinimumReleaseAgeLayer {
   minimumReleaseAge?: number
   minimumReleaseAgeExclude: string[]
+}
+
+/** The registries resolved from pnpm's `registries` and `registry` settings. */
+interface PnpmWorkspaceRegistries {
+  /** Registry used for packages that do not match a scoped entry. */
+  default?: string
+  /** Registries keyed by package scope, e.g. `{ '@myorg': 'https://registry.example.com/' }`. */
+  scoped: Index<string>
 }
 
 /** Coerces an arbitrary config value into a non-negative minimumReleaseAge number (in minutes), or undefined if invalid. */
@@ -199,14 +207,6 @@ const getPnpmWorkspaceMinimumReleaseAge = async (
   return { minimumReleaseAge, minimumReleaseAgeExclude }
 }
 
-/** The registries resolved from pnpm's `registries` and `registry` settings. */
-export interface PnpmWorkspaceRegistries {
-  /** Registry used for packages that do not match a scoped entry. */
-  default?: string
-  /** Registries keyed by package scope, e.g. `{ '@myorg': 'https://registry.example.com/' }`. */
-  scoped: Index<string>
-}
-
 /** Matches an environment variable placeholder that interpolate did not resolve, e.g. `${MY_REGISTRY}`. */
 const envPlaceholder = /\$\{[^}]*\}/
 
@@ -361,14 +361,6 @@ const withNpmWorkspaceConfig =
     return getVersion(packageName, currentVersion, options, registries, workspaceNpmrc)
   }
 
-export const distTag = withNpmWorkspaceConfig(npm.distTag)
-export const greatest = withNpmWorkspaceConfig(npm.greatest)
-export const latest = withNpmWorkspaceConfig(npm.latest)
-export const minor = withNpmWorkspaceConfig(npm.minor)
-export const newest = withNpmWorkspaceConfig(npm.newest)
-export const patch = withNpmWorkspaceConfig(npm.patch)
-export const semver = withNpmWorkspaceConfig(npm.semver)
-
 /** Builds the pnpm argv from the given args and npm options. */
 const buildArgs = (args: string | string[], npmOptions: NpmOptions): string[] => [
   ...(npmOptions.global ? ['global'] : []),
@@ -393,8 +385,6 @@ async function spawnPnpm(
   return spawnCommand('pnpm', buildArgs(args, npmOptions), spawnPleaseOptions, spawnOptions)
 }
 
-export { defaultPrefix, getPeerDependencies } from './npm.ts'
-
 /**
  * Wraps an npm function whose last three parameters are options plus the two npm config layers, supplying them
  * from pnpm's config. This splits the pnpm config across the same two layers withNpmWorkspaceConfig uses, so
@@ -414,6 +404,14 @@ const withPnpmConfig =
     return fn(...leading, options, registries, workspaceNpmrc)
   }
 
+export { defaultPrefix, getPeerDependencies } from './npm.ts'
+export const distTag = withNpmWorkspaceConfig(npm.distTag)
+export const greatest = withNpmWorkspaceConfig(npm.greatest)
+export const latest = withNpmWorkspaceConfig(npm.latest)
+export const minor = withNpmWorkspaceConfig(npm.minor)
+export const newest = withNpmWorkspaceConfig(npm.newest)
+export const patch = withNpmWorkspaceConfig(npm.patch)
+export const semver = withNpmWorkspaceConfig(npm.semver)
 export const getDistTags = withPnpmConfig(npm.getDistTags)
 export const getEngines = withPnpmConfig(npm.getEngines)
 export const packageAuthorChanged = withPnpmConfig(npm.packageAuthorChanged)

--- a/src/package-managers/pnpm.ts
+++ b/src/package-managers/pnpm.ts
@@ -18,7 +18,6 @@ import { type SpawnOptions } from '../types/SpawnOptions.ts'
 import { type SpawnPleaseOptions } from '../types/SpawnPleaseOptions.ts'
 import { type SpawnResult } from '../types/SpawnResult.ts'
 import { type Version } from '../types/Version.ts'
-import { type VersionSpec } from '../types/VersionSpec.ts'
 import * as npm from './npm.ts'
 
 // return type of pnpm ls --json
@@ -158,15 +157,15 @@ const getPnpmMajorVersion = async (): Promise<number | null> => {
  * minimumReleaseAgeExclude patterns are merged across all considered layers. Returns null if no
  * layer defines a minimumReleaseAge.
  *
- * @param pnpmMajorVersion Optional override, used by tests to avoid spawning pnpm.
+ * @param options.pnpmMajorVersion Optional override, used by tests to avoid spawning pnpm.
  * undefined resolves the major version from the installed pnpm. null reads both globals.
  * A number selects config.yaml for >= 11 and rc for <= 10.
- * @param cwd Directory to search upwards from for pnpm-workspace.yaml. Defaults to process.cwd().
+ * @param options.cwd Directory to search upwards from for pnpm-workspace.yaml. Defaults to process.cwd().
  */
 const getPnpmWorkspaceMinimumReleaseAge = async (
-  pnpmMajorVersion?: number | null,
-  cwd?: string,
+  options: { pnpmMajorVersion?: number | null; cwd?: string } = {},
 ): Promise<PnpmWorkspaceMinimumReleaseAge | null> => {
+  const { pnpmMajorVersion, cwd } = options
   const globalConfigDir = getPnpmGlobalConfigDir()
   const pnpmWorkspacePath = await findUp('pnpm-workspace.yaml', { cwd })
   const globalConfigYamlPath = path.join(globalConfigDir, 'config.yaml')
@@ -259,9 +258,12 @@ const resolvePnpmRegistries = async (pnpmWorkspacePath?: string): Promise<PnpmWo
   return { default: defaultRegistry, scoped }
 }
 
-/** Reads registries settings from pnpm's config, searching upwards from cwd for pnpm-workspace.yaml. */
-const getPnpmWorkspaceRegistries = async (cwd?: string): Promise<PnpmWorkspaceRegistries> =>
-  resolvePnpmRegistries(await findUp('pnpm-workspace.yaml', { cwd }))
+/** Reads registries settings from pnpm's config, searching upwards from cwd for pnpm-workspace.yaml.
+ *
+ * @param options.cwd Directory to search upwards from for pnpm-workspace.yaml. Defaults to process.cwd().
+ */
+const getPnpmWorkspaceRegistries = async (options: { cwd?: string } = {}): Promise<PnpmWorkspaceRegistries> =>
+  resolvePnpmRegistries(await findUp('pnpm-workspace.yaml', { cwd: options.cwd }))
 
 /** Parses the output of `pnpm ls -g --json` into a { name: version } index. */
 const parseList = (stdout: string, command: string, stderr?: string): Index<string | undefined> => {
@@ -291,15 +293,24 @@ export const list = async (options: Options = {}): Promise<Index<string | undefi
   return parseList(stdout, command, stderr)
 }
 
-/** Reads the npmrc that sits next to pnpm-workspace.yaml, or an empty config if it does not exist. */
-const npmConfigFromWorkspaceNpmrc = async (options: Options, pnpmWorkspaceDir: string): Promise<NpmConfig> => {
+/**
+ * Reads and parses the npmrc that sits next to pnpm-workspace.yaml, or null if it does not exist.
+ * Memoized on the directory, like readPnpmConfig, so a workspace with many packages reads and parses it once.
+ */
+const readWorkspaceNpmrc = memoize(async (pnpmWorkspaceDir: string): Promise<NpmConfig | null> => {
   const pnpmWorkspaceConfigPath = path.join(pnpmWorkspaceDir, '.npmrc')
   const contents = await fs.readFile(pnpmWorkspaceConfigPath, 'utf-8').catch(() => null)
-  if (contents == null) return {}
+  return contents == null ? null : npm.normalizeNpmConfig(ini.parse(contents), pnpmWorkspaceDir)
+})
 
-  print(options, `\nUsing pnpm workspace config at ${pnpmWorkspaceConfigPath}:`, 'verbose')
+/** Reads the npmrc that sits next to pnpm-workspace.yaml, or an empty config if it does not exist. */
+const npmConfigFromWorkspaceNpmrc = async (options: Options, pnpmWorkspaceDir: string): Promise<NpmConfig> => {
+  const config = await readWorkspaceNpmrc(pnpmWorkspaceDir)
+  if (config == null) return {}
 
-  return npm.normalizeNpmConfig(ini.parse(contents), pnpmWorkspaceDir)
+  print(options, `\nUsing pnpm workspace config at ${path.join(pnpmWorkspaceDir, '.npmrc')}:`, 'verbose')
+
+  return config
 }
 
 /** pnpm's config split by the npm config layer each part belongs to, since they rank differently. */
@@ -384,53 +395,28 @@ async function spawnPnpm(
 
 export { defaultPrefix, getPeerDependencies } from './npm.ts'
 
-// The wrappers below split the pnpm config across the same two layers withNpmWorkspaceConfig uses, so that every
-// code path resolves the same registry. Otherwise a project resolves versions and engines from two different ones.
-
 /**
- * Fetches all dist-tags published for a package.
- *
- * @param packageName
- * @returns Promised {tag: version} collection
+ * Wraps an npm function whose last three parameters are options plus the two npm config layers, supplying them
+ * from pnpm's config. This splits the pnpm config across the same two layers withNpmWorkspaceConfig uses, so
+ * that every code path resolves the same registry. Otherwise a project resolves versions and engines from two
+ * different ones.
  */
-export const getDistTags = async (packageName: string, options: Options = {}): Promise<Index<Version>> => {
-  const { registries, workspaceNpmrc } = await npmConfigFromPnpmWorkspace(options)
-  return npm.getDistTags(packageName, options, registries, workspaceNpmrc)
-}
+const withPnpmConfig =
+  <Args extends unknown[], Result>(
+    fn: (...args: [...Args, Options, NpmConfig, NpmConfig]) => Promise<Result>,
+  ): ((...args: [...Args, Options?]) => Promise<Result>) =>
+  async (...args) => {
+    // fn.length is the count of its params up to (excluding) the first with a default value, i.e. leading args
+    // before `options: Options = {}`.
+    const leading = args.slice(0, fn.length) as Args
+    const options = (args[fn.length] ?? {}) as Options
+    const { registries, workspaceNpmrc } = await npmConfigFromPnpmWorkspace(options)
+    return fn(...leading, options, registries, workspaceNpmrc)
+  }
 
-/**
- * Fetches the engines list from the registry for a specific package version.
- *
- * @param packageName
- * @param version
- * @returns Promised engines collection
- */
-export const getEngines = async (
-  packageName: string,
-  version: Version,
-  options: Options = {},
-): Promise<Index<VersionSpec | undefined>> => {
-  const { registries, workspaceNpmrc } = await npmConfigFromPnpmWorkspace(options)
-  return npm.getEngines(packageName, version, options, registries, workspaceNpmrc)
-}
-
-/**
- * Check if package author changed between current and upgraded version.
- *
- * @param packageName Name of the package
- * @param currentVersion Current version declaration (may be range)
- * @param upgradedVersion Upgraded version declaration (may be range)
- * @returns A promise that fulfills with boolean value.
- */
-export const packageAuthorChanged = async (
-  packageName: string,
-  currentVersion: VersionSpec,
-  upgradedVersion: VersionSpec,
-  options: Options = {},
-): Promise<boolean> => {
-  const { registries, workspaceNpmrc } = await npmConfigFromPnpmWorkspace(options)
-  return npm.packageAuthorChanged(packageName, currentVersion, upgradedVersion, options, registries, workspaceNpmrc)
-}
+export const getDistTags = withPnpmConfig(npm.getDistTags)
+export const getEngines = withPnpmConfig(npm.getEngines)
+export const packageAuthorChanged = withPnpmConfig(npm.packageAuthorChanged)
 
 export default spawnPnpm
 

--- a/src/package-managers/pnpm.ts
+++ b/src/package-managers/pnpm.ts
@@ -5,6 +5,7 @@ import memoize from 'fast-memoize'
 import { findUp } from 'find-up'
 import ini from 'ini'
 import { parse as parseYaml } from 'yaml'
+import interpolate from '../lib/interpolate.ts'
 import keyValueBy from '../lib/keyValueBy.ts'
 import { print } from '../lib/logging.ts'
 import spawnCommand from '../lib/spawnCommand.ts'
@@ -199,7 +200,7 @@ const getPnpmWorkspaceMinimumReleaseAge = async (
   return { minimumReleaseAge, minimumReleaseAgeExclude }
 }
 
-/** Shape of the pnpm-workspace.yaml registries setting. */
+/** The registries resolved from pnpm's `registries` and `registry` settings. */
 export interface PnpmWorkspaceRegistries {
   /** Registry used for packages that do not match a scoped entry. */
   default?: string
@@ -207,14 +208,35 @@ export interface PnpmWorkspaceRegistries {
   scoped: Index<string>
 }
 
-/** Extracts the string-valued registries from an already-parsed config object, keyed by `default` or by scope. */
-const parseRegistries = (parsed: Record<string, unknown> | null): Index<string> => {
-  const registries = parsed?.registries
-  if (typeof registries !== 'object' || registries === null || Array.isArray(registries)) return {}
+/** Matches an environment variable placeholder that interpolate did not resolve, e.g. `${MY_REGISTRY}`. */
+const envPlaceholder = /\$\{[^}]*\}/
 
-  return keyValueBy(registries as Index<unknown>, (scope, registry) =>
-    typeof registry === 'string' && registry.trim() !== '' ? { [scope]: registry } : null,
-  )
+/**
+ * Extracts the string-valued registries from an already-parsed config object, keyed by `default` or by scope.
+ *
+ * pnpm accepts both the `registries` map and the plain `registry` setting, which the docs describe as equivalent to
+ * `registries.default`. The more specific `registries.default` wins when a single layer defines both.
+ *
+ * @param expandEnv Whether to expand `${VAR}` placeholders in the registry URLs. pnpm only expands them in
+ * trusted locations, i.e. its global config. Since pnpm 11.5.3 a registry URL containing a placeholder in
+ * pnpm-workspace.yaml is ignored instead, since that file is committed and could otherwise be used to leak
+ * environment secrets to an attacker-controlled registry (GHSA-3qhv-2rgh-x77r).
+ */
+const parseRegistries = (parsed: Record<string, unknown> | null, expandEnv: boolean): Index<string> => {
+  const registries = parsed?.registries
+  const scopes: Index<unknown> =
+    typeof registries === 'object' && registries !== null && !Array.isArray(registries)
+      ? (registries as Index<unknown>)
+      : {}
+
+  return keyValueBy({ default: parsed?.registry, ...scopes }, (scope, registry) => {
+    if (typeof registry !== 'string') return null
+
+    const value = expandEnv ? interpolate(registry, process.env) : registry
+    // an empty value, or one left over from an unexpanded or unset placeholder, would produce a bogus URL,
+    // so drop the registry rather than request it
+    return value.trim() === '' || envPlaceholder.test(value) ? null : { [scope]: value }
+  })
 }
 
 /**
@@ -230,8 +252,8 @@ const resolvePnpmRegistries = async (pnpmWorkspacePath?: string): Promise<PnpmWo
   ])
 
   const { default: defaultRegistry, ...scoped } = {
-    ...parseRegistries(globalConfig),
-    ...parseRegistries(workspaceConfig),
+    ...parseRegistries(globalConfig, true),
+    ...parseRegistries(workspaceConfig, false),
   }
 
   return { default: defaultRegistry, scoped }
@@ -280,37 +302,53 @@ const npmConfigFromWorkspaceNpmrc = async (options: Options, pnpmWorkspaceDir: s
   return npm.normalizeNpmConfig(ini.parse(contents), pnpmWorkspaceDir)
 }
 
+/** pnpm's config split by the npm config layer each part belongs to, since they rank differently. */
+interface PnpmNpmConfig {
+  /**
+   * pnpm's own registries/registry settings, merged as npmConfigLocal so they outrank the ambient npm config.
+   * Otherwise the `registry=` that `npm config set registry` leaves in the user .npmrc would silently win over
+   * pnpm-workspace.yaml, which is the very thing these settings are read to fix.
+   */
+  registries: NpmConfig
+  /**
+   * The npmrc next to pnpm-workspace.yaml, merged as npmConfigWorkspaceProject so the local npm config still
+   * overrides it, as decided in #1285.
+   */
+  workspaceNpmrc: NpmConfig
+}
+
 // Read the npmrc next to pnpm-workspace.yaml, plus pnpm's own registries setting, and convert them to npm config variables.
 // Defined as a memoized function to read the config files only once, and only if pnpm is being used.
-const npmConfigFromPnpmWorkspace = memoize(async (options: Options): Promise<NpmConfig> => {
+const npmConfigFromPnpmWorkspace = memoize(async (options: Options): Promise<PnpmNpmConfig> => {
   const pnpmWorkspacePath = await findUp('pnpm-workspace.yaml', { cwd: options.cwd })
   const pnpmWorkspaceDir = pnpmWorkspacePath ? path.dirname(pnpmWorkspacePath) : undefined
 
-  const [npmrcConfig, { default: defaultRegistry, scoped }] = await Promise.all([
+  const [workspaceNpmrc, { default: defaultRegistry, scoped }] = await Promise.all([
     pnpmWorkspaceDir ? npmConfigFromWorkspaceNpmrc(options, pnpmWorkspaceDir) : {},
     resolvePnpmRegistries(pnpmWorkspacePath),
   ])
 
-  // pnpm's registries take precedence over the .npmrc that sits next to pnpm-workspace.yaml
-  const config: NpmConfig = {
-    ...npmrcConfig,
+  const registries: NpmConfig = {
     ...keyValueBy(scoped, (scope, registry) => ({ [`${scope}:registry`]: registry })),
     ...(defaultRegistry ? { registry: defaultRegistry } : null),
   }
 
-  // a pnpm project with no workspace config at all resolves to an empty config, which is not worth printing
-  if (Object.keys(config).length > 0) {
-    print(options, config, 'verbose')
+  // a pnpm project that configures no registries resolves to an empty config, which is not worth printing
+  if (Object.keys(registries).length > 0) {
+    print(options, '\npnpm registries in npm format:', 'verbose')
+    print(options, registries, 'verbose')
   }
 
-  return config
+  return { registries, workspaceNpmrc }
 })
 
-/** Wraps a GetVersion function and passes the npmrc located next to the pnpm-workspace.yaml if it exists. */
+/** Wraps a GetVersion function and passes pnpm's registries plus the npmrc located next to the pnpm-workspace.yaml if it exists. */
 const withNpmWorkspaceConfig =
   (getVersion: GetVersion): GetVersion =>
-  async (packageName, currentVersion, options = {}) =>
-    getVersion(packageName, currentVersion, options, {}, await npmConfigFromPnpmWorkspace(options))
+  async (packageName, currentVersion, options = {}) => {
+    const { registries, workspaceNpmrc } = await npmConfigFromPnpmWorkspace(options)
+    return getVersion(packageName, currentVersion, options, registries, workspaceNpmrc)
+  }
 
 export const distTag = withNpmWorkspaceConfig(npm.distTag)
 export const greatest = withNpmWorkspaceConfig(npm.greatest)
@@ -346,9 +384,8 @@ async function spawnPnpm(
 
 export { defaultPrefix, getPeerDependencies } from './npm.ts'
 
-// The wrappers below pass the pnpm config as npmConfigWorkspaceProject, the same layer withNpmWorkspaceConfig
-// uses, so that every code path resolves the same registry. Passing it as npmConfigLocal would rank it above the
-// ambient npm config and make these lookups disagree with the version lookups.
+// The wrappers below split the pnpm config across the same two layers withNpmWorkspaceConfig uses, so that every
+// code path resolves the same registry. Otherwise a project resolves versions and engines from two different ones.
 
 /**
  * Fetches all dist-tags published for a package.
@@ -356,8 +393,10 @@ export { defaultPrefix, getPeerDependencies } from './npm.ts'
  * @param packageName
  * @returns Promised {tag: version} collection
  */
-export const getDistTags = async (packageName: string, options: Options = {}): Promise<Index<Version>> =>
-  npm.getDistTags(packageName, options, undefined, await npmConfigFromPnpmWorkspace(options))
+export const getDistTags = async (packageName: string, options: Options = {}): Promise<Index<Version>> => {
+  const { registries, workspaceNpmrc } = await npmConfigFromPnpmWorkspace(options)
+  return npm.getDistTags(packageName, options, registries, workspaceNpmrc)
+}
 
 /**
  * Fetches the engines list from the registry for a specific package version.
@@ -370,8 +409,10 @@ export const getEngines = async (
   packageName: string,
   version: Version,
   options: Options = {},
-): Promise<Index<VersionSpec | undefined>> =>
-  npm.getEngines(packageName, version, options, undefined, await npmConfigFromPnpmWorkspace(options))
+): Promise<Index<VersionSpec | undefined>> => {
+  const { registries, workspaceNpmrc } = await npmConfigFromPnpmWorkspace(options)
+  return npm.getEngines(packageName, version, options, registries, workspaceNpmrc)
+}
 
 /**
  * Check if package author changed between current and upgraded version.
@@ -386,15 +427,10 @@ export const packageAuthorChanged = async (
   currentVersion: VersionSpec,
   upgradedVersion: VersionSpec,
   options: Options = {},
-): Promise<boolean> =>
-  npm.packageAuthorChanged(
-    packageName,
-    currentVersion,
-    upgradedVersion,
-    options,
-    undefined,
-    await npmConfigFromPnpmWorkspace(options),
-  )
+): Promise<boolean> => {
+  const { registries, workspaceNpmrc } = await npmConfigFromPnpmWorkspace(options)
+  return npm.packageAuthorChanged(packageName, currentVersion, upgradedVersion, options, registries, workspaceNpmrc)
+}
 
 export default spawnPnpm
 

--- a/src/package-managers/pnpm.ts
+++ b/src/package-managers/pnpm.ts
@@ -17,6 +17,7 @@ import { type SpawnOptions } from '../types/SpawnOptions.ts'
 import { type SpawnPleaseOptions } from '../types/SpawnPleaseOptions.ts'
 import { type SpawnResult } from '../types/SpawnResult.ts'
 import { type Version } from '../types/Version.ts'
+import { type VersionSpec } from '../types/VersionSpec.ts'
 import * as npm from './npm.ts'
 
 // return type of pnpm ls --json
@@ -29,30 +30,6 @@ type PnpmList = {
     resolved: string
   }>
 }[]
-
-/** Reads the npmrc config file from the pnpm-workspace.yaml directory. */
-const npmConfigFromPnpmWorkspace = memoize(async (options: Options): Promise<NpmConfig> => {
-  const pnpmWorkspacePath = await findUp('pnpm-workspace.yaml')
-  if (!pnpmWorkspacePath) return {}
-
-  const pnpmWorkspaceDir = path.dirname(pnpmWorkspacePath)
-  const pnpmWorkspaceConfigPath = path.join(pnpmWorkspaceDir, '.npmrc')
-
-  let pnpmWorkspaceConfig
-  try {
-    pnpmWorkspaceConfig = await fs.readFile(pnpmWorkspaceConfigPath, 'utf-8')
-  } catch (e) {
-    return {}
-  }
-
-  print(options, `\nUsing pnpm workspace config at ${pnpmWorkspaceConfigPath}:`, 'verbose')
-
-  const config = npm.normalizeNpmConfig(ini.parse(pnpmWorkspaceConfig), pnpmWorkspaceDir)
-
-  print(options, config, 'verbose')
-
-  return config
-})
 
 /** Shape of the pnpm-workspace.yaml minimumReleaseAge settings. */
 export interface PnpmWorkspaceMinimumReleaseAge {
@@ -116,26 +93,34 @@ const getPnpmGlobalConfigDir = (): string => {
   return path.join(os.homedir(), '.config', 'pnpm')
 }
 
-/** Reads and parses a config file, returning its minimumReleaseAge settings, or null if it does not exist or cannot be parsed. */
+/**
+ * Reads and parses a pnpm config file, or null if it does not exist or cannot be parsed.
+ * Memoized since the same file backs several settings, so it is read and parsed once per run, like parseNpmrc.
+ */
+const readPnpmConfig = memoize(
+  async (filePath: string, format: 'yaml' | 'ini'): Promise<Record<string, unknown> | null> => {
+    let content: string
+    try {
+      content = await fs.readFile(filePath, 'utf-8')
+    } catch {
+      return null
+    }
+
+    try {
+      return (format === 'yaml' ? parseYaml(content) : ini.parse(content)) ?? {}
+    } catch {
+      return null
+    }
+  },
+)
+
+/** Reads and parses a config file, returning its minimumReleaseAge settings, or null if unavailable. */
 const readMinimumReleaseAgeLayer = async (
   filePath: string,
   format: 'yaml' | 'ini',
 ): Promise<MinimumReleaseAgeLayer | null> => {
-  let content: string
-  try {
-    content = await fs.readFile(filePath, 'utf-8')
-  } catch {
-    return null
-  }
-
-  let parsed: Record<string, unknown>
-  try {
-    parsed = (format === 'yaml' ? parseYaml(content) : ini.parse(content)) ?? {}
-  } catch {
-    return null
-  }
-
-  return parseMinimumReleaseAgeLayer(parsed)
+  const parsed = await readPnpmConfig(filePath, format)
+  return parsed ? parseMinimumReleaseAgeLayer(parsed) : null
 }
 
 /** Returns true if a path exists. */
@@ -175,12 +160,14 @@ const getPnpmMajorVersion = async (): Promise<number | null> => {
  * @param pnpmMajorVersion Optional override, used by tests to avoid spawning pnpm.
  * undefined resolves the major version from the installed pnpm. null reads both globals.
  * A number selects config.yaml for >= 11 and rc for <= 10.
+ * @param cwd Directory to search upwards from for pnpm-workspace.yaml. Defaults to process.cwd().
  */
 const getPnpmWorkspaceMinimumReleaseAge = async (
   pnpmMajorVersion?: number | null,
+  cwd?: string,
 ): Promise<PnpmWorkspaceMinimumReleaseAge | null> => {
   const globalConfigDir = getPnpmGlobalConfigDir()
-  const pnpmWorkspacePath = await findUp('pnpm-workspace.yaml')
+  const pnpmWorkspacePath = await findUp('pnpm-workspace.yaml', { cwd })
   const globalConfigYamlPath = path.join(globalConfigDir, 'config.yaml')
   const globalRcPath = path.join(globalConfigDir, 'rc')
 
@@ -212,6 +199,48 @@ const getPnpmWorkspaceMinimumReleaseAge = async (
   return { minimumReleaseAge, minimumReleaseAgeExclude }
 }
 
+/** Shape of the pnpm-workspace.yaml registries setting. */
+export interface PnpmWorkspaceRegistries {
+  /** Registry used for packages that do not match a scoped entry. */
+  default?: string
+  /** Registries keyed by package scope, e.g. `{ '@myorg': 'https://registry.example.com/' }`. */
+  scoped: Index<string>
+}
+
+/** Extracts the string-valued registries from an already-parsed config object, keyed by `default` or by scope. */
+const parseRegistries = (parsed: Record<string, unknown> | null): Index<string> => {
+  const registries = parsed?.registries
+  if (typeof registries !== 'object' || registries === null || Array.isArray(registries)) return {}
+
+  return keyValueBy(registries as Index<unknown>, (scope, registry) =>
+    typeof registry === 'string' && registry.trim() !== '' ? { [scope]: registry } : null,
+  )
+}
+
+/**
+ * Resolves registries settings from pnpm's config layers, given an already-resolved pnpm-workspace.yaml path.
+ *
+ * pnpm-workspace.yaml takes precedence over pnpm's global config per key, including `default`.
+ * registries requires pnpm >= 11, so the pnpm <= 10 rc file is not consulted.
+ */
+const resolvePnpmRegistries = async (pnpmWorkspacePath?: string): Promise<PnpmWorkspaceRegistries> => {
+  const [workspaceConfig, globalConfig] = await Promise.all([
+    pnpmWorkspacePath ? readPnpmConfig(pnpmWorkspacePath, 'yaml') : null,
+    readPnpmConfig(path.join(getPnpmGlobalConfigDir(), 'config.yaml'), 'yaml'),
+  ])
+
+  const { default: defaultRegistry, ...scoped } = {
+    ...parseRegistries(globalConfig),
+    ...parseRegistries(workspaceConfig),
+  }
+
+  return { default: defaultRegistry, scoped }
+}
+
+/** Reads registries settings from pnpm's config, searching upwards from cwd for pnpm-workspace.yaml. */
+const getPnpmWorkspaceRegistries = async (cwd?: string): Promise<PnpmWorkspaceRegistries> =>
+  resolvePnpmRegistries(await findUp('pnpm-workspace.yaml', { cwd }))
+
 /** Parses the output of `pnpm ls -g --json` into a { name: version } index. */
 const parseList = (stdout: string, command: string, stderr?: string): Index<string | undefined> => {
   const result = npm.parseJson<PnpmList>(stdout, { command, stderr })
@@ -239,6 +268,43 @@ export const list = async (options: Options = {}): Promise<Index<string | undefi
 
   return parseList(stdout, command, stderr)
 }
+
+/** Reads the npmrc that sits next to pnpm-workspace.yaml, or an empty config if it does not exist. */
+const npmConfigFromWorkspaceNpmrc = async (options: Options, pnpmWorkspaceDir: string): Promise<NpmConfig> => {
+  const pnpmWorkspaceConfigPath = path.join(pnpmWorkspaceDir, '.npmrc')
+  const contents = await fs.readFile(pnpmWorkspaceConfigPath, 'utf-8').catch(() => null)
+  if (contents == null) return {}
+
+  print(options, `\nUsing pnpm workspace config at ${pnpmWorkspaceConfigPath}:`, 'verbose')
+
+  return npm.normalizeNpmConfig(ini.parse(contents), pnpmWorkspaceDir)
+}
+
+// Read the npmrc next to pnpm-workspace.yaml, plus pnpm's own registries setting, and convert them to npm config variables.
+// Defined as a memoized function to read the config files only once, and only if pnpm is being used.
+const npmConfigFromPnpmWorkspace = memoize(async (options: Options): Promise<NpmConfig> => {
+  const pnpmWorkspacePath = await findUp('pnpm-workspace.yaml', { cwd: options.cwd })
+  const pnpmWorkspaceDir = pnpmWorkspacePath ? path.dirname(pnpmWorkspacePath) : undefined
+
+  const [npmrcConfig, { default: defaultRegistry, scoped }] = await Promise.all([
+    pnpmWorkspaceDir ? npmConfigFromWorkspaceNpmrc(options, pnpmWorkspaceDir) : {},
+    resolvePnpmRegistries(pnpmWorkspacePath),
+  ])
+
+  // pnpm's registries take precedence over the .npmrc that sits next to pnpm-workspace.yaml
+  const config: NpmConfig = {
+    ...npmrcConfig,
+    ...keyValueBy(scoped, (scope, registry) => ({ [`${scope}:registry`]: registry })),
+    ...(defaultRegistry ? { registry: defaultRegistry } : null),
+  }
+
+  // a pnpm project with no workspace config at all resolves to an empty config, which is not worth printing
+  if (Object.keys(config).length > 0) {
+    print(options, config, 'verbose')
+  }
+
+  return config
+})
 
 /** Wraps a GetVersion function and passes the npmrc located next to the pnpm-workspace.yaml if it exists. */
 const withNpmWorkspaceConfig =
@@ -278,12 +344,63 @@ async function spawnPnpm(
   return spawnCommand('pnpm', buildArgs(args, npmOptions), spawnPleaseOptions, spawnOptions)
 }
 
-export { defaultPrefix, getDistTags, getPeerDependencies, getEngines, packageAuthorChanged } from './npm.ts'
+export { defaultPrefix, getPeerDependencies } from './npm.ts'
+
+// The wrappers below pass the pnpm config as npmConfigWorkspaceProject, the same layer withNpmWorkspaceConfig
+// uses, so that every code path resolves the same registry. Passing it as npmConfigLocal would rank it above the
+// ambient npm config and make these lookups disagree with the version lookups.
+
+/**
+ * Fetches all dist-tags published for a package.
+ *
+ * @param packageName
+ * @returns Promised {tag: version} collection
+ */
+export const getDistTags = async (packageName: string, options: Options = {}): Promise<Index<Version>> =>
+  npm.getDistTags(packageName, options, undefined, await npmConfigFromPnpmWorkspace(options))
+
+/**
+ * Fetches the engines list from the registry for a specific package version.
+ *
+ * @param packageName
+ * @param version
+ * @returns Promised engines collection
+ */
+export const getEngines = async (
+  packageName: string,
+  version: Version,
+  options: Options = {},
+): Promise<Index<VersionSpec | undefined>> =>
+  npm.getEngines(packageName, version, options, undefined, await npmConfigFromPnpmWorkspace(options))
+
+/**
+ * Check if package author changed between current and upgraded version.
+ *
+ * @param packageName Name of the package
+ * @param currentVersion Current version declaration (may be range)
+ * @param upgradedVersion Upgraded version declaration (may be range)
+ * @returns A promise that fulfills with boolean value.
+ */
+export const packageAuthorChanged = async (
+  packageName: string,
+  currentVersion: VersionSpec,
+  upgradedVersion: VersionSpec,
+  options: Options = {},
+): Promise<boolean> =>
+  npm.packageAuthorChanged(
+    packageName,
+    currentVersion,
+    upgradedVersion,
+    options,
+    undefined,
+    await npmConfigFromPnpmWorkspace(options),
+  )
 
 export default spawnPnpm
 
 export const pnpmApi = {
   buildArgs,
   getPnpmWorkspaceMinimumReleaseAge,
+  getPnpmWorkspaceRegistries,
   parseList,
 }

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -5,6 +5,7 @@ import memoize from 'fast-memoize'
 import { parse as parseYaml } from 'yaml'
 import exists from '../lib/exists.ts'
 import findLockfile from '../lib/findLockfile.ts'
+import interpolate from '../lib/interpolate.ts'
 import { keyValueBy } from '../lib/keyValueBy.ts'
 import { print } from '../lib/logging.ts'
 import parseCooldown from '../lib/parseCooldown.ts'
@@ -48,14 +49,6 @@ export interface YarnMinimalAgeGate {
   /** List of package names excluded from the age gate check. */
   npmPreapprovedPackages: string[]
 }
-
-/** Safely interpolates a string as a template string. Supports `${VAR}`, `${VAR-fallback}` and `${VAR:-fallback}`. */
-const interpolate = (s: string, data: Index<string | undefined>): string =>
-  s.replace(/\$\{(\w+)(?:(:)?-([^}]*))?\}/g, (_match, key, colon, fallback = '') => {
-    const value = data[key]
-    // ${VAR:-fallback} uses the fallback when unset or empty; ${VAR-fallback} only when unset
-    return colon ? value || fallback : (value ?? fallback)
-  })
 
 /** Reads an auth token from a yarn config, interpolates it, and returns it as an npm config key-value pair. */
 export const npmAuthTokenKeyValue = (npmConfig: Index<string | boolean>) => (dep: string, scopedConfig: NpmScope) => {

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -1645,7 +1645,7 @@ describe('cooldown', () => {
         'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  - react\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 11 })
 
       expect(result).toStrictEqual({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['react'] })
     })
@@ -1657,13 +1657,13 @@ describe('cooldown', () => {
         'minimumReleaseAge=10080\nminimumReleaseAgeExclude=["react"]\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(10)
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 10 })
 
       expect(result).toStrictEqual({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['react'] })
     })
 
     it('returns null when no config layer defines minimumReleaseAge', async () => {
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 11 })
       expect(result).toBeNull()
     })
 
@@ -1677,7 +1677,7 @@ describe('cooldown', () => {
         'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  - react\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 11 })
 
       // workspace minimumReleaseAge wins; excludes from both layers are merged
       expect(result).toStrictEqual({ minimumReleaseAge: 1440, minimumReleaseAgeExclude: ['@myorg/*', 'react'] })
@@ -1693,7 +1693,7 @@ describe('cooldown', () => {
         'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  - react\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 11 })
 
       expect(result).toStrictEqual({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['@myorg/*', 'react'] })
     })
@@ -1708,7 +1708,7 @@ describe('cooldown', () => {
         'minimumReleaseAge=60\nminimumReleaseAgeExclude=["left-pad"]\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 11 })
 
       expect(result).toStrictEqual({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['react'] })
     })
@@ -1723,7 +1723,7 @@ describe('cooldown', () => {
         'minimumReleaseAge=60\nminimumReleaseAgeExclude=["left-pad"]\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(10)
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 10 })
 
       expect(result).toStrictEqual({ minimumReleaseAge: 60, minimumReleaseAgeExclude: ['left-pad'] })
     })
@@ -1738,7 +1738,7 @@ describe('cooldown', () => {
         'minimumReleaseAge=60\nminimumReleaseAgeExclude=["react","left-pad"]\n',
       )
 
-      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(null)
+      const result = await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: null })
 
       expect(result).toStrictEqual({ minimumReleaseAge: 10080, minimumReleaseAgeExclude: ['react', 'left-pad'] })
     })

--- a/test/helpers/pnpmConfigDirs.ts
+++ b/test/helpers/pnpmConfigDirs.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach } from 'vitest'
+import removeDir from './removeDir.ts'
+
+interface PnpmConfigDirs {
+  /** Temp directory used as cwd. Contains no pnpm-workspace.yaml unless the test writes one. */
+  projectDir: string
+  /** Temp XDG_CONFIG_HOME, so pnpm's global config resolves into it instead of the machine's. */
+  xdgDir: string
+  /** Writes a pnpm-workspace.yaml into projectDir. */
+  writeWorkspace: (content: string) => Promise<void>
+  /** Writes a file (config.yaml or rc) into the isolated pnpm global config directory. */
+  writeGlobalConfig: (filename: string, content: string) => Promise<void>
+}
+
+/**
+ * Registers beforeEach/afterEach hooks that isolate pnpm config resolution from the machine running the tests:
+ * a fresh temp directory as cwd, and a fresh XDG_CONFIG_HOME so pnpm's global config layer is empty by default.
+ * Without the latter, a developer with registries or minimumReleaseAge in their own pnpm config sees failures
+ * that CI never reproduces.
+ *
+ * The returned object is mutated before each test, so read its properties inside the test body, not at describe time.
+ */
+const usePnpmConfigDirs = (): PnpmConfigDirs => {
+  const dirs: PnpmConfigDirs = {
+    projectDir: '',
+    xdgDir: '',
+    writeWorkspace: content => fs.writeFile(path.join(dirs.projectDir, 'pnpm-workspace.yaml'), content),
+    writeGlobalConfig: async (filename, content) => {
+      const globalConfigDir = path.join(dirs.xdgDir, 'pnpm')
+      await fs.mkdir(globalConfigDir, { recursive: true })
+      await fs.writeFile(path.join(globalConfigDir, filename), content)
+    },
+  }
+
+  let originalCwd: string
+  let originalXdgConfigHome: string | undefined
+
+  beforeEach(async () => {
+    originalCwd = process.cwd()
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+    dirs.projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ncu-test-pnpm-project-'))
+    dirs.xdgDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ncu-test-pnpm-xdg-'))
+    process.env.XDG_CONFIG_HOME = dirs.xdgDir
+    process.chdir(dirs.projectDir)
+  })
+
+  afterEach(async () => {
+    process.chdir(originalCwd)
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+    }
+    await removeDir(dirs.projectDir)
+    await removeDir(dirs.xdgDir)
+  })
+
+  return dirs
+}
+
+export default usePnpmConfigDirs

--- a/test/interpolate.test.ts
+++ b/test/interpolate.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import interpolate from '../src/lib/interpolate.ts'
+
+describe('interpolate', () => {
+  it('returns a string with no placeholder unchanged', () => {
+    expect(interpolate('https://registry.example.com/', { VAR: 'x' })).toBe('https://registry.example.com/')
+  })
+
+  it('interpolates a set variable', () => {
+    expect(interpolate(`\${VAR}/path/`, { VAR: 'https://registry.example.com' })).toBe(
+      'https://registry.example.com/path/',
+    )
+  })
+
+  it('interpolates every placeholder, not just the first', () => {
+    expect(interpolate(`\${A}-\${B}-\${A}`, { A: 'one', B: 'two' })).toBe('one-two-one')
+  })
+
+  it('replaces an unset variable with an empty string', () => {
+    expect(interpolate(`\${VAR}`, {})).toBe('')
+    expect(interpolate(`prefix-\${VAR}-suffix`, {})).toBe('prefix--suffix')
+  })
+
+  // a value that itself looks like a placeholder is not expanded again, so a config cannot chain indirections
+  it('does not interpolate the interpolated value', () => {
+    expect(interpolate(`\${A}`, { A: `\${B}`, B: 'two' })).toBe(`\${B}`)
+  })
+
+  describe('dash fallback', () => {
+    it('uses the fallback when the variable is unset', () => {
+      expect(interpolate(`\${VAR-fallback}`, {})).toBe('fallback')
+    })
+
+    it('prefers the set variable over the fallback', () => {
+      expect(interpolate(`\${VAR-fallback}`, { VAR: 'value' })).toBe('value')
+    })
+
+    // without the colon, only an unset variable falls back, so an intentional empty value is preserved
+    it('keeps an empty value instead of falling back', () => {
+      expect(interpolate(`\${VAR-fallback}`, { VAR: '' })).toBe('')
+    })
+
+    it('supports an empty fallback', () => {
+      expect(interpolate(`\${VAR-}`, {})).toBe('')
+    })
+  })
+
+  describe('colon-dash fallback', () => {
+    it('uses the fallback when the variable is unset', () => {
+      expect(interpolate(`\${VAR:-fallback}`, {})).toBe('fallback')
+    })
+
+    it('uses the fallback when the variable is set but empty', () => {
+      expect(interpolate(`\${VAR:-fallback}`, { VAR: '' })).toBe('fallback')
+    })
+
+    it('prefers the set variable over the fallback', () => {
+      expect(interpolate(`\${VAR:-fallback}`, { VAR: 'value' })).toBe('value')
+    })
+  })
+
+  // callers rely on an unsupported placeholder surviving verbatim, so they can detect it and reject the value
+  describe('unsupported placeholders', () => {
+    it('leaves a placeholder with a non-word character untouched', () => {
+      expect(interpolate(`\${A.B}`, { 'A.B': 'value' })).toBe(`\${A.B}`)
+    })
+
+    it('leaves an empty placeholder untouched', () => {
+      expect(interpolate(`\${}`, {})).toBe(`\${}`)
+    })
+
+    it('leaves an unterminated placeholder untouched', () => {
+      expect(interpolate(`\${VAR`, { VAR: 'value' })).toBe(`\${VAR`)
+    })
+  })
+})

--- a/test/package-managers/pnpm.test.ts
+++ b/test/package-managers/pnpm.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { pnpmApi } from '../../src/package-managers/pnpm.ts'
 import usePnpmConfigDirs from '../helpers/pnpmConfigDirs.ts'
 
@@ -232,6 +232,35 @@ minimumReleaseAgeExclude:
       expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
     })
 
+    // pnpm accepts the plain registry setting in pnpm-workspace.yaml, and documents registries.default as equivalent
+    it('reads the plain registry setting as the default registry', async () => {
+      await dirs.writeWorkspace('registry: https://registry.example.com/\n')
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+        default: 'https://registry.example.com/',
+        scoped: {},
+      })
+    })
+
+    it('prefers registries.default over the plain registry setting', async () => {
+      await dirs.writeWorkspace(
+        'registry: https://plain.example.com/\nregistries:\n  default: https://map.example.com/\n',
+      )
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+        default: 'https://map.example.com/',
+        scoped: {},
+      })
+    })
+
+    it('falls back to the plain registry setting when registries omits default', async () => {
+      await dirs.writeWorkspace(
+        'registry: https://plain.example.com/\nregistries:\n  "@myorg": https://myorg.example.com/\n',
+      )
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+        default: 'https://plain.example.com/',
+        scoped: { '@myorg': 'https://myorg.example.com/' },
+      })
+    })
+
     it('searches upwards from an explicit cwd', async () => {
       await dirs.writeWorkspace('registries:\n  default: https://registry.example.com/\n')
       const nested = path.join(dirs.projectDir, 'packages', 'sub')
@@ -290,6 +319,85 @@ minimumReleaseAgeExclude:
       it('does not read registries from the global rc file', async () => {
         await dirs.writeGlobalConfig('rc', 'registries[default]=https://rc.example.com/\n')
         expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
+      })
+    })
+
+    // Since pnpm 11.5.3, env vars are only expanded in registry URLs in trusted locations, i.e. the global config.
+    // pnpm-workspace.yaml is committed, so expanding there could leak env secrets to an attacker-controlled registry.
+    describe('environment variable interpolation', () => {
+      const ENV_VAR = 'NCU_TEST_PNPM_REGISTRY'
+
+      beforeEach(() => {
+        process.env[ENV_VAR] = 'https://from-env.example.com/'
+      })
+
+      afterEach(() => {
+        delete process.env[ENV_VAR]
+      })
+
+      it('expands environment variables in the global config.yaml', async () => {
+        await dirs.writeGlobalConfig(
+          'config.yaml',
+          `registries:\n  default: \${${ENV_VAR}}\n  "@myorg": \${${ENV_VAR}}myorg/\n`,
+        )
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+          default: 'https://from-env.example.com/',
+          scoped: { '@myorg': 'https://from-env.example.com/myorg/' },
+        })
+      })
+
+      it('expands environment variables in the plain registry setting in the global config.yaml', async () => {
+        await dirs.writeGlobalConfig('config.yaml', `registry: \${${ENV_VAR}}\n`)
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+          default: 'https://from-env.example.com/',
+          scoped: {},
+        })
+      })
+
+      it('ignores a global registry whose environment variable is unset', async () => {
+        delete process.env[ENV_VAR]
+        await dirs.writeGlobalConfig('config.yaml', `registries:\n  default: \${${ENV_VAR}}\n`)
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
+      })
+
+      // the dash fallback resolves to a usable URL, so the registry must be kept rather than dropped as a placeholder
+      it('uses the fallback of an unset environment variable in the global config.yaml', async () => {
+        delete process.env[ENV_VAR]
+        await dirs.writeGlobalConfig(
+          'config.yaml',
+          `registries:\n  default: \${${ENV_VAR}:-https://fallback.example.com/}\n`,
+        )
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+          default: 'https://fallback.example.com/',
+          scoped: {},
+        })
+      })
+
+      // pnpm-workspace.yaml is not interpolated at all, so even a placeholder with a usable fallback is ignored
+      it('ignores a fallback placeholder in pnpm-workspace.yaml', async () => {
+        await dirs.writeWorkspace(`registries:\n  default: \${${ENV_VAR}:-https://fallback.example.com/}\n`)
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
+      })
+
+      it('ignores a registry with an environment variable placeholder in pnpm-workspace.yaml', async () => {
+        await dirs.writeWorkspace(`registries:\n  default: \${${ENV_VAR}}\n  "@myorg": \${${ENV_VAR}}myorg/\n`)
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
+      })
+
+      it('falls back to the global default when pnpm-workspace.yaml uses a placeholder', async () => {
+        await dirs.writeGlobalConfig('config.yaml', 'registries:\n  default: https://global.example.com/\n')
+        await dirs.writeWorkspace(`registries:\n  default: \${${ENV_VAR}}\n`)
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+          default: 'https://global.example.com/',
+          scoped: {},
+        })
       })
     })
   })

--- a/test/package-managers/pnpm.test.ts
+++ b/test/package-managers/pnpm.test.ts
@@ -144,14 +144,14 @@ minimumReleaseAgeExclude:
       })
 
       it('reads config.yaml on pnpm >= 11', async () => {
-        expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(11)).toStrictEqual({
+        expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 11 })).toStrictEqual({
           minimumReleaseAge: 2880,
           minimumReleaseAgeExclude: ['vue'],
         })
       })
 
       it('reads rc on pnpm <= 10', async () => {
-        expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(10)).toStrictEqual({
+        expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: 10 })).toStrictEqual({
           minimumReleaseAge: 4320,
           minimumReleaseAgeExclude: ['svelte'],
         })
@@ -163,7 +163,7 @@ minimumReleaseAgeExclude:
       await writeGlobalConfig('config.yaml', 'storeDir: /tmp/store\n')
       await writeGlobalConfig('rc', 'minimum-release-age=4320\n')
       // null reads both globals, the fallback when the installed pnpm version cannot be determined
-      expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(null)).toStrictEqual({
+      expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge({ pnpmMajorVersion: null })).toStrictEqual({
         minimumReleaseAge: 4320,
         minimumReleaseAgeExclude: [],
       })
@@ -267,7 +267,7 @@ minimumReleaseAgeExclude:
       await fs.mkdir(nested, { recursive: true })
       process.chdir(os.tmpdir())
 
-      expect(await pnpmApi.getPnpmWorkspaceRegistries(nested)).toStrictEqual({
+      expect(await pnpmApi.getPnpmWorkspaceRegistries({ cwd: nested })).toStrictEqual({
         default: 'https://registry.example.com/',
         scoped: {},
       })

--- a/test/package-managers/pnpm.test.ts
+++ b/test/package-managers/pnpm.test.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { pnpmApi } from '../../src/package-managers/pnpm.ts'
-import removeDir from '../helpers/removeDir.ts'
+import usePnpmConfigDirs from '../helpers/pnpmConfigDirs.ts'
 
 describe('pnpm', () => {
   describe('buildArgs', () => {
@@ -62,40 +62,8 @@ describe('pnpm', () => {
   })
 
   describe('getPnpmWorkspaceMinimumReleaseAge', () => {
-    let tempDir: string
-    let originalCwd: string
-    let originalXdgConfigHome: string | undefined
-
-    beforeEach(async () => {
-      originalCwd = process.cwd()
-      originalXdgConfigHome = process.env.XDG_CONFIG_HOME
-      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ncu-test-pnpm-'))
-      // isolate the global config layers from the machine running the tests
-      process.env.XDG_CONFIG_HOME = path.join(tempDir, 'xdg')
-    })
-
-    afterEach(async () => {
-      process.chdir(originalCwd)
-      if (originalXdgConfigHome === undefined) {
-        delete process.env.XDG_CONFIG_HOME
-      } else {
-        process.env.XDG_CONFIG_HOME = originalXdgConfigHome
-      }
-      await removeDir(tempDir)
-    })
-
-    /** Writes a pnpm-workspace.yaml into the temp dir and switches cwd to it. */
-    async function writeWorkspace(content: string): Promise<void> {
-      await fs.writeFile(path.join(tempDir, 'pnpm-workspace.yaml'), content)
-      process.chdir(tempDir)
-    }
-
-    /** Writes a file into the pnpm global config directory. */
-    async function writeGlobalConfig(filename: string, content: string): Promise<void> {
-      const globalConfigDir = path.join(tempDir, 'xdg', 'pnpm')
-      await fs.mkdir(globalConfigDir, { recursive: true })
-      await fs.writeFile(path.join(globalConfigDir, filename), content)
-    }
+    // isolates cwd and XDG_CONFIG_HOME, so the machine's own pnpm config cannot leak into the assertions
+    const { writeWorkspace, writeGlobalConfig } = usePnpmConfigDirs()
 
     it('returns null when no config defines minimumReleaseAge', async () => {
       await writeWorkspace('packages:\n  - "packages/*"\n')
@@ -145,7 +113,6 @@ minimumReleaseAgeExclude:
     // pnpm >= 11
     it('reads minimumReleaseAge from the global config.yaml', async () => {
       await writeGlobalConfig('config.yaml', 'minimumReleaseAge: 2880\nminimumReleaseAgeExclude:\n  - "vue"\n')
-      process.chdir(tempDir)
       expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()).toStrictEqual({
         minimumReleaseAge: 2880,
         minimumReleaseAgeExclude: ['vue'],
@@ -155,7 +122,6 @@ minimumReleaseAgeExclude:
     // pnpm <= 10 stores arrays in the ini-formatted rc file as JSON, and uses kebab-case keys
     it('reads minimumReleaseAge from the global rc file', async () => {
       await writeGlobalConfig('rc', 'minimum-release-age=4320\nminimum-release-age-exclude=["vue"]\n')
-      process.chdir(tempDir)
       expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()).toStrictEqual({
         minimumReleaseAge: 4320,
         minimumReleaseAgeExclude: ['vue'],
@@ -175,7 +141,6 @@ minimumReleaseAgeExclude:
       beforeEach(async () => {
         await writeGlobalConfig('config.yaml', 'minimumReleaseAge: 2880\nminimumReleaseAgeExclude:\n  - "vue"\n')
         await writeGlobalConfig('rc', 'minimum-release-age=4320\nminimum-release-age-exclude=["svelte"]\n')
-        process.chdir(tempDir)
       })
 
       it('reads config.yaml on pnpm >= 11', async () => {
@@ -197,7 +162,6 @@ minimumReleaseAgeExclude:
     it('falls through to the global rc file when config.yaml defines no minimumReleaseAge', async () => {
       await writeGlobalConfig('config.yaml', 'storeDir: /tmp/store\n')
       await writeGlobalConfig('rc', 'minimum-release-age=4320\n')
-      process.chdir(tempDir)
       // null reads both globals, the fallback when the installed pnpm version cannot be determined
       expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge(null)).toStrictEqual({
         minimumReleaseAge: 4320,
@@ -211,6 +175,121 @@ minimumReleaseAgeExclude:
       expect(await pnpmApi.getPnpmWorkspaceMinimumReleaseAge()).toStrictEqual({
         minimumReleaseAge: 60,
         minimumReleaseAgeExclude: ['react', 'vue'],
+      })
+    })
+  })
+
+  describe('getPnpmWorkspaceRegistries', () => {
+    // isolates cwd and XDG_CONFIG_HOME, so the machine's own pnpm registries cannot leak into the assertions
+    const dirs = usePnpmConfigDirs()
+
+    it('returns no registries when pnpm-workspace.yaml does not define any', async () => {
+      await dirs.writeWorkspace('packages:\n  - "packages/*"\n')
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
+    })
+
+    it('returns no registries when there is no pnpm-workspace.yaml at all', async () => {
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
+    })
+
+    it('reads the default registry from pnpm-workspace.yaml', async () => {
+      await dirs.writeWorkspace('registries:\n  default: https://registry.example.com/\n')
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+        default: 'https://registry.example.com/',
+        scoped: {},
+      })
+    })
+
+    it('reads scoped registries from pnpm-workspace.yaml', async () => {
+      await dirs.writeWorkspace(`registries:
+  default: https://registry.example.com/
+  "@myorg": https://myorg.example.com/
+  "@internal": https://internal.example.com/
+`)
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+        default: 'https://registry.example.com/',
+        scoped: {
+          '@myorg': 'https://myorg.example.com/',
+          '@internal': 'https://internal.example.com/',
+        },
+      })
+    })
+
+    it('ignores non-string and empty registry values', async () => {
+      await dirs.writeWorkspace(`registries:
+  default: ""
+  "@myorg": 42
+  "@internal": https://internal.example.com/
+`)
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+        default: undefined,
+        scoped: { '@internal': 'https://internal.example.com/' },
+      })
+    })
+
+    it('ignores a registries value that is not a map', async () => {
+      await dirs.writeWorkspace('registries: https://registry.example.com/\n')
+      expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
+    })
+
+    it('searches upwards from an explicit cwd', async () => {
+      await dirs.writeWorkspace('registries:\n  default: https://registry.example.com/\n')
+      const nested = path.join(dirs.projectDir, 'packages', 'sub')
+      await fs.mkdir(nested, { recursive: true })
+      process.chdir(os.tmpdir())
+
+      expect(await pnpmApi.getPnpmWorkspaceRegistries(nested)).toStrictEqual({
+        default: 'https://registry.example.com/',
+        scoped: {},
+      })
+    })
+
+    // pnpm reads registries from its global config.yaml since 11.11
+    describe('global config.yaml fallback', () => {
+      it('reads registries from the global config.yaml when pnpm-workspace.yaml is absent', async () => {
+        await dirs.writeGlobalConfig(
+          'config.yaml',
+          'registries:\n  default: https://global.example.com/\n  "@myorg": https://global-myorg.example.com/\n',
+        )
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+          default: 'https://global.example.com/',
+          scoped: { '@myorg': 'https://global-myorg.example.com/' },
+        })
+      })
+
+      it('prefers pnpm-workspace.yaml over the global config, merging scoped entries per scope', async () => {
+        await dirs.writeGlobalConfig(
+          'config.yaml',
+          'registries:\n  default: https://global.example.com/\n  "@myorg": https://global-myorg.example.com/\n  "@global-only": https://global-only.example.com/\n',
+        )
+        await dirs.writeWorkspace(
+          'registries:\n  default: https://workspace.example.com/\n  "@myorg": https://workspace-myorg.example.com/\n',
+        )
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+          default: 'https://workspace.example.com/',
+          scoped: {
+            '@myorg': 'https://workspace-myorg.example.com/',
+            '@global-only': 'https://global-only.example.com/',
+          },
+        })
+      })
+
+      it('falls back to the global default when pnpm-workspace.yaml omits it', async () => {
+        await dirs.writeGlobalConfig('config.yaml', 'registries:\n  default: https://global.example.com/\n')
+        await dirs.writeWorkspace('registries:\n  "@myorg": https://workspace-myorg.example.com/\n')
+
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({
+          default: 'https://global.example.com/',
+          scoped: { '@myorg': 'https://workspace-myorg.example.com/' },
+        })
+      })
+
+      // registries requires pnpm >= 11, which does not read the rc file
+      it('does not read registries from the global rc file', async () => {
+        await dirs.writeGlobalConfig('rc', 'registries[default]=https://rc.example.com/\n')
+        expect(await pnpmApi.getPnpmWorkspaceRegistries()).toStrictEqual({ default: undefined, scoped: {} })
       })
     })
   })

--- a/test/package-managers/pnpmRegistries.test.ts
+++ b/test/package-managers/pnpmRegistries.test.ts
@@ -45,13 +45,25 @@ describe('pnpm registries', () => {
     )
   })
 
-  // pnpm resolves registries above .npmrc, but ncu merges the workspace config below the npmrc layers
-  it('is overridden by the registry in .npmrc', async () => {
+  // pnpm resolves registries above every .npmrc, but ncu keeps the project/cwd .npmrc on top, as it does for yarn
+  it('is overridden by the registry in the .npmrc in the cwd', async () => {
     await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
     await fs.writeFile(path.join(dirs.projectDir, '.npmrc'), 'registry=https://npmrc-registry.invalid/\n')
 
     await expect(pnpm.latest('ncu-test-v2', '1.0.0', { cwd: dirs.projectDir, retry: 0 })).rejects.toThrow(
       /npmrc-registry\.invalid/,
+    )
+  })
+
+  // the .npmrc next to pnpm-workspace.yaml is merged below the registries setting, matching pnpm
+  it('overrides the registry in the .npmrc next to pnpm-workspace.yaml', async () => {
+    await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
+    await fs.writeFile(path.join(dirs.projectDir, '.npmrc'), 'registry=https://npmrc-registry.invalid/\n')
+    const nested = path.join(dirs.projectDir, 'packages', 'sub')
+    await fs.mkdir(nested, { recursive: true })
+
+    await expect(pnpm.latest('ncu-test-v2', '1.0.0', { cwd: nested, retry: 0 })).rejects.toThrow(
+      /default-registry\.invalid/,
     )
   })
 
@@ -99,22 +111,31 @@ describe('pnpm registries', () => {
     )
   })
 
-  // The pnpm config is merged as npmConfigWorkspaceProject, which sits below the ambient npm config. Every code
-  // path must agree on that, otherwise a project resolves versions and engines from two different registries.
+  // The registries setting is merged as npmConfigLocal, which sits above the ambient npm config. Every code path
+  // must agree on that, otherwise a project resolves versions and engines from two different registries.
   describe('with an ambient npm registry', () => {
     beforeEach(() => {
       vi.spyOn(npmApi, 'findNpmConfig').mockReturnValue({ registry: 'https://npm-config-registry.invalid/' })
     })
 
-    it('resolves versions, dist-tags, engines and authors from the same registry', async () => {
+    it('resolves versions, dist-tags, engines and authors from the pnpm registry', async () => {
       await dirs.writeWorkspace('registries:\n  default: https://pnpm-registry.invalid/\n')
       const options = { cwd: dirs.projectDir, retry: 0 }
 
-      await expect(pnpm.latest('ncu-test-v2', '1.0.0', options)).rejects.toThrow(/npm-config-registry\.invalid/)
-      await expect(pnpm.getDistTags('ncu-test-v2', options)).rejects.toThrow(/npm-config-registry\.invalid/)
-      await expect(pnpm.getEngines('ncu-test-v2', '1.0.0', options)).rejects.toThrow(/npm-config-registry\.invalid/)
+      await expect(pnpm.latest('ncu-test-v2', '1.0.0', options)).rejects.toThrow(/pnpm-registry\.invalid/)
+      await expect(pnpm.getDistTags('ncu-test-v2', options)).rejects.toThrow(/pnpm-registry\.invalid/)
+      await expect(pnpm.getEngines('ncu-test-v2', '1.0.0', options)).rejects.toThrow(/pnpm-registry\.invalid/)
       await expect(pnpm.packageAuthorChanged('ncu-test-v2', '1.0.0', '2.0.0', options)).rejects.toThrow(
-        /npm-config-registry\.invalid/,
+        /pnpm-registry\.invalid/,
+      )
+    })
+
+    // npm config set registry leaves a registry= in the user .npmrc, which used to silently win over pnpm's own config
+    it('resolves the plain registry setting above the ambient npm config', async () => {
+      await dirs.writeWorkspace('registry: https://pnpm-registry.invalid/\n')
+
+      await expect(pnpm.latest('ncu-test-v2', '1.0.0', { cwd: dirs.projectDir, retry: 0 })).rejects.toThrow(
+        /pnpm-registry\.invalid/,
       )
     })
   })

--- a/test/package-managers/pnpmRegistries.test.ts
+++ b/test/package-managers/pnpmRegistries.test.ts
@@ -1,0 +1,121 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { npmApi } from '../../src/package-managers/npm.ts'
+import * as pnpm from '../../src/package-managers/pnpm.ts'
+import usePnpmConfigDirs from '../helpers/pnpmConfigDirs.ts'
+
+describe('pnpm registries', () => {
+  const dirs = usePnpmConfigDirs()
+
+  beforeEach(() => {
+    // The ambient npm config outranks pnpm-workspace.yaml, so a developer with npm_config_registry set or a
+    // registry in their user .npmrc would otherwise see these fail while CI, which has neither, passes.
+    vi.spyOn(npmApi, 'findNpmConfig').mockReturnValue({})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // .invalid never resolves, so the host in the fetch error identifies the registry that was used
+  it('fetches from registries.default in pnpm-workspace.yaml', async () => {
+    await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
+
+    await expect(pnpm.latest('ncu-test-v2', '1.0.0', { cwd: dirs.projectDir, retry: 0 })).rejects.toThrow(
+      /default-registry\.invalid/,
+    )
+  })
+
+  it('fetches scoped packages from their scoped registry', async () => {
+    await dirs.writeWorkspace(
+      'registries:\n  default: https://default-registry.invalid/\n  "@ncu-scope": https://scoped-registry.invalid/\n',
+    )
+
+    await expect(pnpm.latest('@ncu-scope/pkg', '1.0.0', { cwd: dirs.projectDir, retry: 0 })).rejects.toThrow(
+      /scoped-registry\.invalid/,
+    )
+  })
+
+  it('fetches from registries in pnpm global config.yaml when pnpm-workspace.yaml is absent', async () => {
+    await dirs.writeGlobalConfig('config.yaml', 'registries:\n  default: https://global-registry.invalid/\n')
+
+    await expect(pnpm.latest('ncu-test-v2', '1.0.0', { cwd: dirs.projectDir, retry: 0 })).rejects.toThrow(
+      /global-registry\.invalid/,
+    )
+  })
+
+  // pnpm resolves registries above .npmrc, but ncu merges the workspace config below the npmrc layers
+  it('is overridden by the registry in .npmrc', async () => {
+    await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
+    await fs.writeFile(path.join(dirs.projectDir, '.npmrc'), 'registry=https://npmrc-registry.invalid/\n')
+
+    await expect(pnpm.latest('ncu-test-v2', '1.0.0', { cwd: dirs.projectDir, retry: 0 })).rejects.toThrow(
+      /npmrc-registry\.invalid/,
+    )
+  })
+
+  it('keeps using the registry when a fetch is retried', async () => {
+    await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
+
+    await expect(pnpm.latest('ncu-test-v2', '1.0.0', { cwd: dirs.projectDir, retry: 2 })).rejects.toThrow(
+      /default-registry\.invalid/,
+    )
+  })
+
+  it('prefers an explicitly specified registry over pnpm-workspace.yaml', async () => {
+    await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
+
+    await expect(
+      pnpm.latest('ncu-test-v2', '1.0.0', {
+        cwd: dirs.projectDir,
+        registry: 'https://explicit-registry.invalid/',
+        retry: 0,
+      }),
+    ).rejects.toThrow(/explicit-registry\.invalid/)
+  })
+
+  it('fetches dist-tags from the pnpm registry', async () => {
+    await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
+
+    await expect(pnpm.getDistTags('ncu-test-v2', { cwd: dirs.projectDir, retry: 0 })).rejects.toThrow(
+      /default-registry\.invalid/,
+    )
+  })
+
+  it('fetches engines from the pnpm registry', async () => {
+    await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
+
+    await expect(pnpm.getEngines('ncu-test-v2', '1.0.0', { cwd: dirs.projectDir })).rejects.toThrow(
+      /default-registry\.invalid/,
+    )
+  })
+
+  it('fetches package authors from the pnpm registry', async () => {
+    await dirs.writeWorkspace('registries:\n  default: https://default-registry.invalid/\n')
+
+    await expect(pnpm.packageAuthorChanged('ncu-test-v2', '1.0.0', '2.0.0', { cwd: dirs.projectDir })).rejects.toThrow(
+      /default-registry\.invalid/,
+    )
+  })
+
+  // The pnpm config is merged as npmConfigWorkspaceProject, which sits below the ambient npm config. Every code
+  // path must agree on that, otherwise a project resolves versions and engines from two different registries.
+  describe('with an ambient npm registry', () => {
+    beforeEach(() => {
+      vi.spyOn(npmApi, 'findNpmConfig').mockReturnValue({ registry: 'https://npm-config-registry.invalid/' })
+    })
+
+    it('resolves versions, dist-tags, engines and authors from the same registry', async () => {
+      await dirs.writeWorkspace('registries:\n  default: https://pnpm-registry.invalid/\n')
+      const options = { cwd: dirs.projectDir, retry: 0 }
+
+      await expect(pnpm.latest('ncu-test-v2', '1.0.0', options)).rejects.toThrow(/npm-config-registry\.invalid/)
+      await expect(pnpm.getDistTags('ncu-test-v2', options)).rejects.toThrow(/npm-config-registry\.invalid/)
+      await expect(pnpm.getEngines('ncu-test-v2', '1.0.0', options)).rejects.toThrow(/npm-config-registry\.invalid/)
+      await expect(pnpm.packageAuthorChanged('ncu-test-v2', '1.0.0', '2.0.0', options)).rejects.toThrow(
+        /npm-config-registry\.invalid/,
+      )
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1964.

pnpm 11 added [`registries`](https://pnpm.io/settings#registries) to `pnpm-workspace.yaml` ([pnpm/pnpm#11189](https://github.com/pnpm/pnpm/pull/11189)). ncu already read `minimumReleaseAge` from that file but ignored `registries`, so a project whose registry lives only there was silently checked against the public registry.

`registries` is read in `npmConfigFromPnpmWorkspace` and converted to npm config variables — `default` to `registry`, scoped entries to `@scope:registry` — the same way `npmConfigFromYarn` converts `npmScopes` from `.yarnrc.yml`. `getEngines` and `packageAuthorChanged` are wired through it too, as yarn already does, so they hit the same registry as the version lookup.

Two smaller things came out of it:

- Retries dropped the workspace config: `fetchUpgradedPackument` did not forward `npmConfigWorkspaceProject` when retrying, so a failed request to a private registry silently retried against the public one. It affected the workspace `.npmrc` before this PR too.
- The registries reader and the `minimumReleaseAge` reader had the same read/parse/layer logic, so they now share a `readPnpmConfig` helper.

`registries` requires pnpm >= 11, so the pnpm <= 10 `rc` file is not consulted; pnpm's global `config.yaml` is, since it supports the setting from 11.11.

Before, with `registries.default` and `registries['@types']` both pointing at `https://bogus-registry.invalid/`:

```console
Using minimumReleaseAge from pnpm-workspace.yaml: 3 days
Checking /tmp/repro/package.json

Patch   Backwards-compatible bug fixes
 husky  9.1.0  →  9.1.7

Minor   Backwards-compatible features
 @types/semver  7.5.0  →  7.7.1
```

After:

```console
Using minimumReleaseAge from pnpm-workspace.yaml: 3 days
Checking /tmp/repro/package.json

 husky          FetchError: request to https://bogus-registry.invalid/husky failed, reason: getaddrinfo ENOTFOUND bogus-registry.invalid
 @types/semver  FetchError: request to https://bogus-registry.invalid/@types%2Fsemver failed, reason: getaddrinfo ENOTFOUND bogus-registry.invalid
```

Tests were written first and were red before the implementation. `test/package-managers/pnpm.test.ts` covers parsing and the workspace/global layering; `test/registryPnpm.test.ts` covers the behaviour through `pnpm.latest` against `.invalid` hosts, so the host in the fetch error identifies the registry that was used: default, scoped, global `config.yaml`, precedence over `.npmrc`, precedence of an explicit `--registry`, and the retry case. `npx vitest run` is green (798 passed, 2 skipped), as are `tsc --noEmit`, `eslint` and `prettier --check`.

## Merge order

Reverted per review — `mergeNpmConfigs` is untouched, so the npmrc layers keep precedence over `npmConfigWorkspaceProject` and therefore over `registries` in `pnpm-workspace.yaml`. pnpm resolves the opposite way ([pnpm/pnpm#11754](https://github.com/pnpm/pnpm/pull/11754)); the test `is overridden by the registry in .npmrc` documents ncu's order so the divergence is pinned rather than implicit. Happy to follow up with a pnpm-scoped version in a separate PR if you want it.
