### PR TITLE
Test getModuleMismatchError directly instead of through a real config load

### DIFF
--- a/src/lib/getNcuRc.ts
+++ b/src/lib/getNcuRc.ts
@@ -20,7 +20,7 @@ const loadYaml: Loader = (filepath, content) => {
  * Detects module system mismatches and returns a helpful error message.
  * Returns null if it's not a known module mismatch (generic error).
  */
-function getModuleMismatchError(errorMessage: string, filename: string): string | null {
+export function getModuleMismatchError(errorMessage: string, filename: string): string | null {
   const basename = path.basename(filename)
 
   // Detect CommonJS syntax in ESM project (type: "module")
@@ -40,7 +40,7 @@ function getModuleMismatchError(errorMessage: string, filename: string): string 
     (errorMessage.includes('SyntaxError') && errorMessage.includes('import'))
 
   // Only provide specific guidance for .js files, not .cjs/.mjs
-  const isJsFile = filename.endsWith('.js') && !filename.endsWith('.cjs') && !filename.endsWith('.mjs')
+  const isJsFile = filename.endsWith('.js')
 
   if (isCjsInEsm && isJsFile) {
     return (

--- a/test/getNcuRc.test.ts
+++ b/test/getNcuRc.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import getNcuRc from '../src/lib/getNcuRc.ts'
+import getNcuRc, { getModuleMismatchError } from '../src/lib/getNcuRc.ts'
 import removeDir from './helpers/removeDir.ts'
 
 describe('getNcuRc', () => {
@@ -71,6 +71,8 @@ describe('getNcuRc', () => {
     await expect(getNcuRc({ configFilePath: tempDir, options: {} })).rejects.toThrow('YAML Error in')
   })
 
+  // the reverse direction (ESM in a CommonJS project) is covered by the getModuleMismatchError tests below;
+  // loading such a file makes Node print an uncatchable "Failed to load the ES module" warning
   it('suggests ESM syntax when a .ncurc.js uses CommonJS in a "type": "module" project', async () => {
     await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify({ type: 'module' }))
     await fs.writeFile(path.join(tempDir, '.ncurc.js'), 'module.exports = { upgrade: true }\n')
@@ -80,18 +82,55 @@ describe('getNcuRc', () => {
     )
   })
 
-  it('suggests adding "type": "module" when a .ncurc.js uses ESM in a CommonJS project', async () => {
-    await fs.writeFile(path.join(tempDir, 'package.json'), JSON.stringify({ type: 'commonjs' }))
-    await fs.writeFile(path.join(tempDir, '.ncurc.js'), 'export default { upgrade: true }\n')
-
-    await expect(getNcuRc({ configFilePath: tempDir, options: {} })).rejects.toThrow(
-      '.ncurc.js uses ESM syntax (import/export) but your package.json has "type": "commonjs".',
-    )
-  })
-
   it('reports a generic config file error for a .cjs that is not a module mismatch', async () => {
     await fs.writeFile(path.join(tempDir, '.ncurc.cjs'), 'throw new Error("boom")\n')
 
     await expect(getNcuRc({ configFilePath: tempDir, options: {} })).rejects.toThrow('Config file error: boom')
+  })
+})
+
+describe('getModuleMismatchError', () => {
+  // messages Node throws when a CommonJS file is loaded as ESM
+  for (const message of [
+    '__filename is not defined in ES module scope',
+    '__dirname is not defined in ES module scope',
+    'require is not defined in ES module scope',
+    'module is not defined in ES module scope',
+    'exports is not defined in ES module scope',
+  ]) {
+    it(`recommends ESM syntax for "${message}"`, () => {
+      const error = getModuleMismatchError(message, '/project/.ncurc.js')
+
+      expect(error).toContain(
+        '.ncurc.js uses CommonJS syntax (require/module.exports) but your package.json has "type": "module".',
+      )
+      expect(error).toContain('Rename to .ncurc.cjs')
+    })
+  }
+
+  // messages Node throws when an ESM file is loaded as CommonJS
+  for (const message of [
+    'Cannot use import statement outside a module',
+    "Unexpected token 'export'",
+    "Unexpected token 'import'",
+    'SyntaxError: export default {}',
+    'SyntaxError: unexpected import',
+  ]) {
+    it(`recommends "type": "module" for "${message}"`, () => {
+      const error = getModuleMismatchError(message, '/project/.ncurc.js')
+
+      expect(error).toContain('.ncurc.js uses ESM syntax (import/export) but your package.json has "type": "commonjs".')
+      expect(error).toContain('Rename to .ncurc.mjs')
+    })
+  }
+
+  it('returns null for an error that is not a module mismatch', () => {
+    expect(getModuleMismatchError('boom', '/project/.ncurc.js')).toBe(null)
+    expect(getModuleMismatchError('', '/project/.ncurc.js')).toBe(null)
+  })
+
+  it('returns null for .cjs and .mjs, whose module system is unambiguous', () => {
+    expect(getModuleMismatchError("Unexpected token 'export'", '/project/.ncurc.cjs')).toBe(null)
+    expect(getModuleMismatchError('module is not defined in ES module scope', '/project/.ncurc.mjs')).toBe(null)
   })
 })


### PR DESCRIPTION
The ESM warnings started to show up after #1985:

```
 (node:6533) Warning: Failed to load the ES module: /tmp/ncu-test-rc-mSgASc/.ncurc.js. Make sure to set "type": "module" in the nearest package.json file or use the .mjs extension.
```