### PR TITLE
Add support for excluding deprecated versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
   </tr>
   <tr>
     <td>--deprecated</td>
-    <td>Include deprecated packages. Use <code>--no-deprecated</code> to exclude deprecated packages (20–25% slower). (default: <code>true</code>)</td>
+    <td>Include deprecated packages. Use <code>--no-deprecated</code> to exclude deprecated packages. (default: <code>true</code>)</td>
   </tr>
   <tr>
     <td><a href="#doctor">-d, --doctor</a></td>

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -745,7 +745,7 @@ const cliOptions: CLIOption[] = [
   {
     long: 'deprecated',
     default: true,
-    description: 'Include deprecated packages. Use `--no-deprecated` to exclude deprecated packages (20–25% slower).',
+    description: 'Include deprecated packages. Use `--no-deprecated` to exclude deprecated packages.',
     type: 'boolean',
   },
   {

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -809,8 +809,8 @@ async function fetchUpgradedPackument(
         new Set([
           'dist-tags',
           ...fields,
-          ...(!options.deprecated ? (['deprecated', 'versions'] as const) : []),
-          ...(options.enginesNode ? (['engines', 'versions'] as const) : []),
+          // deprecated and engines are only set on entries of versions, not on the packument itself
+          ...(!options.deprecated || options.enginesNode ? (['versions'] as const) : []),
         ]),
       ),
       fullMetadata ? null : tag,

--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -141,6 +141,34 @@ const fetchPartialPackument = async (
   }
 }
 
+/**
+ * Fetches the manifest published to a dist-tag in packument shape.
+ * Returns null if the tag does not exist or the registry does not serve manifests.
+ */
+const fetchTagManifest = async (
+  name: string,
+  tag: string,
+  opts: npmRegistryFetch.FetchOptions,
+): Promise<Partial<Packument> | null> => {
+  let manifest: Partial<Packument>
+  try {
+    // a manifest is a few KB, so read it whole instead of aborting the stream partway
+    manifest = await fetchPartialPackument(name, [], null, { ...opts, fullMetadata: true }, tag)
+  } catch (err: any) {
+    // a missing tag and an unsupported endpoint are both 4xx
+    if (err.statusCode >= 400 && err.statusCode < 500) return null
+    throw err
+  }
+
+  if (!manifest?.version) return null
+
+  return {
+    name,
+    'dist-tags': { [tag]: manifest.version },
+    versions: { [manifest.version]: manifest as Packument['versions'][string] },
+  }
+}
+
 interface GreatestWithFallbackResult {
   targetVersion: string | null
   fallbackVersion: string | null
@@ -763,6 +791,18 @@ async function fetchUpgradedPackument(
   let result: Partial<Packument> | undefined
   try {
     const tag = options.distTag || 'latest'
+
+    // when a single tag is requested, its manifest exposes deprecated without the whole versions map
+    if (options.distTag && !options.deprecated && !fullMetadata && fields.length === 1 && fields[0] === 'dist-tags') {
+      const manifest = await fetchTagManifest(packageName, tag, npmConfigMerged)
+      if (manifest) return manifest
+
+      // the manifest is missing both when the tag does not exist and when the registry does not
+      // serve manifests, so resolve the tag before paying for the versions map
+      const distTags = await fetchPartialPackument(packageName, ['dist-tags'], tag, npmConfigMerged)
+      if (!distTags['dist-tags']?.[tag]) return distTags
+    }
+
     result = await fetchPartialPackument(
       packageName,
       Array.from(
@@ -974,12 +1014,13 @@ export const getDistTags = async (
   npmConfigLocal?: NpmConfig,
   npmConfigWorkspaceProject?: NpmConfig,
 ): Promise<Index<Version>> => {
-  // currentVersion is only used to short circuit unfetchable specs, which does not apply here
+  // currentVersion is only used to short circuit unfetchable specs, which does not apply here.
+  // distTag is cleared because every tag is needed here, not just the one being upgraded to.
   const packument = await npmApi.fetchUpgradedPackumentMemo(
     packageName,
     ['dist-tags'],
     '',
-    options,
+    { ...options, distTag: undefined },
     0,
     npmConfigLocal,
     npmConfigWorkspaceProject,

--- a/src/types/Packument.ts
+++ b/src/types/Packument.ts
@@ -4,7 +4,8 @@ import { type Version } from './Version.ts'
 /** A packument result object from npm-registry-fetch. */
 export interface Packument {
   name: string
-  deprecated?: boolean
+  // The deprecation message. Only set on entries of `versions`
+  deprecated?: string
   'dist-tags': Index<Version>
   engines: {
     node: string

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -79,7 +79,7 @@
         },
         "deprecated": {
           "type": "boolean",
-          "description": "Include deprecated packages. Use `--no-deprecated` to exclude deprecated packages (20–25% slower).",
+          "description": "Include deprecated packages. Use `--no-deprecated` to exclude deprecated packages.",
           "default": true
         },
         "doctor": {

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -56,7 +56,7 @@ export interface RunOptions {
    */
   dep?: string | readonly string[]
 
-  /** Include deprecated packages. Use `--no-deprecated` to exclude deprecated packages (20–25% slower).
+  /** Include deprecated packages. Use `--no-deprecated` to exclude deprecated packages.
    *
    * @default true
    */

--- a/test/enginesNode.test.ts
+++ b/test/enginesNode.test.ts
@@ -38,6 +38,24 @@ describe('enginesNode', () => {
     expect(upgraded).toStrictEqual({})
   })
 
+  // the dist-tag manifest is skipped when deprecated versions are allowed, so engines has to come from the versions map
+  it('do not update packages with incompatible engines.node when deprecated versions are allowed', async () => {
+    const upgraded = await ncu({
+      enginesNode: true,
+      deprecated: true,
+      packageData: {
+        dependencies: {
+          del: '3.0.0',
+        },
+        engines: {
+          node: '>=1',
+        },
+      },
+    })
+
+    expect(upgraded).toStrictEqual({})
+  })
+
   it('update packages that do not have engines.node', async () => {
     const upgraded = (await ncu({
       enginesNode: true,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -172,6 +172,48 @@ describe('run', () => {
       })
       expect(upgrades).toStrictEqual({})
     })
+
+    it('non-deprecated latest upgraded with --no-deprecated', async () => {
+      const upgrades = await ncu({
+        deprecated: false,
+        packageData: {
+          dependencies: {
+            'ncu-test-v2': '1.0.0',
+          },
+        },
+      })
+      expect(upgrades).toStrictEqual({
+        'ncu-test-v2': '2.0.0',
+      })
+    })
+
+    it('custom dist-tag upgraded with --no-deprecated', async () => {
+      const upgrades = await ncu({
+        deprecated: false,
+        target: '@next',
+        packageData: {
+          dependencies: {
+            'ncu-test-tag': '0.1.0',
+          },
+        },
+      })
+      expect(upgrades).toStrictEqual({
+        'ncu-test-tag': '1.0.0-1',
+      })
+    })
+
+    it('unknown dist-tag skipped with --no-deprecated', async () => {
+      const upgrades = await ncu({
+        deprecated: false,
+        target: '@nonexistent',
+        packageData: {
+          dependencies: {
+            'ncu-test-tag': '0.1.0',
+          },
+        },
+      })
+      expect(upgrades).toStrictEqual({})
+    })
   })
 
   it('ignore non-string versions (sometimes used as comments)', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import ncu from '../src/index.ts'
+import { type Packument } from '../src/types/Packument.ts'
 import removeDir from './helpers/removeDir.ts'
 import stubVersions from './helpers/stubVersions.ts'
 
@@ -200,6 +201,35 @@ describe('run', () => {
       expect(upgrades).toStrictEqual({
         'ncu-test-tag': '1.0.0-1',
       })
+    })
+
+    it('deprecation message treated as deprecated', async () => {
+      const stub = stubVersions({
+        'ncu-test-deprecated': {
+          name: 'ncu-test-deprecated',
+          'dist-tags': { latest: '2.0.0' },
+          version: '2.0.0',
+          versions: {
+            '1.0.0': { version: '1.0.0' } as Packument,
+            '1.5.0': { version: '1.5.0' } as Packument,
+            '2.0.0': { version: '2.0.0', deprecated: 'use 1.5.0 instead' } as Packument,
+          },
+        },
+      })
+
+      const upgrades = await ncu({
+        deprecated: false,
+        packageData: {
+          dependencies: {
+            'ncu-test-deprecated': '1.0.0',
+          },
+        },
+      })
+      expect(upgrades).toStrictEqual({
+        'ncu-test-deprecated': '1.5.0',
+      })
+
+      stub.restore()
     })
 
     it('unknown dist-tag skipped with --no-deprecated', async () => {

--- a/test/package-managers/npm/index.test.ts
+++ b/test/package-managers/npm/index.test.ts
@@ -79,6 +79,16 @@ describe('npm', () => {
     })
   })
 
+  // the single-tag manifest only knows about one tag, so it must not be used here
+  it('getDistTags returns every tag even when a distTag is being upgraded to', async () => {
+    const distTags = await npm.getDistTags('ncu-test-tag', { cwd: __dirname, distTag: 'latest' })
+    expect(distTags).toMatchObject({
+      latest: '1.1.0',
+      next: '1.0.0-1',
+      dev: '1.2.0-dev.0',
+    })
+  })
+
   it('ownerChanged', async () => {
     await expect(npm.packageAuthorChanged('mocha', '^7.1.0', '8.0.1')).resolves.toBe(true)
     await expect(npm.packageAuthorChanged('htmlparser2', '^3.10.1', '^4.0.0')).resolves.toBe(false)


### PR DESCRIPTION
Please check the individual patches. The second patch can be considered a breaking change, though.

**If merged this should not be squashed.**

Fixes #1550.