### PR TITLE
lint: remove FORCE_COLOR=1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "vite build",
     "build:options": "node scripts/build-options.ts",
     "build:analyze": "cross-env ANALYZER=true vite build",
-    "lint": "cross-env FORCE_COLOR=1 npm-run-all --parallel --continue-on-error --aggregate-output lint:*",
+    "lint": "npm-run-all --parallel --continue-on-error --aggregate-output lint:*",
     "lint:lockfile": "lockfile-lint",
     "lint:types": "tsc --noEmit",
     "lint:markdown": "markdownlint-cli2 \"**/*.md\" \"!**/node_modules/**/*.md\" \"!build/**/*.md\"",


### PR DESCRIPTION
Unsure why this was there in the first place. I see it was introduced in https://github.com/raineorshine/npm-check-updates/commit/3833db54beabf2d064e10b2a745b0b26db756785 but not sure what it fixes?