### PR TITLE
fix: use makeTempDir in dep.test.ts

### DIFF
--- a/test/dep.test.ts
+++ b/test/dep.test.ts
@@ -404,7 +404,7 @@ describe('--dep', () => {
         2,
       )
 
-      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'npm-check-updates-'))
+      const tempDir = await makeTempDir()
       const pkgFile = path.join(tempDir, 'package.json')
       await fs.writeFile(pkgFile, packageData)
 


### PR DESCRIPTION
Fixes the failing `Lint & TypeCheck` job on `main`.

Semantic conflict between #2063 and #2068: #2063 added an `fs.mkdtemp(path.join(os.tmpdir(), …))` call in `test/dep.test.ts`, while #2068 removed the `os` import and converted every other site to `makeTempDir()`. Each PR passed on its own; the merge left `os` undefined (`TS2304: Cannot find name 'os'`).

Converted the one straggler to `await makeTempDir()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)