### PR TITLE
Auto-merge dependabot minor/patch updates, never majors

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'raineorshine'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Major version updates are never auto-merged; they require manual review.
+      - name: Enable auto-merge for minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[EXPERIMENTAL]

## Summary

Analysis of the current setup: there is no merge automation in the repo today — no auto-merge workflow, no Mergify/Kodiak/Renovate config, and every recent dependabot PR was merged manually (`autoMergeRequest` is null on all of them). [dependabot.yml](https://github.com/raineorshine/npm-check-updates/blob/main/.github/dependabot.yml) already groups npm minor/patch updates, so major bumps always arrive as individual PRs.

This PR adds `.github/workflows/dependabot-auto-merge.yml`, which codifies the policy **major version dependabot updates are never auto-merged**:

- On each dependabot PR, [dependabot/fetch-metadata](https://github.com/dependabot/fetch-metadata) determines the update type (for grouped PRs, the highest bump in the group).
- For `semver-minor` and `semver-patch` updates, GitHub native auto-merge is enabled (`gh pr merge --auto --squash`), so the PR merges only after all required status checks pass.
- For `semver-major` updates, the step is skipped and the PR stays open for manual review.

The workflow follows the repo's existing conventions: actions pinned to full SHAs, `permissions: {}` at the top level with minimal job-level grants, env-var interpolation (no template injection), and the non-spoofable `github.event.pull_request.user.login` check rather than `github.actor`.

## Required repo settings (not changeable from a PR)

For the auto-merge behavior to work as intended, two settings need to be enabled in the repo:

1. **Settings → General → Allow auto-merge** — otherwise the `gh pr merge --auto` call fails.
2. **Branch protection / ruleset on `main` with required status checks** (e.g. Tests, Lint, Build) — without required checks, enabling auto-merge merges the PR immediately instead of waiting for CI.

Until those are enabled, this workflow is inert-but-safe: majors are skipped either way, and the auto-merge step simply errors if the setting is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)