### PR TITLE
Warn when peer dependency lookups fail instead of silently disabling `--peer`

### DIFF
--- a/src/lib/getIgnoredUpgradesDueToPeerDeps.ts
+++ b/src/lib/getIgnoredUpgradesDueToPeerDeps.ts
@@ -6,6 +6,7 @@ import { type Version } from '../types/Version.ts'
 import { type VersionSpec } from '../types/VersionSpec.ts'
 import getPeerDependenciesFromRegistry from './getPeerDependenciesFromRegistry.ts'
 import upgradePackageDefinitions from './upgradePackageDefinitions.ts'
+import { isWildcard } from './version-util.ts'
 
 /** Get all upgrades that are ignored due to incompatible peer dependencies. */
 export async function getIgnoredUpgradesDueToPeerDeps(
@@ -31,7 +32,10 @@ export async function getIgnoredUpgradesDueToPeerDeps(
           packageName,
           // git urls and other non-semver versions are ignored.
           // Make sure versionSpec is a valid semver range; otherwise, minVersion will throw.
-          semver.validRange(versionSpec) ? (semver.minVersion(versionSpec)?.version ?? versionSpec) : versionSpec,
+          // Wildcards and empty specs are left alone since minVersion resolves them to 0.0.0
+          versionSpec && !isWildcard(versionSpec) && semver.validRange(versionSpec)
+            ? (semver.minVersion(versionSpec)?.version ?? versionSpec)
+            : versionSpec,
         ]
       }),
     ),

--- a/src/lib/getPeerDependenciesFromRegistry.ts
+++ b/src/lib/getPeerDependenciesFromRegistry.ts
@@ -4,8 +4,10 @@ import { type Index } from '../types/IndexType.ts'
 import { type Options } from '../types/Options.ts'
 import { type Version } from '../types/Version.ts'
 import getPackageManager from './getPackageManager.ts'
+import isPackageManagerProtocol from './isPackageManagerProtocol.ts'
 import { print } from './logging.ts'
 import resolveDistTagsInPeerDependencies from './resolveDistTagsInPeerDependencies.ts'
+import { isGitHubUrl, isWildcard } from './version-util.ts'
 
 type CircularData =
   | {
@@ -83,6 +85,9 @@ async function getPeerDependenciesFromRegistry(packageMap: Index<Version>, optio
     const cached = options.cacher?.getPeers(pkg, version)
     if (cached) {
       dependencies = cached
+    } else if (!version || isPackageManagerProtocol(version) || isGitHubUrl(version) || isWildcard(version)) {
+      // the registry has nothing to look up for these, so do not report them as unfetchable
+      dependencies = {}
     } else {
       try {
         dependencies = await packageManager.getPeerDependencies!(pkg, version, { cwd: options.cwd })

--- a/src/lib/getPeerDependenciesFromRegistry.ts
+++ b/src/lib/getPeerDependenciesFromRegistry.ts
@@ -4,6 +4,7 @@ import { type Index } from '../types/IndexType.ts'
 import { type Options } from '../types/Options.ts'
 import { type Version } from '../types/Version.ts'
 import getPackageManager from './getPackageManager.ts'
+import { print } from './logging.ts'
 import resolveDistTagsInPeerDependencies from './resolveDistTagsInPeerDependencies.ts'
 
 type CircularData =
@@ -66,6 +67,7 @@ async function getPeerDependenciesFromRegistry(packageMap: Index<Version>, optio
   }
 
   const packageEntries = Object.entries(packageMap)
+  const failed: string[] = []
 
   /**
    * Fetches peer dependencies for a package.
@@ -82,8 +84,19 @@ async function getPeerDependenciesFromRegistry(packageMap: Index<Version>, optio
     if (cached) {
       dependencies = cached
     } else {
-      dependencies = await packageManager.getPeerDependencies!(pkg, version, { cwd: options.cwd })
-      options.cacher?.setPeers(pkg, version, dependencies)
+      try {
+        dependencies = await packageManager.getPeerDependencies!(pkg, version, { cwd: options.cwd })
+        options.cacher?.setPeers(pkg, version, dependencies)
+      } catch (err) {
+        // one unreachable package should not abort the run
+        failed.push(pkg)
+        print(
+          options,
+          `\nFailed to get the peer dependencies of ${pkg}@${version}:\n${err instanceof Error ? err.message : err}`,
+          'verbose',
+        )
+        dependencies = {}
+      }
     }
     if (bar) {
       bar.tick()
@@ -100,6 +113,22 @@ async function getPeerDependenciesFromRegistry(packageMap: Index<Version>, optio
     if (circularData.isCircular) {
       delete peerDepsMap[pkg][circularData.offendingPackage]
     }
+  }
+
+  // peer deps are fetched several times per run, so only report each package once
+  const reported = (options.peerDependenciesFailed ??= new Set())
+  const unreported = failed.filter(pkg => !reported.has(pkg))
+  if (unreported.length > 0) {
+    for (const pkg of unreported) {
+      reported.add(pkg)
+    }
+    const preview = unreported.slice(0, 5).join(', ')
+    const more = unreported.length > 5 ? ` (and ${unreported.length - 5} more)` : ''
+    print(
+      options,
+      `\nCould not determine the peer dependencies of ${preview}${more}. Incompatible updates of these packages will not be ignored. Run with --verbose for details.`,
+      'warn',
+    )
   }
 
   await options.cacher?.save()

--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -32,7 +32,7 @@ import resolveDepSections from './resolveDepSections.ts'
 import upgradePackageData from './upgradePackageData.ts'
 import upgradePackageDefinitions from './upgradePackageDefinitions.ts'
 import parseJson from './utils/parseJson.ts'
-import { getDependencyGroups } from './version-util.ts'
+import { getDependencyGroups, isWildcard } from './version-util.ts'
 
 const INTERACTIVE_HINT = `
   ↑/↓: Select a package
@@ -211,7 +211,10 @@ export default async function runLocal(
             packageName,
             // git urls and other non-semver versions are ignored.
             // Make sure versionSpec is a valid semver range; otherwise, minVersion will throw.
-            semver.validRange(versionSpec) ? (semver.minVersion(versionSpec)?.version ?? versionSpec) : versionSpec,
+            // Wildcards and empty specs are left alone since minVersion resolves them to 0.0.0
+            versionSpec && !isWildcard(versionSpec) && semver.validRange(versionSpec)
+              ? (semver.minVersion(versionSpec)?.version ?? versionSpec)
+              : versionSpec,
           ]
         }),
       ),

--- a/src/package-managers/bun.ts
+++ b/src/package-managers/bun.ts
@@ -160,7 +160,9 @@ export const getPeerDependencies = async (
   const manifest = await bunInfo<{ peerDependencies?: Index<Version> }>(`${packageName}@${version}`, undefined, {
     cwd: spawnOptions.cwd,
   })
-  return manifest?.peerDependencies || {}
+  // bunInfo resolves to null when the lookup fails, which is not the same as having no peer dependencies
+  if (!manifest) throw new Error(`Could not read the manifest of ${packageName}@${version} from bun`)
+  return manifest.peerDependencies || {}
 }
 
 /**

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -946,7 +946,8 @@ export const getPeerDependencies = async (
   spawnOptions: SpawnOptions,
 ): Promise<Index<Version>> => {
   const args = ['view', `${packageName}@${version}`, 'peerDependencies']
-  const { stdout, stderr, command } = await spawnNpm(args, {}, { rejectOnError: false }, spawnOptions)
+  // reject on error so a failed lookup is not mistaken for a package with no peer dependencies
+  const { stdout, stderr, command } = await spawnNpm(args, {}, { rejectOnError: true }, spawnOptions)
   if (!stdout) return {}
   const peerDependencies = parseJson<Index<Version> | Index<Version>[]>(stdout, { command, stderr })
   // npm 12 always wraps the field in an array, npm 11 only for multi-version specs. Last is highest.

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -372,7 +372,10 @@ export const getPeerDependencies = async (
   if (yarnVersion.startsWith('1')) {
     const args = ['--json', 'info', `${packageName}@${version}`, 'peerDependencies']
     const { stdout } = await spawnCommand('yarn', args, { rejectOnError: false }, spawnOptions)
-    return stdout ? npm.parseJson<{ data?: Index<Version> }>(stdout, { command: args.join(' ') }).data || {} : {}
+    // yarn exits 0 and prints nothing when the package or version cannot be resolved, while a
+    // package with no peer dependencies still prints an inspect line
+    if (!stdout) throw new Error(`No response from "yarn ${args.join(' ')}"`)
+    return npm.parseJson<{ data?: Index<Version> }>(stdout, { command: args.join(' ') }).data || {}
   } else {
     const args = ['--json', 'npm', 'info', `${packageName}@${version}`, '--fields', 'peerDependencies']
     const { stdout } = await spawnCommand('yarn', args, { rejectOnError: false }, spawnOptions)
@@ -392,16 +395,17 @@ export const getPeerDependencies = async (
 {"type":"error","name":35,"displayName":"YN0035","indent":"","data":"  \u001b[96mRequest Method\u001b[39m: GET"}
 {"type":"error","name":35,"displayName":"YN0035","indent":"","data":"  \u001b[96mRequest URL\u001b[39m: \u001b[95mhttps://registry.yarnpkg.com/fffffffffffff\u001b[39m"}
        */
+      let first: { type?: string; data?: string; peerDependencies?: Index<Version> } | undefined
       try {
-        const firstObj = extractFirstJsonLine(stdout)
-        if (firstObj) {
-          return (
-            npm.parseJson<{ peerDependencies?: Index<Version> }>(firstObj, { command: args.join(' ') })
-              .peerDependencies || {}
-          )
-        }
+        first = npm.parseJson(extractFirstJsonLine(stdout), { command: args.join(' ') })
       } catch {}
-      throw parseError
+
+      if (!first) throw parseError
+      // report the lookup as failed rather than as a package with no peer dependencies
+      if (first.type === 'error') {
+        throw new Error(`yarn ${args.join(' ')}: ${first.data ?? 'lookup failed'}`, { cause: parseError })
+      }
+      return first.peerDependencies || {}
     }
   }
 }

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -17,6 +17,8 @@ export type Options = RunOptions & {
   nodeEngineVersion?: VersionSpec
   packageData?: string
   peerDependencies?: Index<any>
+  // Packages whose peer dependencies could not be fetched
+  peerDependenciesFailed?: Set<string>
   rcConfigPath?: string
   // A list of local workspace packages by name.
   // This is used to ignore local workspace packages when fetching new versions.

--- a/test/getPeerDependenciesFromRegistry.test.ts
+++ b/test/getPeerDependenciesFromRegistry.test.ts
@@ -56,4 +56,33 @@ describe('getPeerDependenciesFromRegistry', () => {
 
     logSpy.mockRestore()
   })
+
+  it('does not warn about specs the registry cannot resolve', async () => {
+    chalkInit()
+    silenceProgressBar()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const data = await getPeerDependenciesFromRegistry(
+      {
+        'ncu-test-peer': 'workspace:*',
+        'ncu-test-return-version': 'github:user/repo#1.0.0',
+        'ncu-test-v2': '*',
+        'ncu-test-tag': '',
+      },
+      {},
+    )
+
+    expect(data).toStrictEqual({
+      'ncu-test-peer': {},
+      'ncu-test-return-version': {},
+      'ncu-test-v2': {},
+      'ncu-test-tag': {},
+    })
+    const warnings = logSpy.mock.calls
+      .flat()
+      .filter(arg => typeof arg === 'string' && arg.includes('Could not determine the peer dependencies'))
+    expect(warnings).toHaveLength(0)
+
+    logSpy.mockRestore()
+  })
 })

--- a/test/getPeerDependenciesFromRegistry.test.ts
+++ b/test/getPeerDependenciesFromRegistry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { chalkInit } from '../src/lib/chalk.ts'
 import getPeerDependenciesFromRegistry from '../src/lib/getPeerDependenciesFromRegistry.ts'
 import { silenceProgressBar } from './helpers/silenceProgressBar.ts'
@@ -38,5 +38,22 @@ describe('getPeerDependenciesFromRegistry', () => {
         'ncu-test-return-version': '1.x',
       },
     })
+  })
+
+  it('warns when peer dependencies cannot be fetched instead of reporting none', async () => {
+    chalkInit()
+    silenceProgressBar()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const data = await getPeerDependenciesFromRegistry({ 'ncu-test-return-version': '99.99.99' }, {})
+
+    expect(data).toStrictEqual({ 'ncu-test-return-version': {} })
+    const warnings = logSpy.mock.calls
+      .flat()
+      .filter(arg => typeof arg === 'string' && arg.includes('Could not determine the peer dependencies'))
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('ncu-test-return-version')
+
+    logSpy.mockRestore()
   })
 })

--- a/test/package-managers/yarn/index.test.ts
+++ b/test/package-managers/yarn/index.test.ts
@@ -79,7 +79,8 @@ describe('yarn', () => {
     await expect(yarn.getPeerDependencies('ncu-test-peer', '1.0.0', spawnOptions)).resolves.toStrictEqual({
       'ncu-test-return-version': '1.x',
     })
-    await expect(yarn.getPeerDependencies('fffffffffffff', '1.0.0', spawnOptions)).resolves.toStrictEqual({})
+    // an unresolvable package must be reported as a failed lookup, not as having no peer dependencies
+    await expect(yarn.getPeerDependencies('fffffffffffff', '1.0.0', spawnOptions)).rejects.toThrow()
   })
 
   itWithSystemYarn('getPeerDependencies v4', async () => {
@@ -89,7 +90,8 @@ describe('yarn', () => {
     await expect(yarn.getPeerDependencies('ncu-test-peer', '1.0.0', spawnOptions)).resolves.toStrictEqual({
       'ncu-test-return-version': '1.x',
     })
-    await expect(yarn.getPeerDependencies('fffffffffffff', '1.0.0', spawnOptions)).resolves.toStrictEqual({})
+    // an unresolvable package must be reported as a failed lookup, not as having no peer dependencies
+    await expect(yarn.getPeerDependencies('fffffffffffff', '1.0.0', spawnOptions)).rejects.toThrow()
   })
 
   describe('npmAuthTokenKeyValue', () => {


### PR DESCRIPTION
A failed npm view resolved to {}, same as a package with no peer dependencies

Refs #1981.