### PR TITLE
Speed up `--format ownerChanged`

### DIFF
--- a/src/package-managers/npm.ts
+++ b/src/package-managers/npm.ts
@@ -697,23 +697,28 @@ export async function packageAuthorChanged(
 ): Promise<boolean> {
   const npmConfig = npmApi.findNpmConfig()
   // merge the project/cwd .npmrc so a scoped private registry is respected, like the main fetch path
-  const npmConfigMerged = mergeNpmConfigs(
-    { npmConfigUser: { ...npmConfig, fullMetadata: true }, npmConfigLocal },
-    options,
-  )
+  const npmConfigMerged = mergeNpmConfigs({ npmConfigUser: { ...npmConfig }, npmConfigLocal }, options)
   const result = await fetchPartialPackument(packageName, ['versions'], null, npmConfigMerged)
-  if (result.versions) {
-    const pkgVersions = Object.keys(result.versions)
-    const current = nodeSemver.minSatisfying(pkgVersions, currentVersion)
-    const upgraded = nodeSemver.maxSatisfying(pkgVersions, upgradedVersion)
-    if (current && upgraded && result.versions[current]._npmUser && result.versions[upgraded]._npmUser) {
-      const currentAuthor = result.versions[current]._npmUser?.name
-      const latestAuthor = result.versions[upgraded]._npmUser?.name
-      return currentAuthor !== latestAuthor
-    }
-  }
+  if (!result.versions) return false
 
-  return false
+  const pkgVersions = Object.keys(result.versions)
+  const current = nodeSemver.minSatisfying(pkgVersions, currentVersion)
+  const upgraded = nodeSemver.maxSatisfying(pkgVersions, upgradedVersion)
+  // one version cannot have two publishers, so skip the manifests entirely
+  if (!current || !upgraded || current === upgraded) return false
+
+  // the abbreviated packument has the version list but not _npmUser, so read the publisher from the
+  // two version manifests instead of pulling the full packument
+  const [currentManifest, upgradedManifest] = await Promise.all([
+    fetchPartialPackument(packageName, ['_npmUser'], null, npmConfigMerged, current),
+    fetchPartialPackument(packageName, ['_npmUser'], null, npmConfigMerged, upgraded),
+  ])
+
+  const currentAuthor = currentManifest._npmUser?.name
+  const upgradedAuthor = upgradedManifest._npmUser?.name
+  if (!currentAuthor || !upgradedAuthor) return false
+
+  return currentAuthor !== upgradedAuthor
 }
 
 /**

--- a/src/types/Packument.ts
+++ b/src/types/Packument.ts
@@ -4,6 +4,10 @@ import { type Version } from './Version.ts'
 /** A packument result object from npm-registry-fetch. */
 export interface Packument {
   name: string
+  // Omitted from abbreviated packuments, so it has to be read from a version manifest
+  _npmUser?: {
+    name: string
+  }
   deprecated?: boolean
   'dist-tags': Index<Version>
   engines: {
@@ -13,11 +17,5 @@ export interface Packument {
   // TODO: store only the time of the latest version?
   time?: Index<string>
   version: Version
-  versions: Index<
-    Omit<Packument, 'versions'> & {
-      _npmUser?: {
-        name: string
-      }
-    }
-  >
+  versions: Index<Omit<Packument, 'versions'>>
 }


### PR DESCRIPTION
- read _npmUser from the two version manifests instead of the full packument
- run getOwnerPerDependency at --concurrency instead of one dependency at a time

---

Noticed this while looking at #961.

`--format ownerChanged` is the most expensive path in ncu, for two unrelated reasons:

- `packageAuthorChanged` requested the full packument just to read `_npmUser` for two versions. The abbreviated packument has the same version list, and `_npmUser` is in the version manifest, so it now resolves the two versions from the abbreviated packument and fetches those two manifests.
- `getOwnerPerDependency` awaited one dependency at a time. It now uses `pMap` at `--concurrency`, like `queryVersions` and `getPeerDependenciesFromRegistry`.

30 outdated dependencies, gzipped wire bytes:

| | requests | bytes |
| --- | --- | --- |
| before | 30 sequential | 6.69 MB |
| after | 90 at concurrency 8 | 4.84 MB |

The extra requests are 1-3 KB each and now overlap, so effective round trips drop from 30 to ~11. Per package the spread is wide: mocha 871 KB -> 97 KB, htmlparser2 38 KB -> 30 KB, and a package with very few versions costs ~2 KB more.

---

**I'm not sure we want this to land at all, just opening for discussion and testing.**