### PR TITLE
Replace the #catalog path sentinel with a catalog flag on PackageInfo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -285,20 +285,16 @@ async function runUpgrades(
       pkgOptions.packageFile = packageInfo.filepath
       pkgOptions.workspacePackages = workspacePackages
 
-      // For virtual catalog files (like package.json#catalog), use the PackageInfo data directly
-      // since the virtual file doesn't exist on disk
+      // A catalog entry holds the extracted catalog dependencies rather than the contents of
+      // filepath, so use the PackageInfo data instead of reading from disk.
       let pkgData: string | null
       let pkgFile: string
       let indexKey: string
 
-      if (packageInfo.filepath.includes('#') || packageInfo.name === 'catalogs') {
-        // Virtual catalog file or catalog package - use PackageInfo data
+      if (packageInfo.catalog) {
         pkgData = packageInfo.pkgFile
         pkgFile = packageInfo.filepath
-        // For synthetic catalog files, use the actual underlying file path as the index key
-        indexKey = packageInfo.filepath.includes('#catalog')
-          ? packageInfo.filepath.replace('#catalog', '')
-          : packageInfo.filepath
+        indexKey = packageInfo.filepath
 
         // Print the same message as findPackage for consistency
         const relPathToPackage = path.resolve(indexKey)
@@ -323,7 +319,7 @@ async function runUpgrades(
             // convert Windows path to *nix path for consistency
             .replace(/\\/g, '/')
         : indexKey
-      packages[key] = await runLocal(pkgOptions, pkgData, pkgFile)
+      packages[key] = await runLocal(pkgOptions, pkgData, pkgFile, packageInfo.catalog)
     }
     analysis = packages
     if (options.json) {

--- a/src/lib/getAllPackages.ts
+++ b/src/lib/getAllPackages.ts
@@ -207,13 +207,13 @@ async function getCatalogPackageInfo(options: Options, pkgPath: string): Promise
   }
 
   // Determine the correct file path for catalogs. For pnpm, use pnpm-workspace.yaml.
-  // For Bun catalogs in package.json, use a virtual path to avoid conflicts with root package.
+  // For Bun catalogs, the catalogs live in the package.json itself.
   const catalogFilePath =
     options.packageManager === 'pnpm'
       ? path.join(path.dirname(pkgPath), 'pnpm-workspace.yaml')
       : options.packageManager === 'yarn'
         ? path.join(path.dirname(pkgPath), '.yarnrc.yml')
-        : `${pkgPath}#catalog`
+        : pkgPath
 
   // Create synthetic file content that matches the synthetic PackageFile
   const syntheticFileContent = JSON.stringify(catalogPackageFile, null, 2)
@@ -223,6 +223,7 @@ async function getCatalogPackageInfo(options: Options, pkgPath: string): Promise
     pkg: catalogPackageFile,
     pkgFile: syntheticFileContent,
     name: 'catalogs',
+    catalog: true,
   }
 
   return catalogPackageInfo

--- a/src/lib/runLocal.ts
+++ b/src/lib/runLocal.ts
@@ -166,6 +166,8 @@ export default async function runLocal(
   options: Options,
   pkgData?: Maybe<string>,
   pkgFile?: Maybe<string>,
+  /** True when pkgData holds catalog dependencies extracted from pkgFile rather than its contents. */
+  catalog?: boolean,
 ): Promise<PackageFile | Index<VersionSpec>> {
   print(options, '\nOptions:', 'verbose')
   printSorted(options, options, 'verbose')
@@ -286,7 +288,15 @@ export default async function runLocal(
     }
   }
 
-  const newPkgData = await upgradePackageData(pkgData, current, chosenUpgraded, options, pkgFile || undefined, latest)
+  const newPkgData = await upgradePackageData(
+    pkgData,
+    current,
+    chosenUpgraded,
+    options,
+    pkgFile || undefined,
+    latest,
+    catalog,
+  )
 
   const output: PackageFile | Index<VersionSpec> = options.jsonAll
     ? pkgFile?.endsWith('.yaml') || pkgFile?.endsWith('.yml')
@@ -309,7 +319,7 @@ export default async function runLocal(
     if (pkgFile) {
       if (options.upgrade) {
         // do not await until the end
-        writePromise = fs.writeFile(pkgFile.replace('#catalog', ''), newPkgData)
+        writePromise = fs.writeFile(pkgFile, newPkgData)
       } else {
         const ncuCmd = process.env.npm_lifecycle_event === 'npx' ? 'npx npm-check-updates' : 'ncu'
         // quote arguments with spaces

--- a/src/lib/upgradePackageData.ts
+++ b/src/lib/upgradePackageData.ts
@@ -92,23 +92,12 @@ async function upgradePackageData(
   options: Options,
   pkgFile?: string,
   latest?: Index<Version>,
+  catalog?: boolean,
 ) {
   // Check if this is a catalog file (pnpm-workspace.yaml or package.json with catalogs)
   if (pkgFile) {
     const fileName = path.basename(pkgFile)
     const fileExtension = path.extname(pkgFile)
-
-    // Handle synthetic catalog files (package.json#catalog format)
-    if (pkgFile.includes('#catalog')) {
-      // This is a synthetic catalog file, we need to read and update the actual file
-      const actualFilePath = pkgFile.replace('#catalog', '')
-      const actualFileExtension = path.extname(actualFilePath)
-
-      if (actualFileExtension === '.json') {
-        // Bun format: update package.json catalogs and return the updated content
-        return upgradeJsonCatalogDependencies(actualFilePath, current, upgraded)
-      }
-    }
 
     // Handle yaml catalog files
     if (fileName === 'pnpm-workspace.yaml' || fileName === '.yarnrc.yml') {
@@ -154,6 +143,11 @@ async function upgradePackageData(
 
     // Handle package.json catalog files (check if content contains catalog/catalogs at root level or in workspaces)
     if (fileExtension === '.json') {
+      // a catalog entry carries only the extracted catalog deps, so pkgData has no catalog sections to detect
+      if (catalog) {
+        return upgradeJsonCatalogDependencies(pkgFile, current, upgraded)
+      }
+
       const parsed = parseJson<{
         catalog?: unknown
         catalogs?: unknown

--- a/src/types/PackageInfo.ts
+++ b/src/types/PackageInfo.ts
@@ -6,4 +6,6 @@ export interface PackageInfo {
   pkg: PackageFile
   pkgFile: string // the raw file string
   filepath: string
+  /** True when this is a synthetic entry holding the catalog dependencies extracted from filepath. */
+  catalog?: boolean
 }

--- a/test/upgradePackageData.test.ts
+++ b/test/upgradePackageData.test.ts
@@ -73,12 +73,22 @@ workspaces:
       expect(parsed.catalogs.legacy.react).toBe('17.0.0')
     })
 
-    it('upgrades a synthetic bun catalog file (package.json#catalog)', async () => {
+    it('upgrades a bun catalog entry', async () => {
       const json = JSON.stringify({ name: 'x', workspaces: { catalog: { react: '18.0.0' } } }, null, 2)
       const pkgFile = path.join(tempDir, 'package.json')
       await fs.writeFile(pkgFile, json)
 
-      const result = await upgradePackageData(json, { react: '18.0.0' }, { react: '19.0.0' }, {}, `${pkgFile}#catalog`)
+      // a catalog entry passes the extracted catalog deps as pkgData, not the file contents
+      const catalogData = JSON.stringify({ name: 'catalog-dependencies', dependencies: { react: '18.0.0' } }, null, 2)
+      const result = await upgradePackageData(
+        catalogData,
+        { react: '18.0.0' },
+        { react: '19.0.0' },
+        {},
+        pkgFile,
+        undefined,
+        true,
+      )
 
       expect(JSON.parse(result).workspaces.catalog.react).toBe('19.0.0')
     })


### PR DESCRIPTION
@raineorshine: I have rebased my other branches but all of them belong to the previous one. So it doesn't make a lot of sense to open them now. Unsure how to proceed because it needs to be sequential... One reviewed, then rebase and the next one, etc.