### PR TITLE
fix: ignore versionless packageManager field

### DIFF
--- a/src/lib/getCurrentDependencies.ts
+++ b/src/lib/getCurrentDependencies.ts
@@ -22,7 +22,7 @@ const isGreaterThanSafe = (spec1: VersionSpec, spec2: VersionSpec) =>
 const parsePackageManager = (pkgData: PackageFile) => {
   if (!pkgData.packageManager) return {}
   const [name, version] = pkgData.packageManager.split('@')
-  return { [name]: version }
+  return version ? { [name]: version } : {}
 }
 
 /** Parses the devEngines.packageManager field into a { [name]: version } collection. */

--- a/test/dep.test.ts
+++ b/test/dep.test.ts
@@ -389,6 +389,45 @@ describe('--dep', () => {
       }
     })
 
+    it('ignore a packageManager field without a version', async () => {
+      const stub = stubVersions({
+        'ncu-test-tag': '1.0.0',
+      })
+      const packageData = JSON.stringify(
+        {
+          packageManager: 'pnpm',
+          dependencies: {
+            'ncu-test-tag': '0.1.0',
+          },
+        },
+        null,
+        2,
+      )
+
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+      const pkgFile = path.join(tempDir, 'package.json')
+      await fs.writeFile(pkgFile, packageData)
+
+      try {
+        await ncu({
+          packageFile: pkgFile,
+          jsonUpgraded: false,
+          upgrade: true,
+        })
+        const pkgNew = JSON.parse(await fs.readFile(pkgFile, 'utf-8'))
+
+        expect(pkgNew).toStrictEqual({
+          packageManager: 'pnpm',
+          dependencies: {
+            'ncu-test-tag': '1.0.0',
+          },
+        })
+      } finally {
+        await removeDir(tempDir)
+        stub.restore()
+      }
+    })
+
     it('upgrade packageManager field if specified in --dep', async () => {
       const stub = stubVersions({
         'ncu-test-tag': '1.0.0',


### PR DESCRIPTION
## Summary

- ignore a `packageManager` entry when it does not declare a version
- preserve the existing field while continuing to upgrade normal dependencies
- add an end-to-end regression for the reported `packageManager: "pnpm"` crash

## Validation

- `vitest run test/dep.test.ts` (20 passed)
- `tsc --noEmit`
- targeted ESLint and Prettier checks
- `npm run build`
- `git diff --check`

AI-assisted; tested and reviewed manually.

Fixes #2055
