### PR TITLE
feat: add --interactiveSelect to control pre-selected upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,30 @@ Combine with `--format group` for a truly _luxe_ experience:
 - <kbd>a</kbd> Toggle all
 - <kbd>Enter</kbd> Upgrade
 
+### Pre-selected upgrades
+
+`ncu -i` pre-selects patch and minor upgrades, since `--format group` is enabled by default. Only when group formatting is disabled with `--format no-group` are all upgrades pre-selected, including major. Use `--interactiveSelect` to control this explicitly:
+
+```sh
+# start with nothing selected
+ncu -i --interactiveSelect none
+
+# pre-select patch upgrades only
+ncu -i --interactiveSelect patch
+
+# pre-select patch and minor upgrades
+ncu -i --interactiveSelect minor
+
+# pre-select everything, including major
+ncu -i --interactiveSelect all
+
+# the default: patch and minor with --format group, everything otherwise
+# specify it explicitly to override a value set in your config file
+ncu -i --interactiveSelect auto
+```
+
+Major version zero upgrades (e.g. `0.1.0` → `0.2.0`) are only pre-selected by `all`, since anything may change before `1.0.0`. Custom groups returned by [--groupFunction](#groupfunction) are likewise only pre-selected by `all`.
+
 ## Filter packages
 
 Filter packages using the `--filter` option or adding additional cli arguments:
@@ -287,6 +311,10 @@ Options that take no arguments can be negated by prefixing them with `--no-`, e.
   <tr>
     <td>-i, --interactive</td>
     <td>Enable interactive prompts for each dependency; implies <code>-u</code> unless one of the json options are set.</td>
+  </tr>
+  <tr>
+    <td><a href="#interactiveselect">--interactiveSelect &lt;value&gt;</a></td>
+    <td>Control which upgrades are pre-selected in interactive mode: auto, none, patch, minor, all. Only applies with <code>--interactive</code>. (default: <code>"auto"</code>)</td>
   </tr>
   <tr>
     <td>-j, --jsonAll</td>
@@ -739,6 +767,30 @@ Control the auto-install behavior.
   <tr><td>never</td><td>Does not install and does not prompt.</td></tr>
   <tr><td>prompt</td><td>Shows a message after upgrading that recommends an install, but does not install. In interactive mode, prompts for install. (default)</td></tr>
 </table>
+
+## interactiveSelect
+
+Usage:
+
+```sh
+ncu --interactiveSelect [value]
+```
+
+Default: auto
+
+Control which upgrades are pre-selected in interactive mode. Only applies with `--interactive`.
+
+<table>
+  <tr><td>auto</td><td>Pre-selects patch and minor upgrades with <code>--format group</code>, which is enabled by default, and all upgrades otherwise. This is what <code>ncu -i</code> does. (default)</td></tr>
+  <tr><td>none</td><td>Nothing is pre-selected.</td></tr>
+  <tr><td>patch</td><td>Patch upgrades are pre-selected.</td></tr>
+  <tr><td>minor</td><td>Patch and minor upgrades are pre-selected.</td></tr>
+  <tr><td>all</td><td>All upgrades are pre-selected, including major.</td></tr>
+</table>
+
+Specify `auto` explicitly to restore the default when another value is set in your [config file](#config-file).
+
+Major version zero upgrades (e.g. 0.1.0 → 0.2.0) are only pre-selected by `all`, since anything may change before 1.0.0. Custom groups returned by [--groupFunction](#groupfunction) are likewise only pre-selected by `all`.
 
 ## packageManager
 

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -226,6 +226,34 @@ const extendedHelpInstall: ExtendedHelp = ({ markdown }) => {
 `
 }
 
+/** Extended help for the --interactiveSelect option. */
+const extendedHelpInteractiveSelect: ExtendedHelp = ({ markdown }) => {
+  const header = 'Control which upgrades are pre-selected in interactive mode. Only applies with `--interactive`.'
+  const tableString = table({
+    colAligns: ['right', 'left'],
+    markdown,
+    rows: [
+      [
+        'auto',
+        `Pre-selects patch and minor upgrades with \`--format group\`, which is enabled by default, and all upgrades otherwise. This is what \`ncu -i\` does. (default)`,
+      ],
+      ['none', `Nothing is pre-selected.`],
+      ['patch', `Patch upgrades are pre-selected.`],
+      ['minor', `Patch and minor upgrades are pre-selected.`],
+      ['all', `All upgrades are pre-selected, including major.`],
+    ],
+  })
+
+  return `${header}
+
+${padLeft(tableString, markdown ? 0 : 4)}
+
+Specify \`auto\` explicitly to restore the default when another value is set in your ${readmeLink('config file', 'config-file', { markdown })}.
+
+Major version zero upgrades (e.g. 0.1.0 → 0.2.0) are only pre-selected by \`all\`, since anything may change before 1.0.0. Custom groups returned by ${readmeLink('--groupFunction', 'groupfunction', { markdown })} are likewise only pre-selected by \`all\`.
+`
+}
+
 /** Extended help for the --filter option. */
 const extendedHelpFilterFunction: ExtendedHelp = ({ markdown }) => {
   return `Include only package names matching the given string, wildcard, glob, comma-or-space-delimited list, /regex/, or predicate function. Only included packages will be checked with \`--peer\`.
@@ -839,6 +867,16 @@ const cliOptions: CLIOption[] = [
     short: 'i',
     description: 'Enable interactive prompts for each dependency; implies `-u` unless one of the json options are set.',
     type: 'boolean',
+  },
+  {
+    long: 'interactiveSelect',
+    arg: 'value',
+    description:
+      'Control which upgrades are pre-selected in interactive mode: auto, none, patch, minor, all. Only applies with `--interactive`.',
+    help: extendedHelpInteractiveSelect,
+    default: 'auto',
+    choices: ['auto', 'none', 'patch', 'minor', 'all'],
+    type: `'auto' | 'none' | 'patch' | 'minor' | 'all'`,
   },
   {
     // program.json is set to true in programInit if any options that begin with 'json' are true

--- a/src/lib/isPreSelected.ts
+++ b/src/lib/isPreSelected.ts
@@ -1,0 +1,38 @@
+import { type InteractiveSelect, type ResolvedInteractiveSelect } from '../types/InteractiveSelect.ts'
+import { type Options } from '../types/Options.ts'
+import { partChanged } from './version-util.ts'
+
+/** The upgrade groups that are pre-selected for each --interactiveSelect value. `all` pre-selects every group, including custom groups returned by --groupFunction, so it is not enumerated here. */
+const preSelectedGroups: Record<Exclude<ResolvedInteractiveSelect, 'all'>, string[]> = {
+  none: [],
+  patch: ['patch'],
+  minor: ['patch', 'minor'],
+}
+
+/**
+ * Resolves `auto` (the default) to a concrete --interactiveSelect value. `auto` preserves the historical behavior:
+ * patch and minor are pre-selected with `--format group`, and everything is pre-selected otherwise.
+ */
+export const resolveInteractiveSelect = (options: Options): ResolvedInteractiveSelect => {
+  const interactiveSelect: InteractiveSelect = options.interactiveSelect ?? 'auto'
+  return interactiveSelect !== 'auto' ? interactiveSelect : options.format?.includes('group') ? 'minor' : 'all'
+}
+
+/**
+ * Determines if an upgrade group is pre-selected in interactive mode. majorVersionZero and custom groups are only
+ * pre-selected by `all`, since anything may change in a 0.x upgrade and custom groups have unknown semantics.
+ */
+export const isPreSelectedGroup = (groupName: string, interactiveSelect: ResolvedInteractiveSelect): boolean =>
+  interactiveSelect === 'all' || preSelectedGroups[interactiveSelect].includes(groupName)
+
+/** Determines if a dependency upgrade is pre-selected in interactive mode, based on the semver part that changed. */
+export const isPreSelectedUpgrade = (
+  from: string,
+  to: string,
+  interactiveSelect: ResolvedInteractiveSelect,
+): boolean => {
+  // short-circuit the group derivation, which is not needed when everything or nothing is pre-selected
+  if (interactiveSelect === 'all') return true
+  if (interactiveSelect === 'none') return false
+  return isPreSelectedGroup(partChanged(from, to), interactiveSelect)
+}

--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -17,6 +17,7 @@ import { getIgnoredUpgradesDueToEnginesNode } from './getIgnoredUpgradesDueToEng
 import getIgnoredUpgradesDueToPeerDeps from './getIgnoredUpgradesDueToPeerDeps.ts'
 import getPackageManager from './getPackageManager.ts'
 import getPeerDependenciesFromRegistry from './getPeerDependenciesFromRegistry.ts'
+import { isPreSelectedGroup, isPreSelectedUpgrade, resolveInteractiveSelect } from './isPreSelected.ts'
 import keyValueBy from './keyValueBy.ts'
 import {
   print,
@@ -112,6 +113,8 @@ const chooseUpgrades = async (
   if (Object.keys(newDependencies).length > 0) {
     print(options, '')
 
+    const interactiveSelect = resolveInteractiveSelect(options)
+
     if (options.format?.includes('group')) {
       const groups = getDependencyGroups(newDependencies, oldDependencies, options)
 
@@ -123,7 +126,7 @@ const chooseUpgrades = async (
             .map(dep => ({
               title: formattedLines[dep],
               value: dep,
-              selected: ['patch', 'minor'].includes(groupName),
+              selected: isPreSelectedGroup(groupName, interactiveSelect),
             })),
         ]
       })
@@ -150,7 +153,7 @@ const chooseUpgrades = async (
         .map(dep => ({
           title: formattedLines[dep],
           value: dep,
-          selected: true,
+          selected: isPreSelectedUpgrade(oldDependencies[dep], newDependencies[dep], interactiveSelect),
         }))
 
       const response = await prompts({

--- a/src/types/InteractiveSelect.ts
+++ b/src/types/InteractiveSelect.ts
@@ -1,0 +1,5 @@
+/** Which upgrades are pre-selected in interactive mode, controlled by `--interactiveSelect`. */
+export type InteractiveSelect = 'auto' | 'none' | 'patch' | 'minor' | 'all'
+
+/** An --interactiveSelect value with `auto` resolved to a concrete value. */
+export type ResolvedInteractiveSelect = Exclude<InteractiveSelect, 'auto'>

--- a/src/types/RunOptions.json
+++ b/src/types/RunOptions.json
@@ -188,6 +188,12 @@
           "type": "boolean",
           "description": "Enable interactive prompts for each dependency; implies `-u` unless one of the json options are set."
         },
+        "interactiveSelect": {
+          "type": "string",
+          "enum": ["auto", "none", "patch", "minor", "all"],
+          "description": "Control which upgrades are pre-selected in interactive mode: auto, none, patch, minor, all. Only applies with `--interactive`. Run \"ncu --help --interactiveSelect\" for details.",
+          "default": "auto"
+        },
         "jsonAll": {
           "type": "boolean",
           "description": "Output new package file instead of human-readable message."

--- a/src/types/RunOptions.ts
+++ b/src/types/RunOptions.ts
@@ -110,6 +110,12 @@ export interface RunOptions {
   /** Enable interactive prompts for each dependency; implies `-u` unless one of the json options are set. */
   interactive?: boolean
 
+  /** Control which upgrades are pre-selected in interactive mode: auto, none, patch, minor, all. Only applies with `--interactive`. Run "ncu --help --interactiveSelect" for details.
+   *
+   * @default "auto"
+   */
+  interactiveSelect?: 'auto' | 'none' | 'patch' | 'minor' | 'all'
+
   /** Output new package file instead of human-readable message. */
   jsonAll?: boolean
 

--- a/test/interactive.test.ts
+++ b/test/interactive.test.ts
@@ -226,4 +226,54 @@ describe('--interactive', () => {
       await removeDir(tempDir)
     }
   })
+  // Pre-selection cannot be observed end-to-end, since INJECT_PROMPTS replaces the prompt entirely.
+  // See test/interactiveSelect.test.ts for the pre-selected state and test/isPreSelected.test.ts for the logic itself.
+  describe('--interactiveSelect', () => {
+    it('rejects an invalid value', async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+      const pkgFile = path.join(tempDir, 'package.json')
+      await fs.writeFile(pkgFile, JSON.stringify({ dependencies: { 'ncu-test-v2': '1.0.0' } }), 'utf-8')
+      try {
+        await expect(
+          spawn('node', [bin, '--interactive', '--interactiveSelect', 'bogus'], {}, { cwd: tempDir }),
+        ).rejects.toThrow(
+          'Invalid option value: --interactiveSelect bogus. Valid values are: auto, none, patch, minor, all.',
+        )
+      } finally {
+        await removeDir(tempDir)
+      }
+    })
+
+    it('accepts a valid value', async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+      const pkgFile = path.join(tempDir, 'package.json')
+      await fs.writeFile(
+        pkgFile,
+        JSON.stringify({ dependencies: { 'ncu-test-v2': '1.0.0', 'ncu-test-tag': '1.0.0' } }),
+        'utf-8',
+      )
+      try {
+        await spawn(
+          'node',
+          [bin, '--interactive', '--interactiveSelect', 'none'],
+          {},
+          {
+            cwd: tempDir,
+            env: {
+              ...process.env,
+              INJECT_PROMPTS: JSON.stringify([['ncu-test-v2'], true]),
+            },
+          },
+        )
+
+        const upgradedPkg = JSON.parse(await fs.readFile(pkgFile, 'utf-8'))
+        expect(upgradedPkg.dependencies).toStrictEqual({
+          'ncu-test-v2': '2.0.0',
+          'ncu-test-tag': '1.0.0',
+        })
+      } finally {
+        await removeDir(tempDir)
+      }
+    })
+  })
 })

--- a/test/interactiveSelect.test.ts
+++ b/test/interactiveSelect.test.ts
@@ -1,0 +1,123 @@
+import prompts from 'prompts-ncu'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ncu from '../src/index.ts'
+import stubVersions from './helpers/stubVersions.ts'
+
+vi.mock('prompts-ncu', () => {
+  const prompt = vi.fn(async () => ({ value: [] }))
+  return { default: Object.assign(prompt, { inject: vi.fn(), override: vi.fn() }) }
+})
+
+const packageData = {
+  dependencies: {
+    'patch-dep': '1.0.0',
+    'minor-dep': '1.0.0',
+    'major-dep': '1.0.0',
+    'major-version-zero-dep': '0.1.0',
+  },
+}
+
+const versions = {
+  'patch-dep': '1.0.1',
+  'minor-dep': '1.1.0',
+  'major-dep': '2.0.0',
+  'major-version-zero-dep': '0.2.0',
+}
+
+/** Runs ncu in interactive mode and returns the names of the pre-selected dependencies, sorted for stable comparison across group and non-group formats. */
+const preSelected = async (options: Parameters<typeof ncu>[0]): Promise<string[]> => {
+  const stub = stubVersions(versions)
+  try {
+    await ncu({ packageData, interactive: true, jsonUpgraded: true, ...options })
+  } finally {
+    stub.restore()
+  }
+
+  const { choices } = vi.mocked(prompts).mock.calls.at(-1)![0] as any
+  return choices
+    .filter((choice: any) => choice.selected)
+    .map((choice: any) => choice.value)
+    .sort()
+}
+
+afterEach(() => {
+  vi.mocked(prompts).mockClear()
+})
+
+describe('--interactiveSelect', () => {
+  describe('--format group', () => {
+    const format = ['group']
+
+    it('defaults to patch and minor', async () => {
+      expect(await preSelected({ format })).toStrictEqual(['minor-dep', 'patch-dep'])
+    })
+
+    it('auto', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'auto' })).toStrictEqual(['minor-dep', 'patch-dep'])
+    })
+
+    it('none', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'none' })).toStrictEqual([])
+    })
+
+    it('patch', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'patch' })).toStrictEqual(['patch-dep'])
+    })
+
+    it('minor', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'minor' })).toStrictEqual(['minor-dep', 'patch-dep'])
+    })
+
+    it('all', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'all' })).toStrictEqual([
+        'major-dep',
+        'major-version-zero-dep',
+        'minor-dep',
+        'patch-dep',
+      ])
+    })
+  })
+
+  describe('without --format group', () => {
+    const format: string[] = []
+
+    it('defaults to all', async () => {
+      expect(await preSelected({ format })).toStrictEqual([
+        'major-dep',
+        'major-version-zero-dep',
+        'minor-dep',
+        'patch-dep',
+      ])
+    })
+
+    it('auto', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'auto' })).toStrictEqual([
+        'major-dep',
+        'major-version-zero-dep',
+        'minor-dep',
+        'patch-dep',
+      ])
+    })
+
+    it('none', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'none' })).toStrictEqual([])
+    })
+
+    it('patch', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'patch' })).toStrictEqual(['patch-dep'])
+    })
+
+    it('minor', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'minor' })).toStrictEqual(['minor-dep', 'patch-dep'])
+    })
+
+    it('all', async () => {
+      expect(await preSelected({ format, interactiveSelect: 'all' })).toStrictEqual([
+        'major-dep',
+        'major-version-zero-dep',
+        'minor-dep',
+        'patch-dep',
+      ])
+    })
+  })
+})

--- a/test/isPreSelected.test.ts
+++ b/test/isPreSelected.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { isPreSelectedGroup, isPreSelectedUpgrade, resolveInteractiveSelect } from '../src/lib/isPreSelected.ts'
+
+describe('resolveInteractiveSelect', () => {
+  it('defaults to minor with --format group', () => {
+    expect(resolveInteractiveSelect({ format: ['group'] })).toBe('minor')
+  })
+
+  it('defaults to all without --format group', () => {
+    expect(resolveInteractiveSelect({})).toBe('all')
+    expect(resolveInteractiveSelect({ format: ['repo'] })).toBe('all')
+  })
+
+  it('resolves an explicit auto the same as the default', () => {
+    expect(resolveInteractiveSelect({ format: ['group'], interactiveSelect: 'auto' })).toBe('minor')
+    expect(resolveInteractiveSelect({ interactiveSelect: 'auto' })).toBe('all')
+  })
+
+  it('respects an explicit value in either format', () => {
+    expect(resolveInteractiveSelect({ format: ['group'], interactiveSelect: 'none' })).toBe('none')
+    expect(resolveInteractiveSelect({ interactiveSelect: 'patch' })).toBe('patch')
+  })
+})
+
+describe('isPreSelectedGroup', () => {
+  it('none pre-selects nothing', () => {
+    expect(isPreSelectedGroup('patch', 'none')).toBe(false)
+    expect(isPreSelectedGroup('minor', 'none')).toBe(false)
+    expect(isPreSelectedGroup('major', 'none')).toBe(false)
+    expect(isPreSelectedGroup('majorVersionZero', 'none')).toBe(false)
+  })
+
+  it('patch pre-selects patch only', () => {
+    expect(isPreSelectedGroup('patch', 'patch')).toBe(true)
+    expect(isPreSelectedGroup('minor', 'patch')).toBe(false)
+    expect(isPreSelectedGroup('major', 'patch')).toBe(false)
+    expect(isPreSelectedGroup('majorVersionZero', 'patch')).toBe(false)
+  })
+
+  it('minor pre-selects patch and minor', () => {
+    expect(isPreSelectedGroup('patch', 'minor')).toBe(true)
+    expect(isPreSelectedGroup('minor', 'minor')).toBe(true)
+    expect(isPreSelectedGroup('major', 'minor')).toBe(false)
+    expect(isPreSelectedGroup('majorVersionZero', 'minor')).toBe(false)
+  })
+
+  it('all pre-selects everything', () => {
+    expect(isPreSelectedGroup('patch', 'all')).toBe(true)
+    expect(isPreSelectedGroup('minor', 'all')).toBe(true)
+    expect(isPreSelectedGroup('major', 'all')).toBe(true)
+    expect(isPreSelectedGroup('majorVersionZero', 'all')).toBe(true)
+  })
+
+  it('pre-selects custom groups with all only', () => {
+    expect(isPreSelectedGroup('custom', 'all')).toBe(true)
+    expect(isPreSelectedGroup('custom', 'minor')).toBe(false)
+    expect(isPreSelectedGroup('custom', 'patch')).toBe(false)
+    expect(isPreSelectedGroup('custom', 'none')).toBe(false)
+  })
+})
+
+describe('isPreSelectedUpgrade', () => {
+  it('derives the group from the semver part that changed', () => {
+    expect(isPreSelectedUpgrade('1.0.0', '1.0.1', 'patch')).toBe(true)
+    expect(isPreSelectedUpgrade('1.0.0', '1.1.0', 'patch')).toBe(false)
+    expect(isPreSelectedUpgrade('1.0.0', '1.1.0', 'minor')).toBe(true)
+    expect(isPreSelectedUpgrade('1.0.0', '2.0.0', 'minor')).toBe(false)
+    expect(isPreSelectedUpgrade('1.0.0', '2.0.0', 'all')).toBe(true)
+    expect(isPreSelectedUpgrade('1.0.0', '1.0.1', 'none')).toBe(false)
+  })
+
+  it('handles range operators', () => {
+    expect(isPreSelectedUpgrade('^1.0.0', '^1.0.1', 'patch')).toBe(true)
+    expect(isPreSelectedUpgrade('<1.2.3', '^1.2.9', 'patch')).toBe(true)
+    expect(isPreSelectedUpgrade('^1.0.0', '^2.0.0', 'minor')).toBe(false)
+  })
+
+  it('treats major version zero as major', () => {
+    expect(isPreSelectedUpgrade('0.1.0', '0.2.0', 'minor')).toBe(false)
+    expect(isPreSelectedUpgrade('0.1.0', '0.1.1', 'patch')).toBe(false)
+    expect(isPreSelectedUpgrade('0.1.0', '0.2.0', 'all')).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #2028.

## Problem

Interactive mode hardcodes which upgrades start toggled on, in `chooseUpgrades()`:

- `--format group`: `selected: ['patch', 'minor'].includes(groupName)` — major and majorVersionZero off.
- non-group: `selected: true` for everything.

Neither expression reads `options` or the environment, so the only workaround is `ncu -i` followed by <kbd>a</kbd>. Previously raised in #1580, #1566, and #1684.

## Solution

`--interactiveSelect <value>` accepts `auto`, `none`, `patch`, `minor`, or `all`.

| Value | Pre-selected |
|---|---|
| `auto` (default) | patch + minor with `--format group`, everything otherwise |
| `none` | nothing |
| `patch` | patch |
| `minor` | patch + minor |
| `all` | everything, including major |

Defaults are unchanged: `auto` resolves to exactly the two hardcoded behaviors it replaces. Since `--format group` is on by default, `ncu -i` still pre-selects patch and minor.

`auto` exists so the default is expressible on the command line. Without it, a value in `.ncurc` could be overridden only by naming a concrete value, which pins behavior to one format rather than restoring the format-dependent default.

## Notes for review

- **majorVersionZero follows `major`, not `minor`** — only pre-selected by `all`, since anything may change before 1.0.0. This matches today's group-mode behavior. Custom groups from `--groupFunction` are treated the same way. Documented in the README and `ncu --help --interactiveSelect`.
- **Non-group mode derives the bump type per dependency** via `partChanged`, since there is no group name. It ignores `--groupFunction`, which is documented as applying to `--format group`.
- `--interactiveSelect` only takes effect with `--interactive`; the help says so.
- `RunOptions.ts`, `RunOptions.json`, and the README option tables are regenerated via `npm run build:options`.

## Tests

- `test/interactiveSelect.test.ts` (new) mocks `prompts-ncu` and asserts the actual pre-selected set for every value in both group and non-group mode, plus the unchanged defaults. This is in-process because `INJECT_PROMPTS` replaces the prompt wholesale — the injected answer is returned without the choices ever being evaluated, so pre-selection is invisible to the existing spawn-based e2e style.
- `test/isPreSelected.test.ts` (new) unit-tests the helper: each value, range operators, and major-version-zero.
- `test/interactive.test.ts` gets CLI-level accept/reject cases.

982 tests pass; typecheck, eslint, prettier, and markdownlint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)