### PR TITLE
Keep the resolved version when the peer recursion requeries

### DIFF
--- a/src/lib/upgradePackageDefinitions.ts
+++ b/src/lib/upgradePackageDefinitions.ts
@@ -59,6 +59,15 @@ const checkIfInPeerViolation = (
   }
 }
 
+/**
+ * Merges a peer recursion pass into the previous one. The recursion requeries at the already
+ * upgraded spec, so a result with no version means nothing more to upgrade to.
+ */
+const mergeVersionResults = (previous: Index<VersionResult>, next: Index<VersionResult>): Index<VersionResult> =>
+  keyValueBy({ ...previous, ...next }, (dep, result) => ({
+    [dep]: !result.version && !result.error && previous[dep]?.version ? previous[dep] : result,
+  }))
+
 export type UpgradePackageDefinitionsResult = [
   upgradedDependencies: Index<VersionSpec>,
   latestVersionResults: Index<VersionResult>,
@@ -156,7 +165,7 @@ export async function upgradePackageDefinitions(
       )
       result = [
         { ...checkPeerViolationResult.filteredUpgradedDependencies, ...newUpgradedDependencies },
-        { ...latestVersionResults, ...newLatestVersions },
+        mergeVersionResults(latestVersionResults, newLatestVersions),
         newPeerDependencies,
       ]
       checkPeerViolationResult = checkIfInPeerViolation(currentDependencies, result[0], result[2]!)

--- a/test/peerCooldown.test.ts
+++ b/test/peerCooldown.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ncu from '../src/index.ts'
+import { type Index } from '../src/types/IndexType.ts'
+import { type PackageFile } from '../src/types/PackageFile.ts'
+import createMockVersion from './helpers/createMockVersion.ts'
+import { silenceProgressBar } from './helpers/silenceProgressBar.ts'
+import stubVersions from './helpers/stubVersions.ts'
+
+// peer-pkg reports different peers before and after its upgrade, which is what sends
+// upgradePackageDefinitions into the peer recursion that requeries every dependency
+vi.mock('../src/lib/getPeerDependenciesFromRegistry.ts', () => ({
+  default: async (packageMap: Index<string>) =>
+    Object.fromEntries(
+      Object.entries(packageMap).map(([name, version]) => [
+        name,
+        name === 'peer-pkg' ? { 'unrelated-peer': version.startsWith('1.1') ? '^2' : '^1' } : {},
+      ]),
+    ),
+}))
+
+const DAY = 24 * 60 * 60 * 1000
+const NOW = Date.now()
+/** Returns an ISO timestamp n days in the past. */
+const daysAgo = (n: number) => new Date(NOW - n * DAY).toISOString()
+
+const packageData: PackageFile = {
+  dependencies: { 'cooldown-pkg': '2.9.2', 'peer-pkg': '1.0.0' },
+}
+
+/** Stubs cooldown-pkg with 2.9.5 inside the cooldown window and 2.9.4 outside it. */
+const stub = () =>
+  stubVersions({
+    'cooldown-pkg': createMockVersion({
+      name: 'cooldown-pkg',
+      versions: { '2.9.2': daysAgo(60), '2.9.4': daysAgo(30), '2.9.5': daysAgo(1) },
+      distTags: { latest: '2.9.5' },
+    }),
+    'peer-pkg': createMockVersion({
+      name: 'peer-pkg',
+      versions: { '1.0.0': daysAgo(60), '1.1.0': daysAgo(30) },
+      distTags: { latest: '1.1.0' },
+    }),
+  })
+
+describe('peer with cooldown', () => {
+  beforeEach(() => {
+    silenceProgressBar()
+  })
+
+  // https://github.com/raineorshine/npm-check-updates/issues/1982
+  for (const target of ['latest', 'minor'] as const) {
+    it(`writes the cooldown fallback that the peer requery cannot improve on (target ${target})`, async () => {
+      const stubbed = stub()
+
+      const upgraded = (await ncu({ packageData, peer: true, cooldown: 3, target, silent: true })) as Index<string>
+      const written = (await ncu({
+        packageData,
+        peer: true,
+        cooldown: 3,
+        target,
+        silent: true,
+        jsonAll: true,
+      })) as PackageFile
+
+      stubbed.restore()
+
+      expect(upgraded).toHaveProperty('cooldown-pkg', '2.9.4')
+      expect(written.dependencies).toHaveProperty('cooldown-pkg', '2.9.4')
+    })
+  }
+})


### PR DESCRIPTION
Fixes #1982.

Broke in bfa85c66 (23.0.0), which made `ncu -u` derive the written specs from latest instead of upgraded.

The underlying corruption is older: under `--peer`, the recursion requeries each dependency at its already upgraded spec, and when the only cooldown-safe version is the current one, `latest()` returns a result with no version that overwrites the version the first pass resolved. That dates to the cooldown feature (ddbef7ba) and the merge in 84fe129a, both in 22.2.9, where it was invisible.
