### PR TITLE
feat: add CLIOption.requires to document option dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,9 +565,9 @@ Skipped due to 7-day cooldown
 Usage:
 
 ```sh
-ncu --doctor -u
+ncu -u --doctor
 ncu --no-doctor
-ncu -du
+ncu -u -d
 ```
 
 Iteratively installs upgrades and runs your project's tests to identify breaking upgrades. Reverts broken upgrades and updates package.json with working upgrades.
@@ -773,7 +773,7 @@ Control the auto-install behavior.
 Usage:
 
 ```sh
-ncu --interactiveSelect [value]
+ncu -i --interactiveSelect [value]
 ```
 
 Default: auto
@@ -867,7 +867,7 @@ ncu-test-return-version  1.0.0  →  2.0.0
 Usage:
 
 ```sh
-ncu --registryType [type]
+ncu -r [uri] --registryType [type]
 ```
 
 Specify whether `--registry` refers to a full npm registry or a simple JSON file.

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -43,45 +43,6 @@ const parseNumberOption =
     throw new Error(`${optionName} must be a number`)
   }
 
-/** Renders the extended help for an option with usage information. */
-export const renderExtendedHelp = (option: CLIOption, { markdown }: { markdown?: boolean } = {}) => {
-  let output = ''
-  const usageLines: string[] = []
-
-  if (option.cli !== false) {
-    // add -u to doctor option
-    usageLines.push(
-      `ncu --${option.long}${option.arg ? ` [${option.arg}]` : ''}${option.long === 'doctor' ? ' -u' : ''}`,
-    )
-  }
-
-  if (option.type === 'boolean') {
-    usageLines.push(`ncu --no-${option.long}`)
-  }
-
-  if (option.short) {
-    // add -u to doctor option
-    usageLines.push(`ncu -${option.short}${option.arg ? ` [${option.arg}]` : ''}${option.long === 'doctor' ? 'u' : ''}`)
-  }
-
-  if (usageLines.length > 0) {
-    output = `Usage:\n\n${codeBlock(usageLines.join('\n'), { markdown, lang: 'sh' })}\n`
-  }
-
-  if (option.default !== undefined && !(Array.isArray(option.default) && option.default.length === 0)) {
-    output += `\nDefault: ${option.default}\n`
-  }
-
-  if (option.help) {
-    const helpText = typeof option.help === 'function' ? option.help({ markdown }) : option.help
-    output += `\n${(markdown ? helpText : uncode(helpText)).trim()}\n\n`
-  } else if (option.description) {
-    output += `\n${markdown ? option.description : uncode(option.description)}\n`
-  }
-
-  return output.trim()
-}
-
 /** Extended help for the --doctor option. */
 const extendedHelpDoctor: ExtendedHelp = ({
   markdown,
@@ -680,6 +641,7 @@ const cliOptions: CLIOption[] = [
     long: 'cacheExpiration',
     arg: 'min',
     description: 'Cache expiration in minutes. Only works with `--cache`.',
+    requires: ['cache'],
     parse: parseNumberOption('cacheExpiration'),
     default: 10,
     type: 'number',
@@ -753,6 +715,7 @@ const cliOptions: CLIOption[] = [
     short: 'd',
     description:
       'Iteratively installs upgrades and runs tests to identify breaking upgrades. Requires `-u` to execute.',
+    requires: ['upgrade'],
     type: 'boolean',
     help: extendedHelpDoctor,
   },
@@ -761,12 +724,14 @@ const cliOptions: CLIOption[] = [
     arg: 'command',
     description:
       'Specifies the install script to use in doctor mode. (default: `npm install` or the equivalent for your package manager)',
+    requires: ['doctor'],
     type: 'string',
   },
   {
     long: 'doctorTest',
     arg: 'command',
     description: 'Specifies the test script to use in doctor mode. (default: `npm test`)',
+    requires: ['doctor'],
     type: 'string',
   },
   {
@@ -873,6 +838,7 @@ const cliOptions: CLIOption[] = [
     arg: 'value',
     description:
       'Control which upgrades are pre-selected in interactive mode: auto, none, patch, minor, all. Only applies with `--interactive`.',
+    requires: ['interactive'],
     help: extendedHelpInteractiveSelect,
     default: 'auto',
     choices: ['auto', 'none', 'patch', 'minor', 'all'],
@@ -975,6 +941,7 @@ const cliOptions: CLIOption[] = [
     arg: 'type',
     description:
       'Specify whether --registry refers to a full npm registry or a simple JSON file or url: npm, json. (default: npm)',
+    requires: ['registry'],
     help: extendedHelpRegistryType,
     type: `'npm' | 'json'`,
   },
@@ -1098,6 +1065,65 @@ export const cliOptionsMap = cliOptions.reduce(
   }),
   {} as Index<CLIOption>,
 )
+
+/** Renders an option as it is typed on the command line, preferring the short flag. */
+const renderFlag = (option: CLIOption) =>
+  `${option.short ? `-${option.short}` : `--${option.long}`}${option.arg ? ` [${option.arg}]` : ''}`
+
+/** Returns the flags of all the options that are required for the given option to work, including transitive requirements, ordered from least to most specific. */
+const renderRequiredFlags = (option: CLIOption, visited: Set<string> = new Set([option.long])): string[] =>
+  (option.requires || []).flatMap(long => {
+    // ignore circular and duplicate requirements
+    if (visited.has(long)) return []
+    visited.add(long)
+
+    const required = cliOptionsMap[long]
+    if (!required) {
+      throw new Error(`Unknown option "${long}" in the requires property of --${option.long}`)
+    }
+
+    return [...renderRequiredFlags(required, visited), renderFlag(required)]
+  })
+
+/** Renders the extended help for an option with usage information. */
+export const renderExtendedHelp = (option: CLIOption, { markdown }: { markdown?: boolean } = {}) => {
+  let output = ''
+  const usageLines: string[] = []
+
+  // options that are required for this option to work, e.g. `-i` is prepended to `--interactiveSelect`
+  const requiredFlags = renderRequiredFlags(option)
+  const prefix = requiredFlags.map(flag => `${flag} `).join('')
+
+  if (option.cli !== false) {
+    usageLines.push(`ncu ${prefix}--${option.long}${option.arg ? ` [${option.arg}]` : ''}`)
+  }
+
+  if (option.type === 'boolean') {
+    // do not prepend required options when negating the option, since the requirements do not apply
+    usageLines.push(`ncu --no-${option.long}`)
+  }
+
+  if (option.short) {
+    usageLines.push(`ncu ${prefix}-${option.short}${option.arg ? ` [${option.arg}]` : ''}`)
+  }
+
+  if (usageLines.length > 0) {
+    output = `Usage:\n\n${codeBlock(usageLines.join('\n'), { markdown, lang: 'sh' })}\n`
+  }
+
+  if (option.default !== undefined && !(Array.isArray(option.default) && option.default.length === 0)) {
+    output += `\nDefault: ${option.default}\n`
+  }
+
+  if (option.help) {
+    const helpText = typeof option.help === 'function' ? option.help({ markdown }) : option.help
+    output += `\n${(markdown ? helpText : uncode(helpText)).trim()}\n\n`
+  } else if (option.description) {
+    output += `\n${markdown ? option.description : uncode(option.description)}\n`
+  }
+
+  return output.trim()
+}
 
 const cliOptionsSorted = sortBy(cliOptions, v => v.long)
 

--- a/src/types/CLIOption.ts
+++ b/src/types/CLIOption.ts
@@ -12,6 +12,8 @@ export interface CLIOption<T = any> {
   /** Must be prepared to handle unknown input types since the user's ncurc.json may not match the schema. */
   parse?: (s: unknown, p?: T) => T
   long: string
+  /** The long names of other options that are required for this option to work. Automatically prepended to the usage examples in the extended help and README, including transitive requirements. */
+  requires?: string[]
   short?: string
   type: string
 }

--- a/test/cli-options.test.ts
+++ b/test/cli-options.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
-import cliOptions, { cliOptionsMap } from '../src/cli-options.ts'
+import cliOptions, { cliOptionsMap, renderExtendedHelp } from '../src/cli-options.ts'
+import { chalkInit } from '../src/lib/chalk.ts'
 
 describe('cli-options', () => {
   it('require long and description properties', () => {
@@ -34,6 +35,35 @@ describe('cli-options', () => {
     it('resolves --cacheFile to an absolute path and rejects non-strings', () => {
       expect(path.isAbsolute(cliOptionsMap.cacheFile.parse!('foo.json') as string)).toBe(true)
       expect(() => cliOptionsMap.cacheFile.parse!(5)).toThrow('cacheFile must be a string')
+    })
+  })
+
+  describe('requires', () => {
+    it('refer to valid options', () => {
+      for (const option of cliOptions) {
+        for (const long of option.requires || []) {
+          expect(cliOptionsMap[long], `--${option.long} requires unknown option "${long}"`).toBeDefined()
+        }
+      }
+    })
+
+    it('prepend required options to the usage examples', () => {
+      chalkInit()
+      expect(renderExtendedHelp(cliOptionsMap.interactiveSelect)).toContain('ncu -i --interactiveSelect [value]')
+    })
+
+    it('include transitive requirements, from least to most specific', () => {
+      chalkInit()
+      // --doctorInstall requires --doctor, which requires -u
+      expect(renderExtendedHelp(cliOptionsMap.doctorInstall)).toContain('ncu -u -d --doctorInstall [command]')
+    })
+
+    it('are prepended to the short option usage but not the negated usage', () => {
+      chalkInit()
+      const help = renderExtendedHelp(cliOptionsMap.doctor)
+      expect(help).toContain('ncu -u --doctor')
+      expect(help).toContain('ncu -u -d')
+      expect(help).toContain('ncu --no-doctor')
     })
   })
 })


### PR DESCRIPTION
## Why

Some options only do anything when another option is also specified, but the generated usage examples didn't say so:

- `--interactiveSelect` only applies with `-i`, yet the help and README showed `ncu --interactiveSelect [value]`.
- `--doctorInstall` / `--doctorTest` only apply in doctor mode.
- `--doctor`'s `-u` requirement was hardcoded as an `option.long === 'doctor'` special case in `renderExtendedHelp`.

## What changed

**New `requires` field on `CLIOption`** — the long names of other options required for the option to work:

```ts
requires?: string[]
```

`renderExtendedHelp` prepends them to the usage examples, so `ncu --help <option>` and the auto-generated README Advanced Options section stay in sync with the option definitions:

- Prefers the short flag (`-i`, `-u`, `-d`) and includes the required option's arg (`-r [uri]`).
- Resolves **transitively**, ordered least → most specific, with cycle/duplicate protection — `--doctorInstall` requires `--doctor`, which requires `-u`, giving `ncu -u -d --doctorInstall [command]`.
- Not prepended to the `--no-` negation line, since the requirements don't apply when disabling the option.
- Throws on an unknown option name, so a typo fails the build.

This replaces the hardcoded `--doctor` special cases. The three rendering functions moved below `cliOptionsMap` since they need it for lookups (`no-use-before-define` is enforced).

**Options configured:** `--doctor` → `upgrade`; `--doctorInstall` / `--doctorTest` → `doctor`; `--interactiveSelect` → `interactive`; `--cacheExpiration` → `cache`; `--registryType` → `registry`.

**README** regenerated with `npm run build:options`:

```diff
-ncu --interactiveSelect [value]
+ncu -i --interactiveSelect [value]
-ncu --registryType [type]
+ncu -r [uri] --registryType [type]
-ncu --doctor -u        →  ncu -u --doctor
-ncu -du                →  ncu -u -d
```

**Tests** — a `requires` block in `test/cli-options.test.ts` validating that every reference resolves to a real option, plus the prefix, transitivity, and unprefixed negation behavior.

## Reviewer notes

- The `--doctor` usage lines changed form: `ncu -u -d` instead of `ncu -du`, since the generic prefix keeps flags separate. Equivalent, but let me know if you'd rather preserve the combined `-du`.
- Three options were left unconfigured because they depend on *one of* several options, which a flat list would misdocument: `--cacheFile` (`--cache` **or** `--cacheClear`), `--root` (`--workspace` **or** `--workspaces`, and it defaults to `true` so the meaningful usage is `--no-root`), and `--mergeConfig` (`--deep` **or** `--packageFile`). The field could be extended to accept nested arrays for "one of" (`requires: [['cache', 'cacheClear']]`) if that's wanted.
- `--registryType` is a judgment call: `--registry` is strictly required only for `registryType json`, though `--registryType` is a no-op without it either way.
- `npm run test:unit` (986 passed, 1 skipped), `tsc --noEmit`, eslint, and prettier are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)