### PR TITLE
test: cover coercion of a string format in a nested package's ncurc

### DIFF
--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -270,6 +270,29 @@ describe('--deep with nested ncurc files', () => {
     expect(deepJsonOut['pkg/sub3/sub32/package.json']).toHaveProperty('fp-and-or')
     expect(deepJsonOut['pkg/sub3/sub32/package.json']).toHaveProperty('ncu-test-v2')
   })
+
+  // A nested ncurc is reloaded after the options have already been initialized, so its values still
+  // need to be coerced. An unparsed string format is not just inert: "no-group".includes('group') is
+  // true, so it turns the negation into the very option it is supposed to disable.
+  // See: https://github.com/raineorshine/npm-check-updates/pull/2066
+  it('parses a string format in the ncurc of a nested package', async () => {
+    const tempDir = await makeTempDir()
+    const pkgData = JSON.stringify({ dependencies: { express: '1' } })
+    await fs.writeFile(path.join(tempDir, 'package.json'), pkgData, 'utf-8')
+    await fs.mkdir(path.join(tempDir, 'packages/sub1'), { recursive: true })
+    await fs.writeFile(path.join(tempDir, 'packages/sub1/package.json'), pkgData, 'utf-8')
+    await fs.writeFile(path.join(tempDir, 'packages/sub1/.ncurc.json'), JSON.stringify({ format: 'no-group' }), 'utf-8')
+
+    try {
+      const { stdout } = await spawn('node', [bin, '--deep'], {}, { cwd: tempDir })
+      const output = stripAnsi(stdout)
+
+      // the root package is grouped, the nested package that disabled grouping is not
+      expect(output.match(/Potentially breaking API changes/g)).toHaveLength(1)
+    } finally {
+      await removeDir(tempDir)
+    }
+  })
 })
 
 describe('--deep cli option precedence', () => {


### PR DESCRIPTION
In `--deep` mode, each package's own `.ncurc` is reloaded in `runUpgrades` and merged into the per-package options *after* `initOptions` has already run, so nothing coerces its raw values. `getNcuRc` covers this today by parsing `format` as it loads the config.

An unparsed string `format` is not merely inert there — it silently inverts:

```js
'no-group'.includes('group') // true
```

so `{ "format": "no-group" }` in a nested `.ncurc` would enable the very grouping it is meant to disable.

This adds a test to `--deep with nested ncurc files` that writes `{ "format": "no-group" }` into a sub-package's `.ncurc.json` and asserts that only the root package prints a group header.

Passes on `main`. Fails on #2066, which removes the `format` parse from `getNcuRc` and replaces it with a coercion pass in `initOptions` — a pass the per-package reload never reaches (2 group headers instead of 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)