### PR TITLE
fix: strip control characters from homepage/repo format output

### DIFF
--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -96,6 +96,16 @@ export function printSorted<T extends { [key: string]: any }>(options: Options, 
 }
 
 /** Create a table with the appropriate columns and alignment to render dependency upgrades. */
+/**
+ * Strips control characters (e.g. terminal escape sequences) from text that
+ * originates from an unvalidated package.json field (homepage, repository),
+ * which has no character restrictions, before it is written to the terminal.
+ */
+function sanitizeForDisplay(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\u0000-\u001f\u007f]/g, '')
+}
+
 function renderDependencyTable(rows: string[][]) {
   const table = new Table({
     colAligns: ['left', 'right', 'right', 'right', 'left', 'left'],
@@ -215,9 +225,11 @@ export async function toDependencyTable({
               : '*unknown*'
             : ''
           const toColorized = colorizeDiff(getVersion(from), shortenBuildMetadata(to))
-          const homepageUrl = format?.includes('homepage') ? packageJson?.homepage || '' : ''
+          const homepageUrl = format?.includes('homepage')
+            ? sanitizeForDisplay(packageJson?.homepage || '')
+            : ''
           const repoUrl = format?.includes('repo')
-            ? (await getRepoUrl(dep, packageJson ?? undefined, { pkgFile })) || ''
+            ? sanitizeForDisplay((await getRepoUrl(dep, packageJson ?? undefined, { pkgFile })) || '')
             : ''
           const diffUrl = format?.includes('diff')
             ? `${process.env.NCU_DIFF || 'https://npmdiff.dev'}/${encodeURIComponent(dep)}/${from.replace(/^\W+/, '')}/${to.replace(/^\W+/, '')}`


### PR DESCRIPTION
Fixes #1988

`--format homepage` and `--format repo` read a dependency's own `package.json` `homepage`/`repository` fields with no validation and wrote them straight into the upgrade table. Unlike a package name or version, these fields have no character restrictions, so a crafted dependency could inject terminal escape sequences into ncu's own output during a routine dependency check.

## Change

Adds `sanitizeForDisplay` (`src/lib/logging.ts`), which strips control characters (code points below `0x20` or `0x7f`). Applied narrowly to `homepageUrl` and `repoUrl` where they're computed, rather than at the shared table-rendering function, since other cells in the same table (dependency type label, colorized version diff) carry intentional `chalk` ANSI color codes that must not be stripped.

## Testing

- Reproduced the issue fully offline via the documented `--registry` static-file option: a local dependency with a `homepage` field containing a raw OSC title-set escape sequence, `ncu --format homepage`, raw stdout bytes inspected directly (hex-dumped, not just visually inspected) confirmed the raw escape bytes reached output adjacent to the homepage URL text.
- Re-ran the same reproduction against this fix; the injected control bytes are gone, only harmless printable text remains.
- `tsc --noEmit` and the relevant unit tests (`table.test.ts`, `logging.test.ts`, `getRepoUrl.test.ts`, `format.test.ts`, 29 tests total) pass unchanged.
- Note on environment: the available Node here was v18.19.1, below the `engines.node` requirement, which caused a hard install failure; used a Node v26.0.0 binary for installing dependencies, building, and testing, no project files depend on this.