### PR TITLE
fix: reject a cooldown string that cannot be read

### DIFF
--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -1083,7 +1083,12 @@ const cliOptions: CLIOption[] = [
         return value
       } else if (typeof value === 'string') {
         const days = parseCooldown(value)
-        return days !== null ? days : parseInt(value, 10)
+        if (days !== null) return days
+        // Fall back to a bare number of days. Anything else yields NaN so that the caller rejects it,
+        // rather than parseInt silently reading "7x" as 7 days or "2 weeks" as 2 days.
+        const trimmed = value.trim()
+        const bareNumber = trimmed === '' ? NaN : Number(trimmed)
+        return Number.isFinite(bareNumber) ? bareNumber : NaN
       } else {
         throw new Error('cooldown must be a number, string, or function')
       }

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -128,6 +128,15 @@ describe('bin', () => {
     await expect(spawn('node', [bin, '--cwd', os.tmpdir()])).rejects.toThrow('No package.json')
   })
 
+  it('throw error if --cooldown has an unrecognized unit', async () => {
+    // "7x" must be rejected rather than silently read as 7 days
+    await expect(
+      spawn('node', [bin, '--cooldown', '7x', '--stdin'], {
+        stdin: JSON.stringify({ dependencies: { express: '1.0.0' } }),
+      }),
+    ).rejects.toThrow('Cooldown must be a non-negative number')
+  })
+
   it('throw error if --cwd does not exist', async () => {
     await expect(spawn('node', [bin, '--cwd', 'fnuoathufoawhtufonwauto'])).rejects.toThrow(
       'No such directory: fnuoathufoawhtufonwauto',

--- a/test/cli-options.test.ts
+++ b/test/cli-options.test.ts
@@ -31,6 +31,19 @@ describe('cli-options', () => {
       expect(cliOptionsMap.cooldown.parse!(3)).toBe(3)
     })
 
+    it('parses a bare --cooldown number as days', () => {
+      expect(cliOptionsMap.cooldown.parse!('5')).toBe(5)
+      expect(cliOptionsMap.cooldown.parse!(' 1.5 ')).toBe(1.5)
+    })
+
+    it('returns NaN for a --cooldown string it cannot read', () => {
+      // an unrecognized unit must not be truncated to its leading digits
+      expect(cliOptionsMap.cooldown.parse!('7x')).toBeNaN()
+      expect(cliOptionsMap.cooldown.parse!('2 weeks')).toBeNaN()
+      expect(cliOptionsMap.cooldown.parse!('invalid')).toBeNaN()
+      expect(cliOptionsMap.cooldown.parse!('')).toBeNaN()
+    })
+
     it('resolves --cacheFile to an absolute path and rejects non-strings', () => {
       expect(path.isAbsolute(cliOptionsMap.cacheFile.parse!('foo.json') as string)).toBe(true)
       expect(() => cliOptionsMap.cacheFile.parse!(5)).toThrow('cacheFile must be a string')

--- a/test/cooldown.test.ts
+++ b/test/cooldown.test.ts
@@ -61,6 +61,25 @@ describe('cooldown', () => {
         'Invalid cooldown value: "invalid". Use a number (days) or a string like "7d", "12h", or "30m".',
       )
     })
+
+    // a string that starts with digits must not be truncated to them, e.g. "7x" read as 7 days
+    it('throws error for a cooldown string with an unrecognized unit', async () => {
+      await expect(
+        ncu({
+          packageData: { dependencies: {} },
+          cooldown: '7x',
+        }),
+      ).rejects.toThrow('Invalid cooldown value: "7x". Use a number (days) or a string like "7d", "12h", or "30m".')
+
+      await expect(
+        ncu({
+          packageData: { dependencies: {} },
+          cooldown: '2 weeks',
+        }),
+      ).rejects.toThrow(
+        'Invalid cooldown value: "2 weeks". Use a number (days) or a string like "7d", "12h", or "30m".',
+      )
+    })
   })
 
   describe('cooldown string formats', () => {


### PR DESCRIPTION
`cooldown`'s `parse` fell back to `parseInt` for any string `parseCooldown` did not recognize, so a string that merely *starts* with digits was truncated to them:

```sh
ncu --cooldown 7x        # ran a 7 day cooldown
ncu --cooldown "2 weeks" # ran a 2 day cooldown
ncu --cooldown 1.5       # ran a 1 day cooldown
```

Return `NaN` for anything that is neither a unit string (`7d`, `12h`, `30m`) nor a bare number, so it is rejected like any other invalid value. Using `Number` rather than `parseInt` for the bare-number fallback also makes fractional days work, matching what `12h` already produces.

Note the two paths report it differently, as they already did for `--cooldown invalid`: the module API raises `Invalid cooldown value: "7x"`, while the CLI (where commander has already applied `parse`) raises the general `Cooldown must be a non-negative number ...`.

Tests: `parse` unit tests for the bare-number and unreadable cases, module-API rejection of `7x` and `2 weeks`, and a CLI rejection test.

Relevant to #2066, which applies `parse` to ncurc and module values too. On that branch the `parseInt` fallback becomes the module API's behavior as well, so `ncu({ cooldown: '7x' })` silently resolves to 7 days where it previously raised `Invalid cooldown value`. All four tests here fail on #2066 as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)