### PR TITLE
Memoize the yarn version lookup in getPeerDependencies

### DIFF
--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -348,6 +348,12 @@ export const newest = withNpmConfigFromYarn(npm.newest)
 export const patch = withNpmConfigFromYarn(npm.patch)
 export const semver = withNpmConfigFromYarn(npm.semver)
 
+// memoized since getPeerDependencies is called once per dependency and the yarn version cannot change mid-run
+const getYarnVersion = memoize(async (spawnOptions: SpawnOptions): Promise<string> => {
+  const { stdout } = await spawnCommand('yarn', ['--version'], { rejectOnError: false }, spawnOptions)
+  return stdout
+})
+
 /**
  * Fetches the list of peer dependencies for a specific package version.
  *
@@ -361,7 +367,7 @@ export const getPeerDependencies = async (
   version: Version,
   spawnOptions: SpawnOptions,
 ): Promise<Index<Version>> => {
-  const { stdout: yarnVersion } = await spawnCommand('yarn', ['--version'], { rejectOnError: false }, spawnOptions)
+  const yarnVersion = await getYarnVersion(spawnOptions)
   if (yarnVersion.startsWith('1')) {
     const args = ['--json', 'info', `${packageName}@${version}`, 'peerDependencies']
     const { stdout } = await spawnCommand('yarn', args, { rejectOnError: false }, spawnOptions)


### PR DESCRIPTION
@raineorshine: sorry for the many PRs but I decided to split the patches into separate PRs for easier review.

The PRs I opened today, shouldn't matter in which order they land, but if any conflicts arise feel free to ping me to resolve them. That being said I'd start with this one and move to the newer ones.